### PR TITLE
fix: handle socket timeout in Telnet _read_line (#53)

### DIFF
--- a/simnos/plugins/servers/telnet_server.py
+++ b/simnos/plugins/servers/telnet_server.py
@@ -163,7 +163,10 @@ class TelnetServer(TCPServerBase):
         """
         buf = b""
         while True:
-            byte = self._recv_byte(sock)
+            try:
+                byte = self._recv_byte(sock)
+            except TimeoutError:
+                continue
             if byte is None:
                 break
             if byte == b"\r":
@@ -172,7 +175,10 @@ class TelnetServer(TCPServerBase):
                 # Consume trailing LF or NUL after CR (RFC 854).
                 # Non-standard followers are discarded for simplicity;
                 # in practice, clients always send CR LF or CR NUL.
-                self._recv_byte(sock)
+                try:
+                    self._recv_byte(sock)
+                except TimeoutError:
+                    pass
                 break
             if byte == b"\n":
                 if echo:


### PR DESCRIPTION
## Summary

- Telnet 接続時、`_read_line` 内の `_recv_byte` がソケットタイムアウト（デフォルト1秒）で `TimeoutError` を送出し、ユーザーがキーを打つ前に接続が切断される問題を修正
- `socket_to_shell_tap` で既に使われている `except TimeoutError: continue` パターンを `_read_line` にも適用
- CR 後続バイト（LF/NUL）の読み取りにも同様のハンドリングを追加

## Test plan

- [x] `uv run pytest tests/plugins/test_telnet_server.py -v` — 32 tests passed
- [x] 手動テスト: `telnet localhost 6023` でログイン・コマンド実行を確認

Closes #53

🤖 Generated with [Claude Code](https://claude.com/claude-code)