### PR TITLE
fix: resolve CI failures in Docker scan, macOS tests, and Telnet auth

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -30,6 +30,9 @@ RUN --mount=type=cache,target=/root/.cache/uv \
 # ============ Runtime ============
 FROM python:${PYTHON_VER}-alpine
 
+# Apply security updates to base image packages (e.g. zlib CVEs)
+RUN apk upgrade --no-cache
+
 # Non-root user for security
 RUN addgroup -S -g 456 nonroot \
     && adduser -S -u 456 -G nonroot -D -s /bin/sh nonroot

--- a/simnos/plugins/servers/telnet_server.py
+++ b/simnos/plugins/servers/telnet_server.py
@@ -428,7 +428,8 @@ class TelnetServer(TCPServerBase):
                 return
             if not auth_ok:
                 log.warning("Telnet authentication failed, closing connection")
-                client.sendall(b"Authentication failed.\r\n")
+                with contextlib.suppress(OSError):
+                    client.sendall(b"Authentication failed.\r\n")
                 return
 
             # Create stdio for the shell

--- a/tests/plugins/test_platforms.py
+++ b/tests/plugins/test_platforms.py
@@ -153,7 +153,7 @@ class TestPlatforms:
             assert has_single_curly_brackets(value["help"], exceptions) is False
             assert "prompt" in value
 
-    @pytest.mark.timeout(120)
+    @pytest.mark.timeout(300)
     @pytest.mark.parametrize("platform", get_py_nos_modules())
     def test_platforms_py_all_commands_are_running(self, platform: str):
         """


### PR DESCRIPTION
## Summary
- Add `apk upgrade --no-cache` to Docker runtime stage to fix Trivy zlib CVE (CVE-2026-22184)
- Increase `pytest-timeout` from 120s to 300s for `test_platforms_py_all_commands_are_running` (macOS runners are slow)
- Suppress `BrokenPipeError` on Telnet auth failure `sendall` (client may disconnect before message is sent)

## Context
These three issues caused CI failures on the v2.1.0 tag push:
- Docker Publish: Trivy scan found CRITICAL zlib vulnerability in Alpine 3.23.3
- SIMNOS Tests: macOS `pytest-full-matrix` timed out on `arista_eos` and `cisco_ios`
- macOS warning: `BrokenPipeError` in `connection_function` during auth failure

## Test plan
- [ ] Docker Publish workflow passes Trivy scan
- [ ] macOS full-matrix tests pass within 300s timeout
- [ ] No `PytestUnhandledThreadExceptionWarning` for BrokenPipeError

🤖 Generated with [Claude Code](https://claude.com/claude-code)