### PR TITLE
chore: bump version to 2.1.1

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "simnos"
-version = "2.1.0"
+version = "2.1.1"
 description = "Simulated Network Operating System"
 authors = [
     { name = "KeroRoute lab" },

--- a/uv.lock
+++ b/uv.lock
@@ -1183,7 +1183,7 @@ wheels = [
 
 [[package]]
 name = "simnos"
-version = "2.1.0"
+version = "2.1.1"
 source = { editable = "." }
 dependencies = [
     { name = "detect" },


### PR DESCRIPTION
## Summary
- Bump version from 2.1.0 to 2.1.1
- Update uv.lock accordingly

## Changes since v2.1.0
- #102: Fix Docker Trivy zlib CVE, macOS test timeout, Telnet BrokenPipeError
- #103: Change publish triggers to release event (prevents premature publishing)

## Test plan
- [x] `uv lock` resolves successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)