### PR TITLE
perf: remove unnecessary per-byte time.sleep(0.01) in tap functions

### DIFF
--- a/simnos/plugins/servers/ssh_server_paramiko.py
+++ b/simnos/plugins/servers/ssh_server_paramiko.py
@@ -232,7 +232,6 @@ def channel_to_shell_tap(
                     [byte],
                 )
                 buffer.write(byte)
-            time.sleep(0.01)
         except (OSError, EOFError, paramiko.SSHException) as e:
             log.error("ssh_server.channel_to_shell_tap channel write error: %s", e)
             break

--- a/simnos/plugins/servers/telnet_server.py
+++ b/simnos/plugins/servers/telnet_server.py
@@ -284,7 +284,6 @@ class TelnetServer(TCPServerBase):
                         [byte],
                     )
                     buffer.write(byte)
-                time.sleep(0.01)
             except OSError as e:
                 log.error("telnet_server.socket_to_shell_tap socket write error: %s", e)
                 break


### PR DESCRIPTION
## Summary
- Remove `time.sleep(0.01)` from `channel_to_shell_tap` (SSH) and `socket_to_shell_tap` (Telnet) input loops
- `recv(1)` is already blocking, so the sleep only adds latency when data is available (e.g. netmiko bulk sends)
- Test suite time reduced by ~20% (865s → 694s)

Closes #107

## Test plan
- [x] Full test suite passed (609 passed, 8 skipped, 1 xfailed)
- [ ] CI passes on all platforms (Linux, macOS, Windows)
- [ ] Verify keroroute integration test time improvement

🤖 Generated with [Claude Code](https://claude.com/claude-code)