### PR TITLE
fix: bump trivy-action 0.29.0 to 0.34.1 (#57)

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -58,7 +58,7 @@ jobs:
           cache-from: "type=gha,scope=docker-scan"
           cache-to: "type=gha,mode=max,scope=docker-scan"
       - name: "Trivy vulnerability scan"
-        uses: "aquasecurity/trivy-action@0.29.0"
+        uses: "aquasecurity/trivy-action@0.34.1"
         with:
           image-ref: "${{ env.IMAGE_NAME }}:scan"
           format: "table"


### PR DESCRIPTION
## Summary
- Bump `aquasecurity/trivy-action` from `0.29.0` to `0.34.1`
- `0.29.0` references Trivy `v0.57.1` which no longer exists on GitHub Releases, causing the scan job to fail with exit code 1

## Root Cause
`v2.0.0` tag push triggered `docker-publish.yml`, but the scan job failed because `trivy-action@0.29.0` tried to install Trivy `v0.57.1` (deleted from GitHub Releases). Latest Trivy is `v0.69.2`.

## Test plan
- [ ] CI scan job passes on this PR
- [ ] Re-run `docker-publish.yml` on `v2.0.0` tag after merge

Closes #57

🤖 Generated with [Claude Code](https://claude.com/claude-code)