### PR TITLE
fix: ensure hot reload tests restore files on failure (#93)

### DIFF
--- a/tests/plugins/test_cmd_shell.py
+++ b/tests/plugins/test_cmd_shell.py
@@ -400,9 +400,11 @@ class HotReloadTest(TestCase):
             output = conn.send_command("test")
             assert output == "% Invalid input detected at '^' marker."
             change_file()
-            output = conn.send_command("test")
-            undo_change_file()
-            assert output == "test output"
+            try:
+                output = conn.send_command("test")
+                assert output == "test output"
+            finally:
+                undo_change_file()
 
     @pytest.mark.skipif(detect.windows, reason="Windows does not allow file movement on Github runners")
     @simnos(platform="cisco_ios", return_instance=True)
@@ -435,6 +437,8 @@ class HotReloadTest(TestCase):
             output = conn.send_command("show version")
             assert output != "test output"
             change_file()
-            output = conn.send_command("show version")
-            undo_change_file()
-            assert output == "test output"
+            try:
+                output = conn.send_command("show version")
+                assert output == "test output"
+            finally:
+                undo_change_file()


### PR DESCRIPTION
## Summary
- Wrap `change_file()`/`undo_change_file()` in `try/finally` in both `test_hot_reload_integration_yaml` and `test_hot_reload_integration_py_jinja`
- Ensures `cisco_ios.yaml` and `show_version.j2` are always restored even when assertions or timeouts interrupt the test

Closes #93

## Test plan
- [x] HotReloadTest: 5/5 passed
- [x] Full test suite: 593 passed, 8 skipped, 3 xfailed, 0 failed
- [x] ruff check / format: clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)