### PR TITLE
chore: add yamllint to CI for YAML platform validation (#137)

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -31,6 +31,8 @@ jobs:
           enable-cache: true
       - name: "Linting: ruff"
         run: "uv run invoke ruff"
+      - name: "Linting: yamllint"
+        run: "uv run invoke yamllint"
       - name: "Security: bandit"
         run: "uv run invoke bandit"
 

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -2,7 +2,7 @@
 # pre-commit run --all-files
 
 default_language_version:
-    python: python3
+  python: python3
 
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks

--- a/.yamllint.yml
+++ b/.yamllint.yml
@@ -31,7 +31,8 @@ rules:
     indent-sequences: whatever
     check-multi-line-strings: false
 
-  # Allow `output: true` in platform YAMLs (do not flag truthy values).
+  # GitHub Actions workflows use `on:` as a top-level key, which YAML parses
+  # as boolean `True`. Disable truthy check on keys to allow this idiom.
   truthy:
     allowed-values: ['true', 'false']
     check-keys: false

--- a/.yamllint.yml
+++ b/.yamllint.yml
@@ -1,0 +1,49 @@
+---
+# yamllint configuration for simnos
+# See: https://yamllint.readthedocs.io/
+
+extends: default
+
+ignore: |
+  .venv/
+  .git/
+  build/
+  dist/
+  *.egg-info/
+  htmlcov/
+  site/
+
+rules:
+  # Platform YAMLs contain raw NTC Templates command outputs which can be very long.
+  # Workflow YAMLs and configs are kept under 200 chars.
+  line-length:
+    max: 200
+    ignore:
+      - simnos/plugins/nos/platforms_yaml/
+
+  # simnos YAMLs do not use document start markers.
+  document-start: disable
+
+  # Project YAMLs mix indented sequences (workflows) and non-indented (platforms_yaml).
+  # Accept either style.
+  indentation:
+    spaces: 2
+    indent-sequences: whatever
+    check-multi-line-strings: false
+
+  # Allow `output: true` in platform YAMLs (do not flag truthy values).
+  truthy:
+    allowed-values: ['true', 'false']
+    check-keys: false
+
+  # Allow up to 3 consecutive blank lines (excluding platform YAMLs which
+  # contain raw command outputs that may include multiple blank lines).
+  empty-lines:
+    max: 3
+    ignore:
+      - simnos/plugins/nos/platforms_yaml/
+
+  # Comment formatting is not strictly enforced.
+  comments-indentation: disable
+  comments:
+    min-spaces-from-content: 1

--- a/tasks.py
+++ b/tasks.py
@@ -177,6 +177,7 @@ def cli(context):
 def tests(context, local=INVOKE_LOCAL):
     """Run all tests."""
     ruff(context, local=local)
+    yamllint(context, local=local)
     bandit(context, local=local)
     pytest(context, local=local)
 


### PR DESCRIPTION
## Summary

Adds a yamllint configuration tuned for simnos and integrates it into the lint job alongside ruff and bandit.

Closes #137.

### Why
- 50+ platform YAML files plus workflow/config YAMLs were not lint-checked in CI
- yamllint was already declared as a dev dep and `invoke yamllint` existed, but no config file and no CI step

### What
- `.yamllint.yml` (new) — tuned for simnos:
  - `line-length: 200` for general YAMLs, `ignore` for `simnos/plugins/nos/platforms_yaml/` (raw NTC command outputs reach 276 chars)
  - `document-start: disable` (project does not use `---`)
  - `indent-sequences: whatever` to accept mixed styles between workflows and platform YAMLs
  - `truthy.check-keys: false` to allow GitHub Actions `on:` keys
  - `empty-lines.max: 3` with ignore for `platforms_yaml/` (command outputs may include multiple blank lines)
- `.github/workflows/main.yml` — add `Linting: yamllint` step to the existing lint job
- `.pre-commit-config.yaml` — fix indentation (4 → 2) under `default_language_version`
- `tasks.py` — add yamllint to the `invoke tests` aggregator so local runs match CI

### Verification
- `INVOKE_LOCAL=True uv run invoke yamllint` → PASS
- `INVOKE_LOCAL=True uv run invoke ruff` → PASS
- Default yamllint produced 25,499 violations on this tree; with the tuned config it is clean
- Confirmed `line-length: 200` still triggers on a 223-char synthetic file, and that platforms_yaml is correctly excluded only from `line-length` and `empty-lines`

## Test plan
- [x] `invoke yamllint` passes locally
- [x] `invoke ruff` still passes
- [x] CI green on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)