### PR TITLE
fix: add flush after channel write in shell_to_channel_tap (#83)

### DIFF
--- a/simnos/plugins/servers/ssh_server_paramiko.py
+++ b/simnos/plugins/servers/ssh_server_paramiko.py
@@ -238,6 +238,7 @@ def shell_to_channel_tap(
         while run_srv.is_set() and not written:
             try:
                 channel_stdio.write(line.encode(encoding="utf-8"))
+                channel_stdio.flush()
                 written = True
             except TimeoutError:
                 log.debug("ssh_server.shell_to_channel_tap write timeout, retrying")


### PR DESCRIPTION
## Summary
- Add `channel_stdio.flush()` after `channel_stdio.write()` in `shell_to_channel_tap` to ensure output is sent immediately through the SSH channel
- Without this, paramiko's `BufferedFile` (8KB buffer) holds data until the next implicit flush, causing netmiko `send_command` to return empty strings for long outputs (~1KB+)

## Test plan
- [x] Verified `aruba_os` `show arp` (965 bytes) returns correct output
- [x] Verified `hp_comware` `display vlan all` (1044 bytes) returns correct output
- [x] `uv run ruff check` / `uv run ruff format --check` — pass
- [x] CI: full test suite

Closes #83

🤖 Generated with [Claude Code](https://claude.com/claude-code)