### PR TITLE
fix: pin Trivy binary version to v0.69.2 (#57)

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -61,6 +61,7 @@ jobs:
         uses: "aquasecurity/trivy-action@0.34.1"
         with:
           image-ref: "${{ env.IMAGE_NAME }}:scan"
+          version: "v0.69.2"
           format: "table"
           exit-code: "1"
           severity: "CRITICAL,HIGH"


### PR DESCRIPTION
## Summary
- Pin Trivy binary version to `v0.69.2` in `docker-publish.yml`
- `trivy-action@0.34.1` defaults to `v0.69.1` which has been deleted from GitHub Releases
- Trivy has removed all releases between `v0.26.0` and `v0.69.2`, so only `v0.69.2` is available

## Context
Follow-up to #58 (`trivy-action` bump). The action bump alone was not sufficient because the default Trivy binary version (`v0.69.1`) referenced by `trivy-action@0.34.1` is also deleted.

## Test plan
- [ ] CI scan job passes on this PR
- [ ] Re-tag and verify `docker-publish.yml` scan + publish succeed

Closes #57

🤖 Generated with [Claude Code](https://claude.com/claude-code)