### PR TITLE
feat: add show privilege to cisco_ios for ansible compatibility (#124)

### DIFF
--- a/docs/platforms/index.ja.md
+++ b/docs/platforms/index.ja.md
@@ -33,7 +33,7 @@ SIMNOS がサポートするプラットフォームの一覧です。各プラ�
 | [cisco_apic](cisco_apic.md) | ✅ | ⚠️ | - | - | Linux ベース NOS。Netmiko が enable モード昇格で `sudo -s` を送信する。SIMNOS は sudo 未対応。手動 `enable` 後に show コマンドは動作。v2.2.0 で追加 |
 | [cisco_asa](cisco_asa.md) | ✅ | ✅ | - | - | |
 | [cisco_ftd](cisco_ftd.md) | ✅ | ✅ | - | - | |
-| [cisco_ios](cisco_ios.md) | ✅ | ✅ | - | - | |
+| [cisco_ios](cisco_ios.md) | ✅ | ✅ | - | ✅ | |
 | [cisco_nxos](cisco_nxos.md) | ✅ | ✅ | - | - | |
 | [cisco_s300](cisco_s300.md) | ✅ | ✅ | - | - | |
 | [cisco_viptela](cisco_viptela.md) | ✅ | ✅ | - | - | v2.2.0 で追加 |

--- a/docs/platforms/index.md
+++ b/docs/platforms/index.md
@@ -33,7 +33,7 @@ The following platforms are supported by SIMNOS. Each platform has been tested f
 | [cisco_apic](cisco_apic.md) | ✅ | ⚠️ | - | - | Linux-based NOS. Netmiko sends `sudo -s` for enable mode escalation. SIMNOS does not support sudo. Show commands work after manual `enable`. New in v2.2.0 |
 | [cisco_asa](cisco_asa.md) | ✅ | ✅ | - | - | |
 | [cisco_ftd](cisco_ftd.md) | ✅ | ✅ | - | - | |
-| [cisco_ios](cisco_ios.md) | ✅ | ✅ | - | - | |
+| [cisco_ios](cisco_ios.md) | ✅ | ✅ | - | ✅ | |
 | [cisco_nxos](cisco_nxos.md) | ✅ | ✅ | - | - | |
 | [cisco_s300](cisco_s300.md) | ✅ | ✅ | - | - | |
 | [cisco_viptela](cisco_viptela.md) | ✅ | ✅ | - | - | New in v2.2.0 |

--- a/simnos/plugins/nos/platforms_yaml/cisco_ios.yaml
+++ b/simnos/plugins/nos/platforms_yaml/cisco_ios.yaml
@@ -4967,3 +4967,15 @@ commands:
       default-policy-tag                default policy-tag\n"
     help: execute the command "show wireless tag policy summary"
     prompt: *id001
+  # ----- Manually maintained (ansible compat) -----
+  # These commands are NOT sourced from NTC Templates. They are added so
+  # ansible's `cisco.ios.ios` cliconf does not see "% Invalid input" responses
+  # when it auto-runs sanity-check commands during connection. Re-runs of
+  # `sync_ntc_commands.py` will not affect this section.
+  show privilege:
+    output: "Current privilege level is 15\n"
+    help: Execute the command show privilege. This automatically generated. Feel
+      free to change it!
+    prompt:
+    - "{base_prompt}>"
+    - "{base_prompt}#"


### PR DESCRIPTION
## Summary

ansible's `cisco.ios.ios` cliconf auto-runs `show privilege` during the post-connection sanity-check sequence. simnos previously had no definition for this command, so the cliconf saw `% Invalid input` and bailed out, breaking `ansible.netcommon` modules like `ios_command` and `ios_facts`.

This PR adds `show privilege` to a new "Manually maintained (ansible compat)" section at the end of `cisco_ios.yaml` (mirroring the same convention used for cisco_asa's netmiko init compat in #152) and updates the platform compatibility tables to mark cisco_ios as ansible-verified.

- `simnos/plugins/nos/platforms_yaml/cisco_ios.yaml`: add `show privilege` (output: `Current privilege level is 15`, prompts: `>` and `#`) under a section header that flags the entry as NOT NTC-sourced
- `docs/platforms/index.md` / `index.ja.md`: bump cisco_ios's Ansible column from `-` to ✅

Scope is intentionally cisco_ios only; other platforms (cisco_asa / xr / nxos and non-Cisco) can be added when their respective ansible collections are exercised.

Closes #124.

---

ansible の `cisco.ios.ios` cliconf は接続後の sanity check で `show privilege` を自動実行する。simnos には従来この定義が無く、cliconf が `% Invalid input` を受けて中断するため `ios_command` / `ios_facts` 等の `ansible.netcommon` モジュールが動作しなかった。

本 PR では `cisco_ios.yaml` 末尾に新規セクション "Manually maintained (ansible compat)" を作って `show privilege` を定義 (#152 で cisco_asa の netmiko init compat 用に確立した規約と同形) し、platform 互換性 table の cisco_ios の Ansible 列を ✅ に更新する。

- `simnos/plugins/nos/platforms_yaml/cisco_ios.yaml`: `show privilege` (output: `Current privilege level is 15`, prompts: `>` / `#`) を NTC 由来でない旨をコメントヘッダで明示しつつ追加
- `docs/platforms/index.md` / `index.ja.md`: cisco_ios の Ansible 列を `-` → ✅

scope は cisco_ios のみに限定。他 platforms (cisco_asa / xr / nxos と非 Cisco) は対応する ansible collection をテストするタイミングで追加する。

Closes #124.

## Test plan

- [x] `uv run yamllint simnos/plugins/nos/platforms_yaml/cisco_ios.yaml` green
- [x] `uv run pytest -k cisco_ios`: 9 passed (init / unknown-command-graceful / send-command / yaml/py format checks 全て pass)
- [x] ansible ライブテスト: simnos を 6010 で起動し `uvx --from ansible --with ansible-pylibssh ansible-playbook` で playbook 実行
  - `ios_command` で `show version` ok
  - `ios_command` で `show privilege` → "Current privilege level is 15" ok (今回追加分)
  - `ios_facts gather_subset=min` で 13 個の facts (hostname, image, model, version 等) を収集
  - play 全 6 task green (ok=6 changed=0 failed=0)
- [x] CI green on PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)