### PR TITLE
chore: bump version to 2.0.5

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "simnos"
-version = "2.0.4"
+version = "2.0.5"
 description = "Simulated Network Operating System"
 authors = [
     { name = "KeroRoute lab" },

--- a/uv.lock
+++ b/uv.lock
@@ -1232,7 +1232,7 @@ wheels = [
 
 [[package]]
 name = "simnos"
-version = "2.0.4"
+version = "2.0.5"
 source = { editable = "." }
 dependencies = [
     { name = "detect" },


### PR DESCRIPTION
## Summary
- Bump version from 2.0.4 to 2.0.5 following the merge of Issue #65 (stop() teardown hang fix)
- Update `pyproject.toml` and `uv.lock`
- Tag: `v2.0.5`

🤖 Generated with [Claude Code](https://claude.com/claude-code)