### PR TITLE
fix: add skip_lf CRLF handling to SSH server (#88)

### DIFF
--- a/simnos/plugins/servers/ssh_server_paramiko.py
+++ b/simnos/plugins/servers/ssh_server_paramiko.py
@@ -409,8 +409,6 @@ class ParamikoSshServer(TCPServerBase):
                 break
             if byte in (b"", None):
                 break
-            if byte == b"\x00":
-                continue
             if skip_lf:
                 skip_lf = False
                 if byte == b"\n":

--- a/tests/plugins/test_ssh_server_paramiko.py
+++ b/tests/plugins/test_ssh_server_paramiko.py
@@ -1275,12 +1275,12 @@ class ReadChannelLineTest(unittest.TestCase):
         self.assertEqual(line, "Pass")
         self.assertTrue(skip_lf)
 
-    def test_read_channel_line_nul_dropped(self):
-        """NUL bytes should be silently dropped from login input."""
+    def test_read_channel_line_nul_preserved(self):
+        """NUL bytes should be preserved in login input to prevent auth bypass."""
         server = ParamikoSshServer(**self.arguments)
         channel = self._make_channel(b"ad\x00min\r")
         line, skip_lf = server._read_channel_line(channel)
-        self.assertEqual(line, "admin")
+        self.assertEqual(line, "ad\x00min")
         self.assertTrue(skip_lf)
 
     def test_read_channel_line_eof(self):


### PR DESCRIPTION
## Summary
- SSH `channel_to_shell_tap` と `_read_channel_line` に `skip_lf` フラグを導入し、CRLF クライアント（PuTTY 等）で余計な空行が挿入される問題を修正
- `_read_channel_line` → `_channel_login` → `channel_to_shell_tap` の `skip_lf` 状態伝播チェーンを構築
- Telnet の `socket_to_shell_tap` と同じパターンを SSH に適用（ただし SSH には CR NUL 規定がないため NUL 越しに `skip_lf` を維持）

## Changes
- `channel_to_shell_tap`: `initial_skip_lf` keyword-only 引数追加、ループ内 `skip_lf` フラグ導入
- `_read_channel_line`: `skip_lf` 引数追加、戻り値を `tuple[str, bool]` に変更、例外処理拡張
- `_channel_login`: 戻り値を `tuple[bool, bool]` に変更、`skip_lf` 伝播
- `connection_function`: `skip_lf` を `channel_to_shell_tap` に `kwargs` で渡す

## Test plan
- [x] `channel_to_shell_tap` CRLF テスト 4件追加（CRLF single line, CR NUL LF, CR followed by data, initial_skip_lf）
- [x] `_read_channel_line` テスト 6件追加（bare CR, bare LF, skip_lf consumes LF, skip_lf non-LF, NUL preserved, EOF）
- [x] `_channel_login` 統合テスト 1件追加（CRLF propagation）
- [x] 既存テスト 4件更新（戻り値変更に対応）
- [x] 全 139 テスト pass、lint/format clean

Closes #88

🤖 Generated with [Claude Code](https://claude.com/claude-code)