### PR TITLE
chore: bump version to 2.2.0

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -3,6 +3,36 @@
 All notable changes to SIMNOS are documented here.
 For full details, see the [GitHub Releases](https://github.com/Route-Reflector/simnos/releases).
 
+## v2.2.0
+
+**Features**
+
+- Add 9 new platforms from NTC Templates v9.0: aruba_aoscx, cisco_apic, cisco_viptela, cisco_wlc_ssh, edgecore, extreme_slxos, oneaccess_oneos, watchguard_firebox, zte_zxros (#129)
+- Add 28 new commands to cisco_ios from NTC Templates v9.1, including SD-WAN, CTS, endpoint-tracker, and license commands (#128)
+
+**Tests**
+
+- Add netmiko connection tests for all YAML-only platforms (#129)
+- Refine test skip logic with granular `skip_enable_platforms` instead of full-platform xfail (#129)
+
+**Documentation**
+
+- Add `CONTRIBUTING.md` with bilingual support (English / Japanese), AI Transparency policy, and contribution workflow (#121)
+- Add `SECURITY.md` with bilingual support pointing to GitHub Private Vulnerability Reporting (#120)
+- Convert platform compatibility list to detailed compatibility table with notes (#129)
+
+**CI/CD**
+
+- Add yamllint to CI for YAML platform validation across 50+ YAML files (#137)
+
+**Dependencies**
+
+- Bump ntc-templates 9.0.0 → 9.1.0 (transitive via netmiko)
+- Bump cryptography 46.0.5 → 46.0.7
+- Bump pytest 9.0.2 → 9.0.3
+- Bump trivy-action 0.35.0 → 0.36.0
+- Bump GitHub Actions Pages workflows to Node.js 24 compatible versions
+
 ## v2.1.3
 
 **Security**

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "simnos"
-version = "2.1.3"
+version = "2.2.0"
 description = "Simulated Network Operating System"
 authors = [
     { name = "KeroRoute lab" },

--- a/uv.lock
+++ b/uv.lock
@@ -1182,7 +1182,7 @@ wheels = [
 
 [[package]]
 name = "simnos"
-version = "2.1.3"
+version = "2.2.0"
 source = { editable = "." }
 dependencies = [
     { name = "detect" },


### PR DESCRIPTION
## Summary

Version bump for the v2.2.0 release. Highlights since v2.1.3:

- **Features**
  - 9 new platforms from NTC Templates v9.0 (#129): aruba_aoscx, cisco_apic, cisco_viptela, cisco_wlc_ssh, edgecore, extreme_slxos, oneaccess_oneos, watchguard_firebox, zte_zxros
  - 28 new commands for cisco_ios from NTC Templates v9.1 (#128), incl. SD-WAN, CTS, endpoint-tracker, license
- **Tests**: netmiko connection tests across all YAML platforms; granular `skip_enable_platforms` (#129)
- **Documentation**: bilingual `CONTRIBUTING.md` (#121) and `SECURITY.md` (#120); platform compatibility table (#129)
- **CI/CD**: yamllint added to lint job (#137)
- **Dependencies**: ntc-templates 9.0.0 → 9.1.0; cryptography 46.0.5 → 46.0.7; pytest 9.0.2 → 9.0.3; trivy-action 0.35.0 → 0.36.0; Pages workflows on Node.js 24

See `docs/changelog.md` for the full list.

## Files
- `pyproject.toml`: 2.1.3 → 2.2.0
- `uv.lock`: simnos package entry bumped
- `docs/changelog.md`: new v2.2.0 section

## Post-merge plan
1. Tag `v2.2.0` and create the GitHub release (publish workflows trigger on the release event)
2. Verify PyPI publish

## Test plan
- [x] `yamllint` passes locally
- [x] `ruff check --diff && ruff format --diff` passes locally
- [x] CI green on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)