### PR TITLE
chore: bump version to 2.1.3

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -3,11 +3,16 @@
 All notable changes to SIMNOS are documented here.
 For full details, see the [GitHub Releases](https://github.com/Route-Reflector/simnos/releases).
 
-## Unreleased
+## v2.1.3
+
+**Security**
+
+- Fix trivy-action supply chain compromise: update 0.34.1 → v0.35.0 (#117)
 
 **CI/CD**
 
-- Update GitHub Actions to Node.js 24 compatible versions (#112)
+- Update GitHub Actions to Node.js 24 compatible versions (#112, #118)
+- Add Dependabot configuration for automated weekly updates (#116)
 
 ## v2.1.2
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "simnos"
-version = "2.1.2"
+version = "2.1.3"
 description = "Simulated Network Operating System"
 authors = [
     { name = "KeroRoute lab" },

--- a/uv.lock
+++ b/uv.lock
@@ -1182,7 +1182,7 @@ wheels = [
 
 [[package]]
 name = "simnos"
-version = "2.1.2"
+version = "2.1.3"
 source = { editable = "." }
 dependencies = [
     { name = "detect" },


### PR DESCRIPTION
## Summary
- Bump version from 2.1.2 to 2.1.3
- Update uv.lock and changelog

## Changes in v2.1.3
- **Security**: Fix trivy-action supply chain compromise (0.34.1 → v0.35.0) (#117)
- **CI/CD**: Update GitHub Actions to Node.js 24 (#112, #118), add Dependabot config (#116)

🤖 Generated with [Claude Code](https://claude.com/claude-code)