### PR TITLE
test: add unit tests for TelnetServer tap functions and watchdog (#75)

### DIFF
--- a/tests/plugins/test_telnet_server.py
+++ b/tests/plugins/test_telnet_server.py
@@ -562,6 +562,23 @@ class SocketToShellTapTest(unittest.TestCase):
 
     @unittest.mock.patch("simnos.plugins.servers.telnet_server.time.sleep")
     @unittest.mock.patch.object(TelnetServer, "_recv_byte")
+    def test_crlf_sends_two_lines_to_shell(self, mock_recv, _mock_sleep):
+        """CRLF input: \\r triggers line send, then \\n sends an empty line.
+
+        Current implementation treats \\r and \\n independently, so a CRLF
+        sequence results in two shell_stdin.write() calls. This test documents
+        the existing behavior for regression detection.
+        """
+        mock_recv.side_effect = [b"h", b"i", b"\r", b"\n", None]
+        self.run_srv.is_set.side_effect = [True] * 10 + [False]
+        self.server.socket_to_shell_tap(self.sock, self.shell_stdin, self.shell_replied_event, self.run_srv)
+        # \r triggers "hi\r", then \n triggers "\n" (empty command)
+        self.assertEqual(self.shell_stdin.write.call_count, 2)
+        self.shell_stdin.write.assert_any_call("hi\r")
+        self.shell_stdin.write.assert_any_call("\n")
+
+    @unittest.mock.patch("simnos.plugins.servers.telnet_server.time.sleep")
+    @unittest.mock.patch.object(TelnetServer, "_recv_byte")
     def test_eof_breaks_loop(self, mock_recv, _mock_sleep):
         """EOF (None) breaks the loop and clears run_srv."""
         mock_recv.return_value = None


### PR DESCRIPTION
## Summary
- Add 22 unit tests for `TelnetServer.socket_to_shell_tap()`, `shell_to_socket_tap()`, and `watchdog()` (54 total, up from 32)
- Cover normal operation, EOF, NUL handling, OSError, TimeoutError, CRLF input, `_SHUTDOWN_TIMEOUT` interruptible wait, and `run_srv` shutdown
- Document CRLF double-write behavior (existing bug, separate issue to follow)

## Test classes added
- `SocketToShellTapTest` (11 tests): byte echo, newline→shell, CRLF behavior, EOF, NUL drop, OSError recv/send, run_srv clear, shutdown during wait, TimeoutError, shell_replied_event
- `ShellToSocketTapTest` (7 tests): line forward, EOF, run_srv recheck, NUL strip, LF→CRLF, OSError, shell_replied_event
- `WatchdogTest` (4 tests): run_srv loop, is_running break, shell.stop guarantee, sleep interval cap

## Test plan
- [x] `uv run pytest tests/plugins/test_telnet_server.py -v` — 54 passed
- [x] `uv run ruff check` / `uv run ruff format --check` — clean

## Review history
- Design review: 2 rounds (codex + gemini), all issues addressed
- Code review: 2 rounds (codex + gemini), MUST FIX (CRLF test) addressed

Closes #75

🤖 Generated with [Claude Code](https://claude.com/claude-code)