### PR TITLE
fix: use atomic file replace in hot reload tests (#99)

### DIFF
--- a/tests/plugins/test_cmd_shell.py
+++ b/tests/plugins/test_cmd_shell.py
@@ -5,6 +5,7 @@ Module to test the cmd_shell plugin.
 import importlib
 import os
 import shutil
+import tempfile
 import threading
 import time
 from unittest import TestCase
@@ -381,8 +382,16 @@ class HotReloadTest(TestCase):
             with open(original_filename, encoding="utf-8") as file:
                 values = yaml.safe_load(file)
             values["commands"].update(test_commands)
-            with open(original_filename, "w", encoding="utf-8") as file:
-                file.write(yaml.dump(values))
+            # Write to a temp file then atomically replace to avoid
+            # exposing an empty/partial file to parallel test workers.
+            fd, tmp = tempfile.mkstemp(dir=os.path.dirname(original_filename), suffix=".yaml")
+            try:
+                with os.fdopen(fd, "w", encoding="utf-8") as file:
+                    file.write(yaml.dump(values))
+                os.replace(tmp, original_filename)
+            except BaseException:
+                os.unlink(tmp)
+                raise
 
         def undo_change_file():
             os.remove(original_filename)
@@ -417,8 +426,16 @@ class HotReloadTest(TestCase):
 
         def change_file():
             shutil.copyfile(original_filename, copy_filename)
-            with open(original_filename, "w", encoding="utf-8") as file:
-                file.write("test output")
+            # Write to a temp file then atomically replace to avoid
+            # exposing an empty/partial file to parallel test workers.
+            fd, tmp = tempfile.mkstemp(dir=os.path.dirname(original_filename), suffix=".j2")
+            try:
+                with os.fdopen(fd, "w", encoding="utf-8") as file:
+                    file.write("test output")
+                os.replace(tmp, original_filename)
+            except BaseException:
+                os.unlink(tmp)
+                raise
 
         def undo_change_file():
             os.remove(original_filename)


### PR DESCRIPTION
## Summary
- Replace direct `open("w")` with `tempfile.mkstemp()` + `os.replace()` in hot reload integration tests
- Prevents parallel pytest-xdist workers from reading empty/partial `cisco_ios.yaml` during file mutation
- Fixes intermittent `TypeError: 'NoneType' object is not subscriptable` in `test_platforms_yaml_commands_has_correct_format[cisco_ios]`

## Root Cause
`change_file()` used `open(original_filename, "w")` which truncates the file to zero bytes before writing. During this window, a parallel worker reading the same file gets `yaml.safe_load()` returning `None`.

## Test plan
- [x] `tests/plugins/test_cmd_shell.py`: 38 passed
- [x] ruff check / format: passed

Closes #99

🤖 Generated with [Claude Code](https://claude.com/claude-code)