### PR TITLE
feat: add PyPI publish workflow (#45)

### DIFF
--- a/.github/workflows/pypi-publish.yml
+++ b/.github/workflows/pypi-publish.yml
@@ -10,7 +10,6 @@ on:
 
 permissions:
   contents: read
-  id-token: write
 
 jobs:
   test:
@@ -59,7 +58,11 @@ jobs:
     runs-on: "ubuntu-latest"
     needs:
       - "build"
-    environment: "release"
+    environment:
+      name: "release"
+      url: "https://pypi.org/p/simnos"
+    permissions:
+      id-token: write
     steps:
       - name: "Download distributions"
         uses: "actions/download-artifact@v4"


### PR DESCRIPTION
## Summary
- Add GitHub Actions workflow for publishing SIMNOS to PyPI via OIDC Trusted Publisher
- 3-job pipeline: `test` (ruff + bandit + pytest) → `build` (`uv build` + artifact upload) → `publish` (`pypa/gh-action-pypi-publish`)
- `id-token: write` scoped to `publish` job only (least privilege)
- `environment: release` with manual approval gate and PyPI URL in deployment UI

## Reviewed by
- 🦊 Codex: LGTM (2 rounds)
- 🤖 Gemini: LGTM (2 rounds)

## Test plan
- [x] YAML syntax validation
- [ ] `v2.0.0` tag push triggers workflow
- [ ] `release` environment manual approval gate works
- [ ] `pip install simnos` succeeds after publish

Closes #45

🤖 Generated with [Claude Code](https://claude.com/claude-code)