### PR TITLE
fix: remove mikrotik_routeros from SEND_CMD_XFAIL (#86)

### DIFF
--- a/tests/core/test_netmiko_init_compat.py
+++ b/tests/core/test_netmiko_init_compat.py
@@ -165,8 +165,7 @@ def _get_test_command(device_type: str) -> tuple[str, str] | None:
 
 # Platforms where send_command is flaky:
 # - aruba_os, hp_comware: intermittently return empty output (#87)
-# - mikrotik_routeros: trailing prompt included in output (#86)
-SEND_CMD_XFAIL = {"aruba_os", "hp_comware", "mikrotik_routeros"}
+SEND_CMD_XFAIL = {"aruba_os", "hp_comware"}
 
 
 class TestSendCommandResponse:
@@ -177,10 +176,7 @@ class TestSendCommandResponse:
     def test_send_command_returns_defined_output(self, device_type: str):
         """Defined command should return matching output via send_command."""
         if device_type in SEND_CMD_XFAIL:
-            if device_type == "mikrotik_routeros":
-                pytest.xfail(f"{device_type}: trailing prompt in output (#86)")
-            else:
-                pytest.xfail(f"{device_type}: intermittently empty output (#87)")
+            pytest.xfail(f"{device_type}: intermittently empty output (#87)")
 
         result = _get_test_command(device_type)
         assert result is not None, (


### PR DESCRIPTION
## Summary
- Remove `mikrotik_routeros` from `SEND_CMD_XFAIL` set — the trailing prompt issue was resolved by the CRLF `skip_lf` fix in #88 (PR #90)
- Simplify the xfail branching logic (no more mikrotik-specific case)

## Verification
- `test_send_command_returns_defined_output[mikrotik_routeros]` passes 10/10 consecutive runs

## Test plan
- [ ] CI passes (`pytest`, `ruff`)
- [ ] `mikrotik_routeros` send_command test runs without xfail and passes

Closes #86

🤖 Generated with [Claude Code](https://claude.com/claude-code)