### PR TITLE
refactor: sync all NTC raw fixtures and prefer canonical as primary (#147)

### DIFF
--- a/sync_ntc_commands.py
+++ b/sync_ntc_commands.py
@@ -146,20 +146,20 @@ def get_ntc_commands(target_dir: str, platform: str) -> dict[str, dict]:
         with open(primary_path, encoding="utf-8") as f:
             output = f.read()
 
-        variants: list[str] = []
+        variant_outputs: list[str] = []
         variant_paths: list[str] = []
         for variant in raw_files:
             if variant == primary:
                 continue
             variant_path = os.path.join(folder_path, variant)
             with open(variant_path, encoding="utf-8") as f:
-                variants.append(f.read())
+                variant_outputs.append(f.read())
             variant_paths.append(variant_path)
 
         command_name = folder.replace("_", " ")
         commands[command_name] = {
             "output": output,
-            "output_variants": variants,
+            "output_variants": variant_outputs,
             "raw_path": primary_path,
             "raw_path_variants": variant_paths,
         }

--- a/sync_ntc_commands.py
+++ b/sync_ntc_commands.py
@@ -70,14 +70,55 @@ def get_ntc_platforms(target_dir: str) -> list[str]:
     return sorted(name for name in os.listdir(tests_dir) if os.path.isdir(os.path.join(tests_dir, name)))
 
 
+def select_primary_raw(platform: str, folder: str, raw_files: list[str]) -> str:
+    """Pick the primary ``.raw`` file for a NTC command folder.
+
+    NTC's fixture naming is inconsistent: some folders have a clean
+    ``<platform>_<folder>.raw``, others use the folder name directly
+    (``ping.raw``), and some swap separators (folder
+    ``...advertised-routes`` vs file ``...advertised_routes.raw``). A
+    naive alphabetical pick can also land on a fixture that belongs to a
+    sibling command (e.g. ``alcatel_aos_show_interfaces_R8.raw`` sitting
+    inside ``show_interfaces_ethernet/``).
+
+    Selection order:
+
+    1. ``<platform>_<folder>.raw`` (canonical exact)
+    2. ``<platform>_<folder normalized>.raw`` (``-`` → ``_``)
+    3. ``<folder>.raw`` (no platform prefix)
+    4. ``<folder normalized>.raw``
+    5. The alphabetical-first raw whose stem contains the (normalized)
+       folder name — filters out unrelated siblings.
+    6. The alphabetical-first raw (last resort).
+
+    ``raw_files`` must be alphabetically sorted; the function does not
+    re-sort.
+    """
+    folder_normalized = folder.replace("-", "_")
+    candidates = [
+        f"{platform}_{folder}.raw",
+        f"{platform}_{folder_normalized}.raw",
+        f"{folder}.raw",
+        f"{folder_normalized}.raw",
+    ]
+    for candidate in candidates:
+        if candidate in raw_files:
+            return candidate
+
+    matching = [f for f in raw_files if folder_normalized in f.replace("-", "_").removesuffix(".raw")]
+    if matching:
+        return matching[0]
+
+    return raw_files[0]
+
+
 def get_ntc_commands(target_dir: str, platform: str) -> dict[str, dict]:
     """Extract commands and outputs from NTC Templates test data.
 
-    Each command folder may contain multiple `.raw` fixtures representing
-    different device states. We collect them all: the canonical fixture
-    (named ``<platform>_<folder>.raw``) is selected as the primary
-    ``output``; the rest are stored as ``output_variants``. If the
-    canonical name is absent we fall back to the alphabetical-first raw.
+    Each command folder may contain multiple ``.raw`` fixtures
+    representing different device states. We collect them all: a
+    primary fixture is picked via :func:`select_primary_raw` and stored
+    as ``output``; the rest are stored as ``output_variants``.
 
     Returns a dict of {command_name: {
         "output": str,
@@ -100,11 +141,7 @@ def get_ntc_commands(target_dir: str, platform: str) -> dict[str, dict]:
         if not raw_files:
             continue
 
-        # Prefer the canonical fixture "<platform>_<folder>.raw" (suffix-less);
-        # fall back to alphabetical first if absent.
-        canonical = f"{platform}_{folder}.raw"
-        primary = canonical if canonical in raw_files else raw_files[0]
-
+        primary = select_primary_raw(platform, folder, raw_files)
         primary_path = os.path.join(folder_path, primary)
         with open(primary_path, encoding="utf-8") as f:
             output = f.read()
@@ -206,7 +243,7 @@ def write_diff_file(
     # Build commands dict for YAML output
     prompt_value = prompts[0] if len(prompts) == 1 else prompts
     commands_data = {}
-    raw_paths = []
+    has_any_variants = False
     for cmd_name, cmd_data in new_commands.items():
         entry: dict = {
             "output": cmd_data["output"],
@@ -215,9 +252,8 @@ def write_diff_file(
         }
         if cmd_data.get("output_variants"):
             entry["output_variants"] = cmd_data["output_variants"]
+            has_any_variants = True
         commands_data[cmd_name] = entry
-        raw_paths.append(cmd_data["raw_path"])
-        raw_paths.extend(cmd_data.get("raw_path_variants", []))
 
     now = datetime.now(tz=UTC).strftime("%Y-%m-%d %H:%M:%S UTC")
 
@@ -229,10 +265,18 @@ def write_diff_file(
         if is_new_platform:
             f.write("# NOTE: New platform — not yet in simnos\n")
         f.write(f"# New commands: {len(new_commands)}\n")
+        if has_any_variants:
+            f.write("#\n")
+            f.write("# NOTE: `output_variants` lists alternate fixtures from NTC and is\n")
+            f.write("# currently ignored by the simnos runtime (no schema support yet).\n")
+            f.write("# It is preserved for future scenario / random response features.\n")
         f.write("#\n")
-        f.write("# Source .raw files:\n")
-        for path in raw_paths:
-            f.write(f"#   {path}\n")
+        f.write("# Source .raw files (primary marked with *):\n")
+        for cmd_name, cmd_data in new_commands.items():
+            f.write(f"#   {cmd_name}:\n")
+            f.write(f"#     * {cmd_data['raw_path']}\n")
+            for variant_path in cmd_data.get("raw_path_variants", []):
+                f.write(f"#       {variant_path}\n")
         f.write("\n")
         yaml.dump({"commands": commands_data}, f)
 

--- a/sync_ntc_commands.py
+++ b/sync_ntc_commands.py
@@ -83,7 +83,7 @@ def get_ntc_commands(target_dir: str, platform: str) -> dict[str, dict]:
         "output": str,
         "output_variants": list[str],
         "raw_path": str,
-        "raw_paths_variants": list[str],
+        "raw_path_variants": list[str],
     }}.
     """
     tests_dir = os.path.join(target_dir, "tests", platform)
@@ -110,21 +110,21 @@ def get_ntc_commands(target_dir: str, platform: str) -> dict[str, dict]:
             output = f.read()
 
         variants: list[str] = []
-        variants_paths: list[str] = []
+        variant_paths: list[str] = []
         for variant in raw_files:
             if variant == primary:
                 continue
             variant_path = os.path.join(folder_path, variant)
             with open(variant_path, encoding="utf-8") as f:
                 variants.append(f.read())
-            variants_paths.append(variant_path)
+            variant_paths.append(variant_path)
 
         command_name = folder.replace("_", " ")
         commands[command_name] = {
             "output": output,
             "output_variants": variants,
             "raw_path": primary_path,
-            "raw_paths_variants": variants_paths,
+            "raw_path_variants": variant_paths,
         }
 
     return commands
@@ -217,7 +217,7 @@ def write_diff_file(
             entry["output_variants"] = cmd_data["output_variants"]
         commands_data[cmd_name] = entry
         raw_paths.append(cmd_data["raw_path"])
-        raw_paths.extend(cmd_data.get("raw_paths_variants", []))
+        raw_paths.extend(cmd_data.get("raw_path_variants", []))
 
     now = datetime.now(tz=UTC).strftime("%Y-%m-%d %H:%M:%S UTC")
 

--- a/sync_ntc_commands.py
+++ b/sync_ntc_commands.py
@@ -73,7 +73,18 @@ def get_ntc_platforms(target_dir: str) -> list[str]:
 def get_ntc_commands(target_dir: str, platform: str) -> dict[str, dict]:
     """Extract commands and outputs from NTC Templates test data.
 
-    Returns a dict of {command_name: {"output": str, "raw_path": str}}.
+    Each command folder may contain multiple `.raw` fixtures representing
+    different device states. We collect them all: the canonical fixture
+    (named ``<platform>_<folder>.raw``) is selected as the primary
+    ``output``; the rest are stored as ``output_variants``. If the
+    canonical name is absent we fall back to the alphabetical-first raw.
+
+    Returns a dict of {command_name: {
+        "output": str,
+        "output_variants": list[str],
+        "raw_path": str,
+        "raw_paths_variants": list[str],
+    }}.
     """
     tests_dir = os.path.join(target_dir, "tests", platform)
     if not os.path.isdir(tests_dir):
@@ -89,15 +100,31 @@ def get_ntc_commands(target_dir: str, platform: str) -> dict[str, dict]:
         if not raw_files:
             continue
 
-        # Use first .raw file (sorted for reproducibility)
-        raw_path = os.path.join(folder_path, raw_files[0])
-        with open(raw_path, encoding="utf-8") as f:
+        # Prefer the canonical fixture "<platform>_<folder>.raw" (suffix-less);
+        # fall back to alphabetical first if absent.
+        canonical = f"{platform}_{folder}.raw"
+        primary = canonical if canonical in raw_files else raw_files[0]
+
+        primary_path = os.path.join(folder_path, primary)
+        with open(primary_path, encoding="utf-8") as f:
             output = f.read()
+
+        variants: list[str] = []
+        variants_paths: list[str] = []
+        for variant in raw_files:
+            if variant == primary:
+                continue
+            variant_path = os.path.join(folder_path, variant)
+            with open(variant_path, encoding="utf-8") as f:
+                variants.append(f.read())
+            variants_paths.append(variant_path)
 
         command_name = folder.replace("_", " ")
         commands[command_name] = {
             "output": output,
-            "raw_path": raw_path,
+            "output_variants": variants,
+            "raw_path": primary_path,
+            "raw_paths_variants": variants_paths,
         }
 
     return commands
@@ -181,12 +208,16 @@ def write_diff_file(
     commands_data = {}
     raw_paths = []
     for cmd_name, cmd_data in new_commands.items():
-        commands_data[cmd_name] = {
+        entry: dict = {
             "output": cmd_data["output"],
             "help": f'execute the command "{cmd_name}"',
             "prompt": prompt_value,
         }
+        if cmd_data.get("output_variants"):
+            entry["output_variants"] = cmd_data["output_variants"]
+        commands_data[cmd_name] = entry
         raw_paths.append(cmd_data["raw_path"])
+        raw_paths.extend(cmd_data.get("raw_paths_variants", []))
 
     now = datetime.now(tz=UTC).strftime("%Y-%m-%d %H:%M:%S UTC")
 

--- a/tests/test_sync_ntc_commands.py
+++ b/tests/test_sync_ntc_commands.py
@@ -40,6 +40,11 @@ class TestSelectPrimaryRaw:
         files = sorted(["cisco_ios_show_foo.raw", "something_unrelated.raw"])
         assert select_primary_raw("cisco_ios", "show-foo", files) == "cisco_ios_show_foo.raw"
 
+    def test_prefix_less_canonical(self):
+        """`<folder>.raw` (no platform prefix) wins over suffixed siblings."""
+        files = sorted(["ping.raw", "ping_bounce.raw", "ping_fail.raw", "ping_rapid.raw"])
+        assert select_primary_raw("alcatel_sros", "ping", files) == "ping.raw"
+
     def test_separator_normalization(self):
         """Folder name with `-` matches a raw file using `_`, no platform prefix."""
         files = sorted(["show_ip_bgp_neighbors_advertised_routes.raw", "show_ip_bgp_neighbors_advertised_routes2.raw"])
@@ -47,11 +52,6 @@ class TestSelectPrimaryRaw:
             select_primary_raw("cisco_ios", "show_ip_bgp_neighbors_advertised-routes", files)
             == "show_ip_bgp_neighbors_advertised_routes.raw"
         )
-
-    def test_prefix_less_canonical(self):
-        """`<folder>.raw` (no platform prefix) wins over suffixed siblings."""
-        files = sorted(["ping.raw", "ping_bounce.raw", "ping_fail.raw", "ping_rapid.raw"])
-        assert select_primary_raw("alcatel_sros", "ping", files) == "ping.raw"
 
     def test_folder_name_filter_skips_sibling_fixture(self):
         """`<folder>` contained in the raw stem wins over an unrelated alpha-first sibling."""

--- a/tests/test_sync_ntc_commands.py
+++ b/tests/test_sync_ntc_commands.py
@@ -35,6 +35,11 @@ class TestSelectPrimaryRaw:
         files = sorted(["cisco_ios_show_cts_pacs.raw", "cisco_ios_show-cts-pacs_6.raw"])
         assert select_primary_raw("cisco_ios", "show_cts_pacs", files) == "cisco_ios_show_cts_pacs.raw"
 
+    def test_canonical_separator_normalization(self):
+        """`<platform>_<folder normalized -→_>.raw` wins when folder uses `-`."""
+        files = sorted(["cisco_ios_show_foo.raw", "something_unrelated.raw"])
+        assert select_primary_raw("cisco_ios", "show-foo", files) == "cisco_ios_show_foo.raw"
+
     def test_separator_normalization(self):
         """Folder name with `-` matches a raw file using `_`, no platform prefix."""
         files = sorted(["show_ip_bgp_neighbors_advertised_routes.raw", "show_ip_bgp_neighbors_advertised_routes2.raw"])
@@ -57,9 +62,13 @@ class TestSelectPrimaryRaw:
         )
 
     def test_alphabetical_last_resort(self):
-        """When nothing matches the folder name, fall back to alphabetical-first."""
-        files = ["random_unrelated_file.raw"]
-        assert select_primary_raw("cisco_ios", "some_command", files) == "random_unrelated_file.raw"
+        """When nothing matches the folder name, fall back to alphabetical-first.
+
+        Multiple files are required to exercise the actual ordering — a
+        single-file fixture would pass any selector trivially.
+        """
+        files = sorted(["zzz_unrelated.raw", "aaa_unrelated.raw", "mmm_unrelated.raw"])
+        assert select_primary_raw("cisco_ios", "some_command", files) == "aaa_unrelated.raw"
 
     def test_single_raw_file(self):
         """Single-raw folder picks that file regardless of canonical match."""

--- a/tests/test_sync_ntc_commands.py
+++ b/tests/test_sync_ntc_commands.py
@@ -1,0 +1,67 @@
+"""Unit tests for sync_ntc_commands.py.
+
+Focuses on `select_primary_raw`, which encodes the NTC fixture-naming
+heuristics (canonical exact, separator normalization, prefix-less name,
+sibling-fixture filtering, alphabetical fallback). These were derived
+from concrete cases observed in real NTC Templates data:
+
+- `cisco_ios/show_ip_bgp_neighbors_advertised-routes/`: folder uses `-`,
+  the matching raw uses `_` and has no platform prefix.
+- `alcatel_sros/ping/`: only prefix-less names (`ping.raw`,
+  `ping_bounce.raw`, ...).
+- `alcatel_aos/show_interfaces_ethernet/`: contains a sibling fixture
+  `alcatel_aos_show_interfaces_R8.raw` that sorts alphabetically before
+  the right fixture and would be picked by a naive selector.
+"""
+
+import importlib.util
+from pathlib import Path
+import sys
+
+# sync_ntc_commands.py is a top-level script (not under simnos/) so we load
+# it explicitly rather than via a package import.
+_SYNC_PATH = Path(__file__).resolve().parents[1] / "sync_ntc_commands.py"
+_spec = importlib.util.spec_from_file_location("sync_ntc_commands", _SYNC_PATH)
+sync_ntc_commands = importlib.util.module_from_spec(_spec)
+sys.modules["sync_ntc_commands"] = sync_ntc_commands
+_spec.loader.exec_module(sync_ntc_commands)
+
+select_primary_raw = sync_ntc_commands.select_primary_raw
+
+
+class TestSelectPrimaryRaw:
+    def test_canonical_exact_match(self):
+        """`<platform>_<folder>.raw` wins over suffixed siblings."""
+        files = sorted(["cisco_ios_show_cts_pacs.raw", "cisco_ios_show-cts-pacs_6.raw"])
+        assert select_primary_raw("cisco_ios", "show_cts_pacs", files) == "cisco_ios_show_cts_pacs.raw"
+
+    def test_separator_normalization(self):
+        """Folder name with `-` matches a raw file using `_`, no platform prefix."""
+        files = sorted(["show_ip_bgp_neighbors_advertised_routes.raw", "show_ip_bgp_neighbors_advertised_routes2.raw"])
+        assert (
+            select_primary_raw("cisco_ios", "show_ip_bgp_neighbors_advertised-routes", files)
+            == "show_ip_bgp_neighbors_advertised_routes.raw"
+        )
+
+    def test_prefix_less_canonical(self):
+        """`<folder>.raw` (no platform prefix) wins over suffixed siblings."""
+        files = sorted(["ping.raw", "ping_bounce.raw", "ping_fail.raw", "ping_rapid.raw"])
+        assert select_primary_raw("alcatel_sros", "ping", files) == "ping.raw"
+
+    def test_folder_name_filter_skips_sibling_fixture(self):
+        """`<folder>` contained in the raw stem wins over an unrelated alpha-first sibling."""
+        files = sorted(["alcatel_aos_show_interfaces_R8.raw", "alcatel_aos_show_interfaces_ethernet_R6.raw"])
+        assert (
+            select_primary_raw("alcatel_aos", "show_interfaces_ethernet", files)
+            == "alcatel_aos_show_interfaces_ethernet_R6.raw"
+        )
+
+    def test_alphabetical_last_resort(self):
+        """When nothing matches the folder name, fall back to alphabetical-first."""
+        files = ["random_unrelated_file.raw"]
+        assert select_primary_raw("cisco_ios", "some_command", files) == "random_unrelated_file.raw"
+
+    def test_single_raw_file(self):
+        """Single-raw folder picks that file regardless of canonical match."""
+        files = ["provided_output.raw"]
+        assert select_primary_raw("cisco_ios", "show_ip_dhcp_snooping_binding", files) == "provided_output.raw"


### PR DESCRIPTION
## Summary

Reworks `sync_ntc_commands.py` so the diff YAMLs surface every `.raw` fixture upstream provides, with a robust canonical-first primary selection. Closes #147.

### Why

Previously the script picked `raw_files[0]` (alphabetical first) and discarded the rest. ASCII order put suffixed/dashed siblings ahead of the canonical fixture, which is how `cisco_ios_show-cts-pacs_6.raw` (containing a `b\^Lz` control-char artefact) ended up as the primary for `show cts pacs` in #128. NTC also intentionally ships multiple raws per command (different device states); throwing them away loses material that could power future scenario / random-response features.

### What

**`sync_ntc_commands.py`**
- New helper `select_primary_raw(platform, folder, raw_files)` with a documented 6-step priority:
  1. `<platform>_<folder>.raw` (canonical exact)
  2. `<platform>_<folder normalized -→_>.raw`
  3. `<folder>.raw` (no platform prefix)
  4. `<folder normalized>.raw`
  5. Alphabetical-first whose stem contains the (normalized) folder name — filters out unrelated siblings (e.g. `alcatel_aos_show_interfaces_R8.raw` sitting in `show_interfaces_ethernet/`)
  6. Alphabetical-first (last resort)
- `get_ntc_commands` now reads every raw in each command folder and returns `output` + `output_variants` + `raw_path` + `raw_path_variants`.
- `write_diff_file` writes `output_variants` only when non-empty, groups the source-`.raw` paths per command in the header (primary marked with `*`), and adds a NOTE explaining that simnos's runtime currently ignores `output_variants` (preserved for future features).

**`tests/test_sync_ntc_commands.py` (new)**
- 7 unit tests, one per selection step plus the degenerate single-raw case. Fixture cases come from real upstream patterns (`cisco_ios/show_ip_bgp_neighbors_advertised-routes`, `alcatel_sros/ping`, `alcatel_aos/show_interfaces_ethernet`).

### Out of scope (deferred)

- Lazy reading of variant raws — current size is ~915 KB total; not worth the refactor.
- `errors="replace"` / try-except for raw reads — no failures observed, current strict behaviour is consistent with prior logic.
- Extending `ModelNosCommand` to actually retain `output_variants` — needs a runtime feature first; for now the YAML header notes the schema gap so reviewers don't assume the field is preserved on load.
- Relative paths in the diff header (gemini SUGGESTION) — minor portability, not pursued here.

## Verification

- `uv run pytest tests/test_sync_ntc_commands.py -v` → 7 passed
- `INVOKE_LOCAL=True uv run invoke ruff` → pass
- `uv run yamllint .` → pass
- Real-data spot checks:
  - `cisco_ios show cts pacs`: primary = `cisco_ios_show_cts_pacs.raw` (canonical, clean); 6 variants include the corrupted `_6.raw`.
  - `cisco_ios show adjacency`: canonical absent, falls back to alphabetical first.
  - `alcatel_aos show_interfaces_ethernet`: sibling-filter picks `..._ethernet_R6.raw` instead of the alphabetically-earlier (and unrelated) `..._R8.raw`.
- Full sync run on all 56 platforms produces 23 platforms / 206 new commands (cisco_ios already merged in #128 so no diff).

## Cross-review (2 rounds)

Round 1: codex `[MUST FIX / bug]` on canonical coverage gaps + sibling fixture risk. Addressed by the 6-step selector and unit tests.
Round 2: codex / gemini / claude all `LGTM` or `SUGGESTION`. The remaining SHOULD FIX items (rule 2 / rule 6 test pin gaps, codex) are addressed in `419011f`. Other SUGGESTIONs (relative paths, package-style imports) are noted as out-of-scope follow-ups.

## Test plan

- [x] `pytest tests/test_sync_ntc_commands.py` passes
- [x] `invoke ruff` passes
- [x] `yamllint` passes
- [x] Manual sanity on `cisco_ios`, `alcatel_aos`, `alcatel_sros`, `huawei_smartax`
- [x] CI green on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)