### PR TITLE
chore: bump version to 2.1.2

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "simnos"
-version = "2.1.1"
+version = "2.1.2"
 description = "Simulated Network Operating System"
 authors = [
     { name = "KeroRoute lab" },

--- a/uv.lock
+++ b/uv.lock
@@ -1183,7 +1183,7 @@ wheels = [
 
 [[package]]
 name = "simnos"
-version = "2.1.1"
+version = "2.1.2"
 source = { editable = "." }
 dependencies = [
     { name = "detect" },


### PR DESCRIPTION
## Summary
- Bump version from 2.1.1 to 2.1.2
- Update uv.lock

## Changes in v2.1.2
- #107: Remove per-byte `time.sleep(0.01)` in tap functions (~20% test speedup)
- #106: Replace `accept()` polling with `selectors` + `socketpair` for instant shutdown

🤖 Generated with [Claude Code](https://claude.com/claude-code)