### PR TITLE
perf: add pytest-xdist for parallel test execution (#39)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -135,6 +135,7 @@ dev = [
     "pytest", # Testing framework
     "pytest-repeat", # Pytest: Repeat tests
     "pytest-timeout", # Pytest: Timeout tests
+    "pytest-xdist>=3.8.0", # Pytest: Parallel test execution
     "bandit",
     "coverage",
     "invoke",

--- a/uv.lock
+++ b/uv.lock
@@ -387,6 +387,15 @@ wheels = [
 ]
 
 [[package]]
+name = "execnet"
+version = "2.1.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/bf/89/780e11f9588d9e7128a3f87788354c7946a9cbb1401ad38a48c4db9a4f07/execnet-2.1.2.tar.gz", hash = "sha256:63d83bfdd9a23e35b9c6a3261412324f964c2ec8dcd8d3c6916ee9373e0befcd", size = 166622, upload-time = "2025-11-12T09:56:37.75Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ab/84/02fc1827e8cdded4aa65baef11296a9bbe595c474f0d6d758af082d849fd/execnet-2.1.2-py3-none-any.whl", hash = "sha256:67fba928dd5a544b783f6056f449e5e3931a5c378b128bc18501f7ea79e296ec", size = 40708, upload-time = "2025-11-12T09:56:36.333Z" },
+]
+
+[[package]]
 name = "filelock"
 version = "3.20.0"
 source = { registry = "https://pypi.org/simple" }
@@ -1059,6 +1068,19 @@ wheels = [
 ]
 
 [[package]]
+name = "pytest-xdist"
+version = "3.8.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "execnet" },
+    { name = "pytest" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/78/b4/439b179d1ff526791eb921115fca8e44e596a13efeda518b9d845a619450/pytest_xdist-3.8.0.tar.gz", hash = "sha256:7e578125ec9bc6050861aa93f2d59f1d8d085595d6551c2c90b6f4fad8d3a9f1", size = 88069, upload-time = "2025-07-01T13:30:59.346Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ca/31/d4e37e9e550c2b92a9cbc2e4d0b7420a27224968580b5a447f420847c975/pytest_xdist-3.8.0-py3-none-any.whl", hash = "sha256:202ca578cfeb7370784a8c33d6d05bc6e13b4f25b5053c30a152269fd10f0b88", size = 46396, upload-time = "2025-07-01T13:30:56.632Z" },
+]
+
+[[package]]
 name = "python-dateutil"
 version = "2.9.0.post0"
 source = { registry = "https://pypi.org/simple" }
@@ -1248,6 +1270,7 @@ dev = [
     { name = "pytest" },
     { name = "pytest-repeat" },
     { name = "pytest-timeout" },
+    { name = "pytest-xdist" },
     { name = "requests" },
     { name = "ruamel-yaml" },
     { name = "ruff" },
@@ -1281,6 +1304,7 @@ dev = [
     { name = "pytest" },
     { name = "pytest-repeat" },
     { name = "pytest-timeout" },
+    { name = "pytest-xdist", specifier = ">=3.8.0" },
     { name = "requests" },
     { name = "ruamel-yaml" },
     { name = "ruff", specifier = ">=0.14.4" },


### PR DESCRIPTION
## Summary
- Add `pytest-xdist` as dev dependency to enable parallel test execution
- With `-n auto` (8 workers), test suite time drops from **221s → 58s (3.8x speedup)**
- All 365 tests pass with no modifications needed

## Profiling Results

| | Before (serial) | After (xdist -n auto) |
|---|---:|---:|
| Time | 221s | 58s |
| Tests | 365 passed | 365 passed |
| Workers | 1 | 8 |

### Bottleneck identified
`test_netmiko.py` accounts for 70% of total test time (155s / 221s) due to SSH handshake + netmiko connection overhead per platform. These tests are independent and benefit greatly from parallelization.

## Changes
- `pyproject.toml`: add `pytest-xdist>=3.8.0` to dev dependencies (grouped with other pytest plugins)
- `uv.lock`: updated

## Test plan
- [x] `uv run pytest --ignore=tests/core/test_docker.py -q -p no:cacheprovider -n auto` — 365 passed (58s)
- [x] Ran twice to confirm consistent results

Closes #39

🤖 Generated with [Claude Code](https://claude.com/claude-code)