### PR TITLE
chore: add Dependabot config and fix trivy-action supply chain alert

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,20 @@
+---
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    groups:
+      github-actions:
+        patterns:
+          - "*"
+
+  - package-ecosystem: "uv"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    groups:
+      python-dependencies:
+        patterns:
+          - "*"

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -57,10 +57,9 @@ jobs:
           cache-from: "type=gha,scope=docker-scan"
           cache-to: "type=gha,mode=max,scope=docker-scan"
       - name: "Trivy vulnerability scan"
-        uses: "aquasecurity/trivy-action@0.34.1"
+        uses: "aquasecurity/trivy-action@v0.35.0"
         with:
           image-ref: "${{ env.IMAGE_NAME }}:scan"
-          version: "v0.69.2"
           format: "table"
           exit-code: "1"
           severity: "CRITICAL,HIGH"

--- a/uv.lock
+++ b/uv.lock
@@ -427,6 +427,7 @@ wheels = [
 name = "griffelib"
 version = "2.0.0"
 source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/ad/06/eccbd311c9e2b3ca45dbc063b93134c57a1ccc7607c5e545264ad092c4a9/griffelib-2.0.0.tar.gz", hash = "sha256:e504d637a089f5cab9b5daf18f7645970509bf4f53eda8d79ed71cce8bd97934", size = 166312, upload-time = "2026-03-23T21:06:55.954Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/4d/51/c936033e16d12b627ea334aaaaf42229c37620d0f15593456ab69ab48161/griffelib-2.0.0-py3-none-any.whl", hash = "sha256:01284878c966508b6d6f1dbff9b6fa607bc062d8261c5c7253cb285b06422a7f", size = 142004, upload-time = "2026-02-09T19:09:40.561Z" },
 ]


### PR DESCRIPTION
## Summary
- Add `.github/dependabot.yml` for automated weekly updates (GitHub Actions + uv)
- Update `trivy-action` from `0.34.1` to `v0.35.0` to fix supply chain compromise (GHSA-69fq-xp46-6x23)
- Remove pinned trivy version to use latest

Closes #116

## Security alerts resolved
- **#8**: trivy-action supply chain compromise → updated to v0.35.0 (safe release)
- **#9**: Pygments ReDoS (CVE-2026-4539) → no fix available yet (severity: low, `first_patched_version: null`)

## Test plan
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)