### PR TITLE
chore: trigger publish workflows on release instead of tag push

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -4,9 +4,8 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 on:
-  push:
-    tags:
-      - "v*"
+  release:
+    types: [published]
 
 permissions:
   contents: read

--- a/.github/workflows/pypi-publish.yml
+++ b/.github/workflows/pypi-publish.yml
@@ -4,9 +4,8 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 on:
-  push:
-    tags:
-      - "v*"
+  release:
+    types: [published]
 
 permissions:
   contents: read


### PR DESCRIPTION
## Summary
- Change PyPI Publish and Docker Publish workflow triggers from `push: tags: ["v*"]` to `release: types: [published]`

## Motivation
Currently, tagging triggers both CI tests and publishing simultaneously. If CI fails (e.g. Trivy scan, macOS timeout), the package may already be published to PyPI, requiring a version bump to fix.

## New release flow
1. Merge version bump PR
2. Push tag (`git tag v2.1.1 && git push origin v2.1.1`)
3. Wait for SIMNOS Tests CI (including full-matrix) to pass
4. Create GitHub Release → triggers PyPI Publish and Docker Publish
5. If CI fails, delete the tag and fix — nothing has been published

## Test plan
- [ ] Verify PyPI Publish does NOT trigger on tag push
- [ ] Verify Docker Publish does NOT trigger on tag push
- [ ] Verify both trigger when a GitHub Release is created

🤖 Generated with [Claude Code](https://claude.com/claude-code)