### PR TITLE
feat: NTC Templates v9.1 commands for non-Cisco batch (fortinet / juniper_junos / paloalto_panos / arista_eos) (#154)

### DIFF
--- a/simnos/plugins/nos/platforms_yaml/arista_eos.yaml
+++ b/simnos/plugins/nos/platforms_yaml/arista_eos.yaml
@@ -1538,3 +1538,178 @@ commands:
     prompt:
     - "{base_prompt}>"
     - "{base_prompt}#"
+  dir:
+    output: "Directory of extension:/\n\nNo files in directory\n\n4093313024 bytes
+      total (3029774336 bytes free)\n"
+    help: execute the command "dir"
+    prompt: &id001
+    - '{base_prompt}>'
+    - '{base_prompt}#'
+    output_variants:
+    - "Directory of flash:/\n\n       -rwx   591941836            Aug 2  2017  EOS-4.18.3.1F.swi\n\
+      \       -rwx   609823300           Feb 14 02:03  EOS-4.19.5M.swi\n       -rwx\
+      \          29           Aug 23  2017  boot-config\n       drwx        4096 \
+      \          Aug 23  2017  debug\n       -rwx           0           Apr 15  2017\
+      \  enable3px\n       -rwx          19           Apr 15  2017  enable3px.key\n\
+      \       -rwx          31           Apr 15  2017  kickstart-config\n       drwx\
+      \        4096            Apr 3 10:29  persist\n       drwx        4096     \
+      \      Apr 15  2017  schedule\n       -rwx       20530           Jan 18 22:46\
+      \  startup-config\n       -rwx          13           Aug 23  2017  zerotouch-config\n\
+      \n3519041536 bytes total (1725112320 bytes free)\n"
+    - "Directory of flash:/\n\n       -rw-        1465           Feb 28 07:12  .CloudInitLogs\n\
+      \       -rw-           0           Sep 19  2022  .assetTags\n       -r--   509379353\
+      \           Sep 19  2022  .boot-image.swi\n       -rw-         250         \
+      \  Feb 28 07:13  .veos-config-internal\n       -rw-         250           Feb
+      28 06:56  .veos-config-internal.save\n       -rw-        1155           Feb
+      28 07:11  AsuFastPktTransmit.log\n       -rw-         710           Feb 28 07:11\
+      \  SsuRestore.log\n       -rw-         710           Feb 28 07:11  SsuRestoreLegacy.log\n\
+      \       -rw-        1186           Sep 19  2022  arista5-default.txt\n     \
+      \  -rw-          24           Apr 13  2022  boot-config\n       -rw-       \
+      \ 1251           Jul 21 04:15  rollback-0\n       -rw-        1418         \
+      \  Jul 21 04:15  startup-config\n       -rw-   509379353           Apr 13  2022\
+      \  vEOS-lab.swi\n       -rw-          13           Sep 19  2022  zerotouch-config\n\
+      \nDirectory of flash:/.checkpoints\n\n       -rw-        1486           Jul
+      13 08:02  ckp-20240713-5\n       -rw-        1416           Jul 15 10:17  ckp-20240715-0\n\
+      \       -rw-        1438           Jul 15 13:04  ckp-20240715-1\n       -rw-\
+      \        1508           Jul 15 13:05  ckp-20240715-2\n       -rw-        1507\
+      \           Jul 16 04:15  ckp-20240716-0\n       -rw-        1416          \
+      \ Jul 17 08:52  ckp-20240717-0\n       -rw-        1248           Jul 17 16:36\
+      \  ckp-20240717-1\n       -rw-        1275           Jul 17 16:36  ckp-20240717-2\n\
+      \       -rw-        1302           Jul 17 16:36  ckp-20240717-3\n       -rw-\
+      \        1329           Jul 17 16:36  ckp-20240717-4\n       -rw-        1356\
+      \           Jul 17 16:39  ckp-20240717-5\n       -rw-        1248          \
+      \ Jul 17 17:33  ckp-20240717-6\n       -rw-        1590           Jul 17 17:34\
+      \  ckp-20240717-7\n       -rw-        1248           Jul 17 21:34  ckp-20240717-8\n\
+      \       -rw-        1589           Jul 18 04:15  ckp-20240718-0\n       -rw-\
+      \        1416           Jul 20 06:32  ckp-20240720-0\n       -rw-        1590\
+      \           Jul 20 06:33  ckp-20240720-1\n       -rw-        1248          \
+      \ Jul 20 06:36  ckp-20240720-2\n       -rw-        1590           Jul 20 06:38\
+      \  ckp-20240720-3\n       -rw-        1247           Jul 21 04:15  ckp-20240721-0\n\
+      \nDirectory of flash:/.extensions\n\nNo files in directory\n\nDirectory of flash:/.managed-config\n\
+      \nNo files in directory\n\nDirectory of flash:/Fossil\n\nNo files in directory\n\
+      \nDirectory of flash:/debug\n\n       -rw-     3600958           Jan 12  2023\
+      \  pre_reload_logs.tgz\n       -rw-          89           Feb 28 07:13  reload_history\n\
+      \nDirectory of flash:/debug/proc\n\n       -r--        1885           Feb 28
+      07:11  modules\n\nDirectory of flash:/fastpkttx.backup\n\nNo files in directory\n\
+      \nDirectory of flash:/lost+found\n\nNo files in directory\n\nDirectory of flash:/persist\n\
+      \n       -rw-         288           Feb 28 07:11  AsuEvent.log\n       -rw-\
+      \        5120           Jul 23 02:15  local\n       -rw-           0       \
+      \    Jul 22 10:15  messages\n       -rw-       30720           Feb 28 07:13\
+      \  secure\n       -rw-        5120           Jul 23 04:30  sys\n\nDirectory
+      of flash:/persist/persistentRestartLog\n\nNo files in directory\n\nDirectory
+      of flash:/schedule\n\nDirectory of flash:/schedule/tech-support\n\n       -rw-\
+      \       71734           Jul 19 00:47  arista5_tech-support_2024-07-19.0047.log.gz\n\
+      \       -rw-       71774           Jul 19 01:47  arista5_tech-support_2024-07-19.0147.log.gz\n\
+      \                                                                          \
+      \                               \n4093313024 bytes total (3029774336 bytes free)\n"
+    - "Directory of system:/\n\n       -rw-        1349              <no date>  running-config\n\
+      \nNo space information available\n"
+  show environment power:
+    output: "Power              Input Output Output\nSupply Model      Capacity Current
+      Current Power Status      Uptime\n------ --------------- -------- ------- -------
+      ------ ------ ----------------\n1   PWR-1011-AC-RED  1000W  0.70A 11.58A 139.0W
+      Ok   68 days, 0:11:28\n2   PWR-1011-AC-RED  1000W  0.68A 11.31A 134.0W Ok  \
+      \ 68 days, 0:11:29\nTotal --         2000W   --   -- 273.0W --          --\n"
+    help: execute the command "show environment power"
+    prompt: *id001
+    output_variants:
+    - "Power                                  Input    Output   Output\nSupply  Model\
+      \                Capacity  Current  Current  Power    Status\n------- --------------------
+      --------- -------- -------- -------- -------------\n1       PWR-460AC-F    \
+      \           460W    0.00A    0.00A     0.0W Power Loss\n2       PWR-460AC-F\
+      \               460W    1.05A   10.38A   121.0W Ok\n"
+    - "Power                        Input  Output  Output\nSupply Model       Capacity
+      Current Current  Power Status              Uptime\n------ ----------- --------
+      ------- ------- ------ ------ -------------------\n1      PWR-500AC-R     500W\
+      \   0.35A   5.34A  64.8W Ok     1087 days, 21:24:36\n2      PWR-500AC-R    \
+      \ 500W   0.38A   5.77A  70.0W Ok       617 days, 8:39:45\nTotal  --        \
+      \     1000W      --      -- 134.8W --                      --\n"
+    - "% There seem to be no power supplies connected.\n"
+  show interfaces transceiver hardware:
+    output: "Name: Et1\nMedia type: 1000BASE-T\nMaximum module power (W): 0.0\nMaximum
+      slot power (W): N/A\n\nName: Et49\nMedia type: 10GBASE-CR\nMaximum module power
+      (W): 1.0\nMaximum slot power (W): N/A\n\nName: Et51\nMedia type: 1000BASE-LX\n\
+      Maximum module power (W): 1.0\nMaximum slot power (W): N/A\nWavelength (nm):
+      1310\n\nName: Ethernet96\nMedia type: 5GBASE-T\n\nName: Ethernet97/1\nModule
+      presence: not detected\nMaximum slot power (W): N/A\n\nName: Ethernet88\nMedia
+      type: 2.5GBASE-T\n\nName: Ethernet76\nMedia type: 2.5GBASE-T\n"
+    help: execute the command "show interfaces transceiver hardware"
+    prompt: *id001
+  show ip mroute vrf all detail:
+    output: "VRF:default\nPIM Bidirectional Mode Multicast Routing Table\nRPF route:
+      U - From unicast routing table\n           M - From multicast routing table\n\
+      PIM Sparse Mode Multicast Routing Table\nFlags: E - Entry forwarding on the
+      RPT, J - Joining to the SPT\n    R - RPT bit is set, S - SPT bit is set, L -
+      Source is attached\n    W - Wildcard entry, X - External component interest\n\
+      \    I - SG Include Join alert rcvd, P - Programmed in hardware\n    H - Joining
+      SPT due to policy, D - Joining SPT due to protocol\n    Z - Entry marked for
+      deletion, C - Learned from a DR via a register\n    A - Learned via Anycast
+      RP Router, M - Learned via MSDP\n    N - May notify MSDP, K - Keepalive timer
+      not running\n    T - Switching Incoming Interface, B - Learned via Border Router\n\
+      \    V - Source is reachable via Evpn Tenant Domain\n    F - Learned via MVPN\n\
+      RPF route: U - From unicast routing table\n           M - From multicast routing
+      table\n* - Interface has EVPN information available in the 'detail' command
+      output\n224.0.1.129\n  169.254.132.172, 118d18h, flags: PE\n    Incoming interface:
+      Null\n    Upstream joined state: upNotJoined\n    Upstream RPT joined state:
+      upRptNotJoined\n    State summarization macros:\n      Could register (S,G):
+      False\n      Register stop (S,G): True\n      Join desired (S,G): False\n  \
+      \    Prune desired (S,G,Rpt): False\n      No interfaces in immediate olist
+      (S,G): True\n      No interfaces in inherited olist (S,G): True\n224.0.23.192\n\
+      \  0.0.0.0, 38d14h, RP 204.14.0.136, flags: W\n    Incoming interface: Register\n\
+      \    Outgoing interface list:\n      Ethernet2/1\n      Ethernet2/2\n    Upstream
+      joined state: upJoined\n    Upstream RPT joined state: upRptNotJoined\n    State
+      summarization macros:\n      Join desired (*,G): True\n      Join desired (*,*,RP):
+      False\n      RPT join desired (*,G): True\n      No interfaces in immediate
+      olist (*,G): False\n      No interfaces in immediate olist (*,*,G): True\n \
+      \ 192.26.98.17, 8:57:21, flags: PE\n    Incoming interface: Register\n    Outgoing
+      interface list:\n      Ethernet2/1\n    Upstream joined state: upNotJoined\n\
+      \    Upstream RPT joined state: upRptNotPruned\n    State summarization macros:\n\
+      \      Could register (S,G): False\n      Register stop (S,G): False\n     \
+      \ Join desired (S,G): False\n      Prune desired (S,G,Rpt): False\n      No
+      interfaces in immediate olist (S,G): True\n      No interfaces in inherited
+      olist (S,G): False\n  192.168.98.17, 8:57:21, flags: SP\n    Incoming interface:
+      Ethernet10\n    RPF route: [U] 192.168.98.0/27 [20/0] via 10.100.10.6\n    Outgoing
+      interface list:\n      Ethernet2/1\n    Upstream joined state: upNotJoined\n\
+      \    Upstream RPT joined state: upRptNotPruned\n    State summarization macros:\n\
+      \      Could register (S,G): False\n      Register stop (S,G): True\n      Join
+      desired (S,G): True\n      Prune desired (S,G,Rpt): False\n      No interfaces
+      in immediate olist (S,G): False\n      No interfaces in inherited olist (S,G):
+      False\n224.0.23.190\n  0.0.0.0, 38d14h, RP 204.14.0.136, flags: W\n    Incoming
+      interface: Register\n    Outgoing interface list:\n      Ethernet0/1\n    Upstream
+      joined state: upJoined\n    Upstream RPT joined state: upRptNotJoined\n    State
+      summarization macros:\n      Join desired (*,G): True\n      Join desired (*,*,RP):
+      False\n      RPT join desired (*,G): True\n      No interfaces in immediate
+      olist (*,G): False\n      No interfaces in immediate olist (*,*,G): True\n \
+      \ 10.205.227.165, 38d14h, flags: SBNP\n    Incoming interface: Ethernet32\n\
+      \    Outgoing interface list:\n      Ethernet2/1\n    Interfaces not in OIL:\n\
+      \      Ethernet0/1: Not DR, RPT Pruned\n    Upstream joined state: upJoined\n\
+      \    Upstream RPT joined state: upRptNotPruned\n    State summarization macros:\n\
+      \      Could register (S,G): True\n      Register stop (S,G): True\n      Join
+      desired (S,G): True\n      Prune desired (S,G,Rpt): False\n      No interfaces
+      in immediate olist (S,G): False\n      No interfaces in inherited olist (S,G):
+      False\n  10.205.227.166, 18d7h, RP 204.14.0.136, flags: SBNP\n    Incoming interface:
+      Ethernet32\n    Outgoing interface list:\n      Ethernet0/1\n      Ethernet2/1\n\
+      \    Upstream joined state: upJoined\n    Upstream RPT joined state: upRptNotPruned\n\
+      \    State summarization macros:\n      Could register (S,G): True\n      Register
+      stop (S,G): True\n      Join desired (S,G): True\n      Prune desired (S,G,Rpt):
+      False\n      No interfaces in immediate olist (S,G): False\n      No interfaces
+      in inherited olist (S,G): False\nVRF:FOO\nPIM Bidirectional Mode Multicast Routing
+      Table\nRPF route: U - From unicast routing table\n           M - From multicast
+      routing table\nPIM Sparse Mode Multicast Routing Table\nFlags: E - Entry forwarding
+      on the RPT, J - Joining to the SPT\n    R - RPT bit is set, S - SPT bit is set,
+      L - Source is attached\n    W - Wildcard entry, X - External component interest\n\
+      \    I - SG Include Join alert rcvd, P - Programmed in hardware\n    H - Joining
+      SPT due to policy, D - Joining SPT due to protocol\n    Z - Entry marked for
+      deletion, C - Learned from a DR via a register\n    A - Learned via Anycast
+      RP Router, M - Learned via MSDP\n    N - May notify MSDP, K - Keepalive timer
+      not running\n    T - Switching Incoming Interface, B - Learned via Border Router\n\
+      \    V - Source is reachable via Evpn Tenant Domain\n    F - Learned via MVPN\n\
+      RPF route: U - From unicast routing table\n           M - From multicast routing
+      table\n224.0.1.130\n  169.254.132.173, 1d18h, flags: PE\n    Incoming interface:
+      Null\n    Upstream joined state: upNotJoined\n    Upstream RPT joined state:
+      upRptNotJoined\n    State summarization macros:\n      Could register (S,G):
+      False\n      Register stop (S,G): True\n      Join desired (S,G): False\n  \
+      \    Prune desired (S,G,Rpt): False\n      No interfaces in immediate olist
+      (S,G): True\n      No interfaces in inherited olist (S,G): True\n"
+    help: execute the command "show ip mroute vrf all detail"
+    prompt: *id001

--- a/simnos/plugins/nos/platforms_yaml/fortinet.yaml
+++ b/simnos/plugins/nos/platforms_yaml/fortinet.yaml
@@ -216,3 +216,366 @@ commands:
       \          40:cb:c0:ce:81:85 lan\n"
     help: execute the command "get system arp"
     prompt: "{base_prompt} # "
+  diagnose lldprx port neighbor details port-name:
+    output: "1 port: 6\n1 port.txt: lan1\n1 mac: 00:11:22:33:44:55\n1 chassis.type:
+      4\n1 chassis.type.txt: interface-mac\n1 chassis.data: 00:11:22:33:44:55\n1 port.id.type:
+      5\n1 port.id.type.txt: interface-name\n1 port.id.len: 20\n1 port.id.data: GigabitEthernet1/0/5\n\
+      1 ttl: 120\n1 port.desc.len: 10\n1 port.desc.data: Port\n1 system.name.len:
+      15\n1 system.name.data: Switch\n1 system.desc.len: 179\n1 system.desc.data:
+      Huawei Switch S5735-L48T4S-A1\nHuawei Versatile Routing Platform Software\n\
+      VRP (R) software, Version 5.170 (S5735 V200R022C00SPC500)\nCopyright (C) 2000-2022
+      HUAWEI TECH Co., Ltd.\n1 system.caps.available: 0014\n1 system.caps.available.txt:
+      bridge router\n1 system.caps.enabled: 0014\n1 system.caps.enabled.txt: bridge
+      router\n1 address.count: 1\n1 address.1.type: 1\n1 address.1.type.txt: ipv4\n\
+      1 address.1.len: 4\n1 address.1.addr: aaa.bbb.ccc.ddd\n1 address.1.addr.interface.type:
+      2\n1 address.1.addr.interface.type.txt: if-index\n1 address.1.addr.interface.number:
+      269\n1 vlan.id: 1\n1 vlan.protocol.count: 1\n1 vlan.protocol.1.flag: 0\n1 vlan.protocol.1.flag.txt:\n\
+      1 vlan.protocol.1.id: 0\n1 vlan.name.count: 1\n1 vlan.name.1.id: 1\n1 vlan.name.1.len:
+      9\n1 vlan.name.1.data: VLAN 0001\n1 aggregation.status: 1\n1 aggregation.status.txt:
+      capable\n1 aggregation.port: 0\n1 mac_phy.auto: 3\n1 mac_phy.auto.txt: supported
+      enabled\n1 mac_phy.pmd: 7c05\n1 mac_phy.pmd.txt: 10BaseT 10BaseTFD 100BaseT4
+      100BaseTX 100baseTXFD 1000baseXFd\n1 mac_phy.mau: 001e\n1 mac_phy.mau.txt: 1000baseTFD\n\
+      1 power.status: 0\n1 power.status.txt: PD\n1 power.pair: 0\n1 power.class: 0\n\
+      1 max-frame-size: 10240\n\n"
+    help: execute the command "diagnose lldprx port neighbor details port-name"
+    prompt: '{base_prompt} # '
+  diagnose sys top:
+    output: "Run Time:  12 days, 3 hours and 4 minutes\n0U, 0N, 0S, 100I, 0WA, 0HI,
+      0SI, 0ST; 1919T, 1214F\n          newcli    29806      R       0.1     0.5\n\
+      \            sshd    29800      S       0.1     0.4\n       ipshelper      199\
+      \      S <     0.0     1.8\n          httpsd      211      S       0.0     1.5\n"
+    help: execute the command "diagnose sys top"
+    prompt: '{base_prompt} # '
+  execute date:
+    output: "current date is: 2023-08-07\n"
+    help: execute the command "execute date"
+    prompt: '{base_prompt} # '
+  execute dhcp lease-list:
+    output: "Staff_Wifi\nIP            MAC-Address             Hostname        VCI\
+      \             Expiry\n10.0.0.4      cc:cc:cc:cc:cc:cc       MyOtherPhone   \
+      \ MSFT 5.0        Sat Aug 10 04:55:47 2019\n10.0.0.6      ee:ee:ee:ee:ee:ee\
+      \       Joes Phone                      Fri Aug  9 21:12:36 2019\nGuest_Wifi\n\
+      IP            MAC-Address             Hostname        VCI             Expiry\n\
+      172.16.31.3   11:11:11:11:11:11       android         android-dhcp    Mon Aug
+      12 07:47:46 2019\nport15\nIP            MAC-Address             Hostname   \
+      \     VCI             Expiry\n192.168.4.101 08:5b:0e:48:48:48       FortiAP-FP221C\
+      \                  Sat Aug 10 14:10:44 2019\n"
+    help: execute the command "execute dhcp lease-list"
+    prompt: '{base_prompt} # '
+    output_variants:
+    - "Vlan1\n  IP            MAC-Address             Hostname            VCI    \
+      \             SSID                AP                  Expiry\n  10.32.159.11\
+      \  cc:6b:1e:14:15:e1       NLZ0637-02          MSFT 5.0                    \
+      \                                Tue Jul 18 19:24:19 2023\n  10.32.159.26  34:db:fd:5d:b6:b5\
+      \       SPA112                                                             \
+      \             Tue Jul 18 19:02:45 2023\nVlan2\n  IP            MAC-Address \
+      \            Hostname            VCI                 SSID                AP\
+      \                  Expiry\n  10.32.159.162 b8:27:eb:9c:56:f9       YUM-FM_567\
+      \          dhcpcd-6.7.1:Linux-4.4.21-v7+:armv7l:BCM2709                    \
+      \                    Mon Jul 24 20:00:26 2023\nVlan3\n  IP            MAC-Address\
+      \             Hostname            VCI                 SSID                AP\
+      \                  Expiry\n  10.32.159.197 74:ac:b9:96:51:fd       Unifi3BS21ubnt\
+      \                                                                  Sun Jul 23
+      21:13:54 2023\n  10.32.159.199 74:ac:b9:96:51:e4       Unifi1BS21ubnt      \
+      \                                                            Sun Jul 23 21:13:29
+      2023\n"
+  execute log display:
+    output: "2492 logs found.\n10 logs returned.\n5.8% of logs has been searched.\n\
+      \n1: date=2023-08-10 time=19:41:18 logid=\"0000000013\" type=\"traffic\" subtype=\"\
+      forward\" level=\"notice\" vd=\"root\" eventtime=1691685678378886140 tz=\"+0300\"\
+      \ srcip=10.18.158.26 srcname=\"SPA112\" srcport=51753 srcintf=\"Vlan10\" srcintfrole=\"\
+      lan\" dstip=192.168.211.2 dstport=69 dstintf=\"Tu-Hub01-Main\" dstintfrole=\"\
+      undefined\" srccountry=\"Reserved\" dstcountry=\"Reserved\" sessionid=27409697
+      proto=17 action=\"accept\" policyid=17 policytype=\"policy\" poluuid=\"764f657a-c0dd-51ec-9d9c-2374a4d1b1d4\"\
+      \ policyname=\"Permit IP-Phones Vlan10 OUT\" service=\"TFTP\" trandisp=\"noop\"\
+      \ duration=1805 sentbyte=66 rcvdbyte=0 sentpkt=1 rcvdpkt=0 vpn=\"Tu-Hub01-Main\"\
+      \ vpntype=\"ipsec-static\" appcat=\"unscanned\" srchwvendor=\"Cisco\" devtype=\"\
+      IP Phone\" srcfamily=\"ATA\" srchwversion=\"SPA112\" mastersrcmac=\"50:67:ae:f0:6c:80\"\
+      \ srcmac=\"50:67:ae:f0:6c:80\" srcserver=0\n\n2: date=2023-08-10 time=19:40:47
+      logid=\"0000000013\" type=\"traffic\" subtype=\"forward\" level=\"notice\" vd=\"\
+      root\" eventtime=1691685647648897600 tz=\"+0300\" srcip=10.18.158.26 srcname=\"\
+      SPA112\" srcport=46212 srcintf=\"Vlan10\" srcintfrole=\"lan\" dstip=192.168.211.2
+      dstport=69 dstintf=\"Tu-Hub01-Main\" dstintfrole=\"undefined\" srccountry=\"\
+      Reserved\" dstcountry=\"Reserved\" sessionid=27408109 proto=17 action=\"accept\"\
+      \ policyid=17 policytype=\"policy\" poluuid=\"764f657a-c0dd-51ec-9d9c-2374a4d1b1d4\"\
+      \ policyname=\"Permit IP-Phones Vlan10 OUT\" service=\"TFTP\" trandisp=\"noop\"\
+      \ duration=1804 sentbyte=66 rcvdbyte=0 sentpkt=1 rcvdpkt=0 vpn=\"Tu-Hub01-Main\"\
+      \ vpntype=\"ipsec-static\" appcat=\"unscanned\" srchwvendor=\"Cisco\" devtype=\"\
+      IP Phone\" srcfamily=\"ATA\" srchwversion=\"SPA112\" mastersrcmac=\"50:67:ae:f0:6c:80\"\
+      \ srcmac=\"50:67:ae:f0:6c:80\" srcserver=0\n\n3: date=2023-08-10 time=19:40:28
+      logid=\"0000000020\" type=\"traffic\" subtype=\"forward\" level=\"notice\" vd=\"\
+      root\" eventtime=1691685628534615260 tz=\"+0300\" srcip=10.18.158.26 srcname=\"\
+      SPA112\" srcport=5060 srcintf=\"Vlan10\" srcintfrole=\"lan\" dstip=10.18.253.10
+      dstport=5060 dstintf=\"Tu-Hub01-Main\" dstintfrole=\"undefined\" srccountry=\"\
+      Reserved\" dstcountry=\"Reserved\" sessionid=1920 proto=17 action=\"accept\"\
+      \ policyid=17 policytype=\"policy\" poluuid=\"764f657a-c0dd-51ec-9d9c-2374a4d1b1d4\"\
+      \ policyname=\"Permit IP-Phones Vlan10 OUT\" service=\"SIP\" trandisp=\"noop\"\
+      \ duration=1506311 sentbyte=12959083 rcvdbyte=16082785 sentpkt=27800 rcvdpkt=27778
+      vpn=\"Tu-Hub01-Main\" vpntype=\"ipsec-static\" appcat=\"unscanned\" sentdelta=890
+      rcvddelta=1158 srchwvendor=\"Cisco\" devtype=\"IP Phone\" srcfamily=\"ATA\"\
+      \ srchwversion=\"SPA112\" mastersrcmac=\"50:67:ae:f0:6c:80\" srcmac=\"50:67:ae:f0:6c:80\"\
+      \ srcserver=0\n"
+    help: execute the command "execute log display"
+    prompt: '{base_prompt} # '
+    output_variants:
+    - "0 logs found.\n0 logs returned.\n"
+  execute ping:
+    output: "PING 8.8.8.8 (8.8.8.8): 56 data bytes\n64 bytes from 8.8.8.8: icmp_seq=0
+      ttl=110 time=25.9 ms\n64 bytes from 8.8.8.8: icmp_seq=1 ttl=110 time=25.8 ms\n\
+      64 bytes from 8.8.8.8: icmp_seq=2 ttl=110 time=25.8 ms\n64 bytes from 8.8.8.8:
+      icmp_seq=3 ttl=110 time=25.8 ms\n64 bytes from 8.8.8.8: icmp_seq=4 ttl=110 time=25.8
+      ms\n\n--- 8.8.8.8 ping statistics ---\n5 packets transmitted, 5 packets received,
+      0% packet loss\nround-trip min/avg/max = 25.8/25.8/25.9 ms\n"
+    help: execute the command "execute ping"
+    prompt: '{base_prompt} # '
+    output_variants:
+    - "PING 8.8.8.8 (8.8.8.8): 56 data bytes\nsendto failed\nsendto failed\nsendto
+      failed\nsendto failed\n\n--- 8.8.8.8 ping statistics ---\n10 packets transmitted,
+      0 packets received, 100% packet loss\n"
+    - "PING 8.87.8.8 (8.87.8.8): 56 data bytes\n\n--- 8.87.8.8 ping statistics ---\n\
+      5 packets transmitted, 0 packets received, 100% packet loss\n"
+  execute time:
+    output: "current time is: 21:05:34\nlast ntp sync: never\n"
+    help: execute the command "execute time"
+    prompt: '{base_prompt} # '
+  execute traceroute:
+    output: "traceroute to 8.8.8.8 (8.8.8.8), 32 hops max, 10 probe packets per hop,
+      84 byte packets\n 1  1.2.3.4  0.454 ms  0.503 ms  0.262 ms  0.191 ms  0.187
+      ms  0.191 ms  0.191 ms  0.192 ms  0.193 ms  0.185 ms\n 2  5.6.7.8  1.225 ms
+      * * *\n"
+    help: execute the command "execute traceroute"
+    prompt: '{base_prompt} # '
+    output_variants:
+    - "traceroute to 8.8.8.8 (8.8.8.8), 32 hops max, 3 probe packets per hop, 84 byte
+      packets\n 1  1.2.3.4  0.423 ms  2.123 ms  0.274 ms\n 2  5.6.7.8  0.389 ms  0.445
+      ms  0.178 ms\n 3  * * *\n 4  * * *\n 5  * * *\n 6  8.8.8.8  15.494 ms  15.488
+      ms  15.469 ms\n"
+  fnsysctl ifconfig:
+    output: "nturbo_rx       Link encap:Ethernet\n        UP BROADCAST MULTICAST \
+      \ MTU:1500  Metric:1\n        RX packets:0 errors:0 dropped:0 overruns:0 frame:0\n\
+      \        TX packets:0 errors:0 dropped:0 overruns:0 carrier:0\n        collisions:0
+      txqueuelen:1000\n        RX bytes:0 (0  Bytes)  TX bytes:0 (0  Bytes)\n\nwan\
+      \     Link encap:Ethernet  HWaddr 12:34:56:78:90:AA\n        inet addr:1.2.3.4\
+      \  Bcast:1.2.3.5  Mask:255.255.255.252\n        UP BROADCAST RUNNING MULTICAST\
+      \  MTU:1500  Metric:1\n        RX packets:7513822 errors:0 dropped:0 overruns:0
+      frame:0\n        TX packets:12533342 errors:0 dropped:0 overruns:0 carrier:0\n\
+      \        collisions:0 txqueuelen:1000\n        RX bytes:1116754241 (1.0 GB)\
+      \  TX bytes:2218288063 (2.1 GB)\n\nlan1    Link encap:Ethernet  HWaddr 12:34:56:78:90:AB\n\
+      \        UP BROADCAST RUNNING MULTICAST  MTU:1500  Metric:1\n        RX packets:3336406
+      errors:0 dropped:0 overruns:0 frame:0\n        TX packets:3382703 errors:0 dropped:0
+      overruns:0 carrier:0\n        collisions:0 txqueuelen:1000\n        RX bytes:258477533
+      (246.5 MB)  TX bytes:365165072 (348.2 MB)\n\nssl.root        Link encap:Unknown\n\
+      \        UP POINTOPOINT RUNNING NOARP MULTICAST  MTU:1500  Metric:1\n      \
+      \  RX packets:0 errors:0 dropped:0 overruns:0 frame:0\n        TX packets:0
+      errors:0 dropped:2 overruns:0 carrier:0\n        collisions:0 txqueuelen:0\n\
+      \        RX bytes:0 (0  Bytes)  TX bytes:0 (0  Bytes)\n\nLoopback772     Link
+      encap:Unknown\n        inet addr:127.0.0.1  Bcast:0.0.0.0  Mask:255.0.0.0\n\
+      \        UP BROADCAST LOOPBACK RUNNING NOARP MULTICAST  MTU:1500  Metric:1\n\
+      \        RX packets:0 errors:0 dropped:0 overruns:0 frame:0\n        TX packets:2
+      errors:0 dropped:0 overruns:0 carrier:0\n        collisions:0 txqueuelen:0\n\
+      \        RX bytes:0 (0  Bytes)  TX bytes:152 (152  Bytes)\n\nlan     Link encap:Ethernet\
+      \  HWaddr 12:34:56:78:90:AC\n        inet addr:10.152.1.230  Bcast:10.152.1.231\
+      \  Mask:255.255.255.252\n        UP BROADCAST RUNNING MULTICAST  MTU:1500  Metric:1\n\
+      \        RX packets:1695331 errors:0 dropped:0 overruns:0 frame:0\n        TX
+      packets:2829487 errors:0 dropped:0 overruns:0 carrier:0\n        collisions:0
+      txqueuelen:1000\n        RX bytes:154509025 (147.4 MB)  TX bytes:320990192 (306.1
+      MB)\n\nTu-Hub01-Main   Link encap:Unknown\n        inet addr:10.149.0.69  Mask:255.255.0.0\n\
+      \        UP POINTOPOINT RUNNING NOARP MULTICAST  MTU:1438  Metric:1\n      \
+      \  RX packets:2669 errors:0 dropped:0 overruns:0 frame:0\n        TX packets:64643
+      errors:0 dropped:0 overruns:0 carrier:0\n        collisions:0 txqueuelen:0\n\
+      \        RX bytes:919078 (897.5 KB)  TX bytes:5464602 (5.2 MB)\n\nTu-Rsnnc-Main\
+      \   Link encap:Unknown  HWaddr 12:34:56:78:90:AD\n        inet addr:192.168.64.10\
+      \  Mask:255.255.255.252\n        inet addr6: fdae:41a4:643b:9303::2 prefixlen
+      128\n        link-local6: fe80::200:aaaa:5f4f:54f4 prefixlen 64\n        UP
+      POINTOPOINT RUNNING NOARP MULTICAST  MTU:1476  Metric:1\n        RX packets:121755
+      errors:0 dropped:0 overruns:0 frame:0\n        TX packets:1 errors:0 dropped:0
+      overruns:0 carrier:0\n        collisions:0 txqueuelen:0\n        RX bytes:8018365
+      (7.6 MB)  TX bytes:84 (84  Bytes)\n\nVlan1   Link encap:Ethernet  HWaddr 12:34:56:78:90:AE\n\
+      \        inet addr:10.100.105.1  Bcast:10.100.105.31  Mask:255.255.255.224\n\
+      \        UP BROADCAST RUNNING MULTICAST  MTU:1500  Metric:1\n        RX packets:69882
+      errors:0 dropped:0 overruns:0 frame:0\n        TX packets:65 errors:0 dropped:0
+      overruns:0 carrier:0\n        collisions:0 txqueuelen:0\n        RX bytes:10988958
+      (10.5 MB)  TX bytes:3128 (3.1 KB)\n\nport_ha Link encap:Ethernet  HWaddr 12:34:56:78:90:AF\n\
+      \        UP BROADCAST MULTICAST  MTU:1496  Metric:1\n        RX packets:0 errors:0
+      dropped:0 overruns:0 frame:0\n        TX packets:0 errors:0 dropped:1 overruns:0
+      carrier:0\n        collisions:0 txqueuelen:1000\n        RX bytes:0 (0  Bytes)\
+      \  TX bytes:0 (0  Bytes)\n\nvsys_fgfm       Link encap:Local Loopback\n    \
+      \    inet addr:127.0.0.1  Mask:255.0.0.0\n        UP LOOPBACK RUNNING  MTU:16436\
+      \  Metric:1\n        RX packets:0 errors:0 dropped:0 overruns:0 frame:0\n  \
+      \      TX packets:0 errors:0 dropped:0 overruns:0 carrier:0\n        collisions:0
+      txqueuelen:0\n        RX bytes:0 (0  Bytes)  TX bytes:0 (0  Bytes)\n"
+    help: execute the command "fnsysctl ifconfig"
+    prompt: '{base_prompt} # '
+    output_variants:
+    - "eth0    Link encap:Ethernet  HWaddr 70:4C:A5:C8:7F:C2\n        UP BROADCAST
+      RUNNING MULTICAST  MTU:1500  Metric:1\n        RX packets:160120833 errors:0
+      dropped:0 overruns:0 frame:0\n        TX packets:229876847 errors:0 dropped:0
+      overruns:0 carrier:0\n        collisions:0 txqueuelen:532\n        RX bytes:48709238097
+      (45.4 GB)  TX bytes:230212740340 (214.4 GB)\n        Interrupt:193\n\nwan1 \
+      \   Link encap:Ethernet  HWaddr 70:4C:A5:C8:7F:C3\n        inet addr:192.168.197.63\
+      \  Bcast:192.168.197.255  Mask:255.255.255.0\n        inet addr6: fdae:41e4:649b:9303::2
+      prefixlen 128\n        link-local6: fe80::724c:a5ff:feb8:4fc3 prefixlen 64\n\
+      \        UP BROADCAST RUNNING ALLMULTI MULTICAST  MTU:1500  Metric:1\n     \
+      \   RX packets:273435252 errors:0 dropped:0 overruns:0 frame:0\n        TX packets:136877108
+      errors:0 dropped:0 overruns:0 carrier:0\n        collisions:0 txqueuelen:532\n\
+      \        RX bytes:233980902876 (217.9 GB)  TX bytes:42230049962 (39.3 GB)\n\
+      \        Interrupt:194\n\nwan2    Link encap:Ethernet  HWaddr 70:4C:A5:C8:7F:C4\n\
+      \        UP BROADCAST ALLMULTI MULTICAST  MTU:1500  Metric:1\n        RX packets:0
+      errors:0 dropped:0 overruns:0 frame:0\n        TX packets:0 errors:0 dropped:0
+      overruns:0 carrier:0\n        collisions:0 txqueuelen:532\n        RX bytes:0
+      (0  Bytes)  TX bytes:0 (0  Bytes)\n        Interrupt:195\n\nlan1    Link encap:Ethernet\
+      \  HWaddr 70:4C:A5:C8:7F:C5\n        inet addr:192.168.251.254  Bcast:192.168.251.255\
+      \  Mask:255.255.255.0\n        UP BROADCAST RUNNING MULTICAST  MTU:1500  Metric:1\n\
+      \        RX packets:11313810 errors:0 dropped:0 overruns:0 frame:0\n       \
+      \ TX packets:12102318 errors:0 dropped:0 overruns:0 carrier:0\n        collisions:0
+      txqueuelen:1000\n        RX bytes:2462897754 (2.3 GB)  TX bytes:7944791506 (7.4
+      GB)\n        Interrupt:255\n\nlan2    Link encap:Ethernet  HWaddr 70:4C:A5:C8:7F:C6\n\
+      \        UP BROADCAST RUNNING MULTICAST  MTU:1500  Metric:1\n        RX packets:0
+      errors:0 dropped:0 overruns:0 frame:0\n        TX packets:0 errors:0 dropped:0
+      overruns:0 carrier:0\n        collisions:0 txqueuelen:1000\n        RX bytes:0
+      (0  Bytes)  TX bytes:0 (0  Bytes)\n        Interrupt:255\n\nlan3    Link encap:Ethernet\
+      \  HWaddr 70:4C:A5:C8:7F:C7\n        UP BROADCAST RUNNING MULTICAST  MTU:1500\
+      \  Metric:1\n        RX packets:0 errors:0 dropped:0 overruns:0 frame:0\n  \
+      \      TX packets:0 errors:0 dropped:0 overruns:0 carrier:0\n        collisions:0
+      txqueuelen:1000\n        RX bytes:0 (0  Bytes)  TX bytes:0 (0  Bytes)\n    \
+      \    Interrupt:255\n\nlan4    Link encap:Ethernet  HWaddr 70:4C:A5:C8:7F:C8\n\
+      \        UP BROADCAST MULTICAST  MTU:1500  Metric:1\n        RX packets:0 errors:0
+      dropped:0 overruns:0 frame:0\n        TX packets:0 errors:0 dropped:0 overruns:0
+      carrier:0\n        collisions:0 txqueuelen:1000\n        RX bytes:0 (0  Bytes)\
+      \  TX bytes:0 (0  Bytes)\n        Interrupt:255\n\nlan5    Link encap:Ethernet\
+      \  HWaddr 70:4C:A5:C8:7F:C9\n        UP BROADCAST RUNNING MULTICAST  MTU:1500\
+      \  Metric:1\n        RX packets:0 errors:0 dropped:0 overruns:0 frame:0\n  \
+      \      TX packets:0 errors:0 dropped:0 overruns:0 carrier:0\n        collisions:0
+      txqueuelen:1000\n        RX bytes:0 (0  Bytes)  TX bytes:0 (0  Bytes)\n    \
+      \    Interrupt:255\n\nroot    Link encap:Local Loopback\n        inet addr:127.0.0.1\
+      \  Mask:255.0.0.0\n        UP LOOPBACK RUNNING  MTU:16436  Metric:1\n      \
+      \  RX packets:2060 errors:0 dropped:0 overruns:0 frame:0\n        TX packets:2060
+      errors:0 dropped:0 overruns:0 carrier:0\n        collisions:0 txqueuelen:0\n\
+      \        RX bytes:346520 (338.4 KB)  TX bytes:346520 (338.4 KB)\n\nssl.root\
+      \        Link encap:Unknown\n        UP POINTOPOINT RUNNING NOARP MULTICAST\
+      \  MTU:1500  Metric:1\n        RX packets:0 errors:0 dropped:0 overruns:0 frame:0\n\
+      \        TX packets:0 errors:0 dropped:2 overruns:0 carrier:0\n        collisions:0
+      txqueuelen:0\n        RX bytes:0 (0  Bytes)  TX bytes:0 (0  Bytes)\n\nlan  \
+      \   Link encap:Ethernet  HWaddr 70:4C:A5:C8:7F:C6\n        inet addr:192.168.250.254\
+      \  Bcast:192.168.250.255  Mask:255.255.255.0\n        UP BROADCAST RUNNING MULTICAST\
+      \  MTU:1500  Metric:1\n        RX packets:148807023 errors:0 dropped:0 overruns:0
+      frame:0\n        TX packets:217774529 errors:0 dropped:0 overruns:0 carrier:0\n\
+      \        collisions:0 txqueuelen:1000\n        RX bytes:45285616545 (42.2 GB)\
+      \  TX bytes:222267948834 (207.0 GB)\n        Interrupt:255\n\nvsys_ha Link encap:Local
+      Loopback\n        inet addr:127.0.0.1  Mask:255.0.0.0\n        UP LOOPBACK RUNNING\
+      \  MTU:16436  Metric:1\n        RX packets:0 errors:0 dropped:0 overruns:0 frame:0\n\
+      \        TX packets:0 errors:0 dropped:0 overruns:0 carrier:0\n        collisions:0
+      txqueuelen:0\n        RX bytes:0 (0  Bytes)  TX bytes:0 (0  Bytes)\n\nport_ha
+      Link encap:Ethernet  HWaddr 70:4C:A5:C8:7F:C4\n        UP BROADCAST MULTICAST\
+      \  MTU:1496  Metric:1\n        RX packets:5 errors:0 dropped:0 overruns:0 frame:0\n\
+      \        TX packets:1 errors:0 dropped:0 overruns:0 carrier:0\n        collisions:0
+      txqueuelen:1000\n        RX bytes:400 (400  Bytes)  TX bytes:94 (94  Bytes)\n\
+      \nvsys_fgfm       Link encap:Local Loopback\n        inet addr:127.0.0.1  Mask:255.0.0.0\n\
+      \        UP LOOPBACK RUNNING  MTU:16436  Metric:1\n        RX packets:0 errors:0
+      dropped:0 overruns:0 frame:0\n        TX packets:0 errors:0 dropped:0 overruns:0
+      carrier:0\n        collisions:0 txqueuelen:0\n        RX bytes:0 (0  Bytes)\
+      \  TX bytes:0 (0  Bytes)"
+  get hardware nic:
+    output: "The following NICs are available:\n        a\n        lan\n        lan1\n\
+      \        lan2\n        lan3\n        npu0_vlink0\n        npu0_vlink1\n    \
+      \    wan\n"
+    help: execute the command "get hardware nic"
+    prompt: '{base_prompt} # '
+  get hardware nic nic-name:
+    output: "Description     :FortiASIC NP6XLITE Adapter\nDriver Name     :FortiASIC
+      NP6XLITE Driver\nBoard           :40F\nlif id          :7\nlif oid         :71\n\
+      netdev oid      :71\nCurrent_HWaddr   12:34:56:78:90:ab\nPermanent_HWaddr 12:34:56:78:90:ab\n\
+      ========== Link Status ==========\nAdmin           :up\nnetdev status   :N/A\n\
+      autonego_setting:1\nlink_setting    :0\nspeed_setting   :1000\nduplex_setting\
+      \  :1\nSpeed           :100\nDuplex          :Full\nlink_status     :Up\n============
+      Counters ===========\nRx Pkts         :645878\nRx Bytes        :62442497\nTx
+      Pkts         :1025883\nTx Bytes        :76984876\nHost Rx Pkts    :1395584\n\
+      Host Rx Bytes   :87501251\nHost Tx Pkts    :933331\nHost Tx Bytes   :69433499\n\
+      Host Tx dropped :0\nFragTxCreate    :0\nFragTxOk        :0\nFragTxDrop     \
+      \ :0\nMember Ports    :\n                [00]: a\n                [01]: lan1\n\
+      \                [02]: lan2\n"
+    help: execute the command "get hardware nic nic-name"
+    prompt: '{base_prompt} # '
+  get router info bgp neighbors:
+    output: "VRF 0 neighbor table:\nBGP neighbor is 10.105.1.254, remote AS 65400,
+      local AS 65400, internal link\n  BGP version 4, remote router ID 10.105.3.254\n\
+      \  BGP state = Established, up for 4d14h28m\n  Last read 00:00:00, hold time
+      is 3, keepalive interval is 1 seconds\n  Configured hold time is 3, keepalive
+      interval is 1 seconds\n  Neighbor capabilities:\n    Route refresh: advertised
+      and received (old and new)\n    Address family IPv4 Unicast: advertised and
+      received\n    Address family IPv6 Unicast: advertised and received\n  Received
+      1517339 messages, 2 notifications, 0 in queue\n  Sent 1482858 messages, 6 notifications,
+      0 in queue\n  Route refresh request: received 0, sent 0\n  Minimum time between
+      advertisement runs is 1 seconds\n\n For address family: IPv4 Unicast\n  BGP
+      table version 31, neighbor version 25\n  Index 1, Offset 0, Mask 0x2\n    Additional
+      Path:\n      Send-mode: received\n      Receive-mode: advertised\n  NEXT_HOP
+      is always this router\n  Community attribute sent to this neighbor (both)\n\
+      \  Inbound path policy configured\n  Route map for incoming advertisements is
+      *prefer_vpn1root\n  423 accepted prefixes, 423 prefixes in rib\n  3 announced
+      prefixes\n\n For address family: IPv6 Unicast\n  BGP table version 1, neighbor
+      version 1\n  Index 1, Offset 0, Mask 0x2\n  Community attribute sent to this
+      neighbor (both)\n  0 accepted prefixes, 0 prefixes in rib\n  0 announced prefixes\n\
+      \n Connections established 9; dropped 8\nLocal host: 10.105.1.2, Local port:
+      3777\nForeign host: 10.105.1.254, Foreign port: 179\nNexthop: 10.105.1.2\nNexthop
+      interface: VPN1_0\nNexthop global: ::\nNexthop local: ::\nBGP connection: non
+      shared network\nLast Reset: 4d14h38m, due to BGP Notification sent\nNotification
+      Error Message: (Hold Timer Expired/Unspecified Error Subcode)\n\nBGP neighbor
+      is 10.105.2.254, remote AS 65400, local AS 65400, internal link\n  BGP version
+      4, remote router ID 10.105.3.254\n  BGP state = Established, up for 12:41:52\n\
+      \  Last read 00:00:00, hold time is 3, keepalive interval is 1 seconds\n  Configured
+      hold time is 3, keepalive interval is 1 seconds\n  Neighbor capabilities:\n\
+      \    Route refresh: advertised and received (old and new)\n    Address family
+      IPv4 Unicast: advertised and received\n    Address family IPv6 Unicast: advertised
+      and received\n  Received 1517182 messages, 4 notifications, 0 in queue\n  Sent
+      1481876 messages, 16 notifications, 0 in queue\n  Route refresh request: received
+      0, sent 0\n  Minimum time between advertisement runs is 1 seconds\n\n For address
+      family: IPv4 Unicast\n  BGP table version 31, neighbor version 30\n  Index 2,
+      Offset 0, Mask 0x4\n    Additional Path:\n      Send-mode: received\n      Receive-mode:
+      advertised\n  NEXT_HOP is always this router\n  Community attribute sent to
+      this neighbor (both)\n  Inbound path policy configured\n  Route map for incoming
+      advertisements is *prefer_vpn2root\n  423 accepted prefixes, 423 prefixes in
+      rib\n  3 announced prefixes\n\n For address family: IPv6 Unicast\n  BGP table
+      version 1, neighbor version 1\n  Index 2, Offset 0, Mask 0x4\n  Community attribute
+      sent to this neighbor (both)\n  0 accepted prefixes, 0 prefixes in rib\n  0
+      announced prefixes\n\n Connections established 21; dropped 20\nLocal host: 10.105.2.2,
+      Local port: 21489\nForeign host: 10.105.2.254, Foreign port: 179\nNexthop: 10.105.2.2\n\
+      Nexthop interface: VPN2_0\nNexthop global: ::\nNexthop local: ::\nBGP connection:
+      non shared network\nLast Reset: 12:55:18, due to BGP Notification sent\nNotification
+      Error Message: (Hold Timer Expired/Unspecified Error Subcode)\n\n\n"
+    help: execute the command "get router info bgp neighbors"
+    prompt: '{base_prompt} # '
+    output_variants:
+    - ''
+  get router info ospf status:
+    output: " Routing Process \"ospf 0\" with ID 10.123.105.1\n Process is not up\n\
+      \ Process bound to VRF default\n Conforms to RFC2328, and RFC1583Compatibility
+      flag is disabled\n Supports only single TOS(TOS0) routes\n Supports opaque LSA\n\
+      \ Do not support Restarting\n SPF schedule delay 5 secs, Hold time between two
+      SPFs 10 secs\n Refresh timer 10 secs\n Number of incomming current DD exchange
+      neighbors 0/5\n Number of outgoing current DD exchange neighbors 0/5\n Number
+      of external LSA 485. Checksum 0xF53F64\n Number of opaque AS LSA 0. Checksum
+      0x000000\n Number of non-default external LSA 483\n External LSA database is
+      unlimited.\n Number of LSA originated 1\n Number of LSA received 1026789\n Number
+      of areas attached to this router: 1\n    Area 0.0.0.0 (BACKBONE)\n        Number
+      of interfaces in this area is 9(11)\n        Number of fully adjacent neighbors
+      in this area is 2\n        Area has no authentication\n        SPF algorithm
+      last executed 00:00:22.990 ago\n        SPF algorithm executed 35480 times\n\
+      \        Number of LSA 68. Checksum 0x207089\n\n"
+    help: execute the command "get router info ospf status"
+    prompt: '{base_prompt} # '
+  get router info routing-table all:
+    output: "Codes: K - kernel, C - connected, S - static, R - RIP, B - BGP\n    \
+      \   O - OSPF, IA - OSPF inter area\n       N1 - OSPF NSSA external type 1, N2
+      - OSPF NSSA external type 2\n       E1 - OSPF external type 1, E2 - OSPF external
+      type 2\n       i - IS-IS, L1 - IS-IS level-1, L2 - IS-IS level-2, ia - IS-IS
+      inter area\n       * - candidate default\n\nRouting table for VRF=0\nO*E2  \
+      \  0.0.0.0/0 [110/10] via 10.149.127.253, Tu-Hub01-Main, 03w2d20h\nS       8.8.8.8/32
+      [200/0] via 4.3.2.1, wan\nO       10.80.58.224/27 [110/201] via 10.149.127.253,
+      Tu-Hub01-Main, 3d13h31m\nO E2    10.80.130.0/24 [110/20] via 10.149.127.253,
+      Tu-Hub01-Main, 22:00:53\nC       10.100.105.224/27 is directly connected, Vlan40\n\
+      C       10.149.0.0/16 is directly connected, Tu-Hub01-Main\n               \
+      \       is directly connected, Tu-Hub02-Main\nB       10.160.0.0/23 [20/0] via
+      10.142.0.74, port3, 2d18h02m\nS       1.2.3.4/32 [10/0] via 10.152.1.229, lan\n\
+      \                   [10/0] via 4.3.2.1, wan\n"
+    help: execute the command "get router info routing-table all"
+    prompt: '{base_prompt} # '

--- a/simnos/plugins/nos/platforms_yaml/juniper_junos.yaml
+++ b/simnos/plugins/nos/platforms_yaml/juniper_junos.yaml
@@ -544,3 +544,209 @@ commands:
     prompt:
     - "{base_prompt}>"
     - "{base_prompt}#"
+  show bgp summary:
+    output: "Threading mode: BGP I/O\nGroups: 2 Peers: 6 Down peers: 0\nPeer     \
+      \                AS      InPkt     OutPkt    OutQ   Flaps Last Up/Dwn State|#Active/Received/Accepted/Damped...\n\
+      192.0.2.254           64496    1165670    1238837       0       1 9w2d 5:23:37\
+      \ Establ\n  wanTrusted.inet.0: 23/224/224/0\n192.0.2.252           64496   \
+      \  753373     783304       0      50 35w2d 3:57:43 Establ\n  wanTrusted.inet.0:\
+      \ 65/224/224/0\n198.51.100.100        64496     814804     865022       0  \
+      \    19 6w3d 13:02:17 Establ\n  wanTrusted.inet.0: 30/226/226/0\n198.51.100.200\
+      \        64496     768547     816071       0      47 36w5d 12:18:32 Establ\n\
+      \  wanUntrust.inet.0: 1/70/70/0\n203.0.113.0           64496     811361    \
+      \ 865023       0      20 6w3d 13:02:22 Establ\n  wanUntrust.inet.0: 6/74/74/0\n\
+      203.0.113.0           64496    1162649    1238837       0       1 9w2d 5:23:33\
+      \ Establ\n  wanUntrust.inet.0: 4/72/72/0"
+    help: execute the command "show bgp summary"
+    prompt: &id001
+    - '{base_prompt}>'
+    - '{base_prompt}#'
+  show ethernet-switching interfaces:
+    output: "Interface    State  VLAN members        Tag   Tagging  Blocking \n\n\
+      ae0.0        up      default                   untagged unblocked\nge-0/0/2.0\
+      \   up      vlan300            300    untagged blocked by RTG (rtggroup)\nge-0/0/3.0\
+      \   up      default                            blocked by STP      \nge-0/0/4.0\
+      \   down    default                            MAC limit exceeded\nge-0/0/5.0\
+      \   down    default                            MAC move limit exceeded\nge-0/0/6.0\
+      \   down    default                            Storm control in effect\nge-0/0/7.0\
+      \   down    default                            unblocked\nge-0/0/13.0  up  \
+      \    default                   untagged unblocked\nge-0/0/14.0  up      vlan100\
+      \             100   tagged   unblocked\n                     vlan200       \
+      \      200   tagged   unblocked\nge-0/0/15.0  up      vlan100             100\
+      \   tagged   blocked by STP\n                     vlan200             200  \
+      \ tagged   blocked by STP\nge-0/0/16.0  down    default                   untagged\
+      \ unblocked\nge-0/0/17.0  down    vlan100             100   tagged   Disabled\
+      \ by bpdu-control\n                     vlan200             200   tagged   Disabled\
+      \ by bpdu-control\n"
+    help: execute the command "show ethernet-switching interfaces"
+    prompt: *id001
+  show route summary:
+    output: "Autonomous system number: 65000\nRouter ID: 129.250.0.2\n\nHighwater\
+      \ Mark (All time / Time averaged watermark)\n    RIB unique destination routes:\
+      \ 1221502 at 2000-01-01 00:00:00 / 1217389\n    RIB routes                 \
+      \  : 11101463 at 2000-01-01 00:00:00 / 10394871\n    FIB routes            \
+      \       : 1207937 at 2000-01-01 00:00:00 / 1203820\n    VRF type routing instances\
+      \   : 1 at 2000-01-01 00:00:00\n\ninet.0: 993427 destinations, 8574425 routes\
+      \ (992253 active, 13182 holddown, 1328663 hidden)\n              Direct:   \
+      \   8 routes,      7 active\n               Local:      7 routes,      7 active\n\
+      \                 BGP: 8568064 routes, 985893 active\n              Static:\
+      \      2 routes,      2 active\n               IS-IS:   6343 routes,   6343\
+      \ active\n                 LDP:      1 routes,      1 active\n\niso.0: 1 destinations,\
+      \ 1 routes (1 active, 0 holddown, 0 hidden)\n              Direct:      1 routes,\
+      \      1 active\n\nmpls.0: 284 destinations, 284 routes (284 active, 0 holddown,\
+      \ 0 hidden)\n                MPLS:      6 routes,      6 active\n          \
+      \      RSVP:      4 routes,      4 active\n                 LDP:    274 routes,\
+      \    274 active\n\ninet6.0: 214385 destinations, 1781556 routes (214292 active,\
+      \ 2700 holddown, 257364 hidden)\n              Direct:      4 routes,      4\
+      \ active\n               Local:      4 routes,      4 active\n             \
+      \    BGP: 1775906 routes, 208642 active\n              Static:      2 routes,\
+      \      2 active\n               IS-IS:   5639 routes,   5639 active\n      \
+      \         INET6:      1 routes,      1 active\n\nl2circuit.0: 1 destinations,\
+      \ 1 routes (1 active, 0 holddown, 0 hidden)\n                 LDP:      1 routes,\
+      \      1 active"
+    help: execute the command "show route summary"
+    prompt: *id001
+  show rsvp interface:
+    output: "Warning: License key missing; requires 'rsvp' license\n\nRSVP interface:\
+      \ 5 active\n                          Active  Subscr- Static      Available\
+      \   Reserved    Highwater\nInterface          State  resv    iption  BW    \
+      \      BW          BW          mark\nae0.0                  Up      10    95%\
+      \  400Gbps     380Gbps     200kbps     251kbps\nae2.0                  Up  \
+      \    86    95%  200Gbps     189.999Gbps 1.49104Mbps 6.91527Mbps\nae3.0     \
+      \             Up      73    95%  100Gbps     94.9994Gbps 572.791kbps 1.78375Mbps\n\
+      ae4.0                  Up       0    95%  100Gbps     95Gbps      0bps     \
+      \   0bps\nae5.0                  Up      54    95%  400Gbps     380Gbps    \
+      \ 8.164kbps   22.649kbps\n"
+    help: execute the command "show rsvp interface"
+    prompt: *id001
+  show system configuration database usage:
+    output: 'Maximum size of the database: 1301.99 MB
+
+      Current database size on disk: 4.00 MB
+
+      Actual database usage: 3.92 MB
+
+      Available database space: 1298.07 MB
+
+
+      {{master}}
+
+
+      '
+    help: execute the command "show system configuration database usage"
+    prompt: *id001
+    output_variants:
+    - Cannot proceed, database is currently being modified
+  show system processes brief:
+    output: 'last pid: 98312;  load averages:  1.72,  1.70,  1.70  up 87+21:25:46    15:51:17
+
+      302 processes: 5 running, 295 sleeping, 1 zombie, 1 waiting
+
+      CPU: 14.7% user,  0.0% nice,  4.2% system,  0.2% interrupt, 80.9% idle
+
+      Mem: 3532M Active, 33G Inact, 2458M Wired, 1046M Buf, 55G Free
+
+      Swap: 12G Total, 12G Free
+
+      '
+    help: execute the command "show system processes brief"
+    prompt: *id001
+    output_variants:
+    - '-------------------------------
+
+      node: fpc0
+
+      -------------------------------
+
+      top - 00:49:18 up 149 days,  5:29,  0 users,  load average: 0.85, 1.08, 0.99
+
+      Tasks: 271 total,   1 running, 270 sleeping,   0 stopped,   0 zombie
+
+      %Cpu(s):  2.0 us,  0.8 sy,  0.0 ni, 97.3 id,  0.0 wa,  0.0 hi,  0.0 si,  0.0
+      st
+
+      MiB Mem :  31554.4 total,  17292.4 free,  10600.3 used,   3661.7 buff/cache
+
+      MiB Swap:    100.0 total,    100.0 free,      0.0 used.  19854.3 avail Mem
+
+      -------------------------------
+
+      node: re0
+
+      -------------------------------
+
+      top - 00:49:18 up 149 days,  5:32,  1 user,  load average: 1.01, 0.97, 0.93
+
+      Tasks: 536 total,   1 running, 533 sleeping,   0 stopped,   2 zombie
+
+      %Cpu(s):  1.5 us,  0.3 sy,  0.0 ni, 97.6 id,  0.0 wa,  0.3 hi,  0.3 si,  0.0
+      st
+
+      MiB Mem : 128191.6 total,  65543.4 free,  17551.4 used,  45096.8 buff/cache
+
+      MiB Swap:   8192.0 total,   8192.0 free,      0.0 used. 108490.7 avail Mem
+
+      -------------------------------
+
+      node: re1
+
+      -------------------------------
+
+      top - 00:49:18 up 149 days,  5:32,  0 users,  load average: 0.30, 0.29, 0.27
+
+      Tasks: 407 total,   1 running, 406 sleeping,   0 stopped,   0 zombie
+
+      %Cpu(s):  2.1 us,  2.7 sy,  0.0 ni, 94.6 id,  0.0 wa,  0.3 hi,  0.3 si,  0.0
+      st
+
+      MiB Mem : 128191.6 total,  93230.9 free,   6286.2 used,  28674.5 buff/cache
+
+      MiB Swap:   4096.0 total,   1131.7 free,   2964.2 used. 119812.1 avail Mem
+
+
+      {{master}}
+
+      '
+  show system processes summary:
+    output: "last pid: 24931;  load averages:  0.89,  0.94,  0.81  up 41+06:26:24\
+      \    00:51:55\n545 threads:   9 running, 481 sleeping, 1 zombie, 54 waiting\n\
+      CPU: 14.7% user,  0.0% nice,  4.1% system,  0.2% interrupt, 81.0% idle\nMem:\
+      \ 3977M Active, 14G Inact, 1815M Wired, 504M Buf, 74G Free\nSwap: 12G Total,\
+      \ 12G Free\n\n  PID USERNAME    PRI NICE   SIZE    RES STATE    C   TIME   \
+      \ WCPU COMMAND\n   11 root        155 ki31     0B   128K CPU7     7 787.8H \
+      \ 98.58% idle{{idle: cpu7}}\n   11 root        155 ki31     0B   128K CPU0 \
+      \    0 931.9H  98.39% idle{{idle: cpu0}}\n   11 root        155 ki31     0B\
+      \   128K CPU2     2 783.0H  96.88% idle{{idle: cpu2}}\n   11 root        155\
+      \ ki31     0B   128K RUN      5 787.6H  96.78% idle{{idle: cpu5}}\n   11 root\
+      \        155 ki31     0B   128K CPU4     4 786.1H  96.68% idle{{idle: cpu4}}\n\
+      \   11 root        155 ki31     0B   128K CPU6     6 787.6H  93.26% idle{{idle:\
+      \ cpu6}}\n   11 root        155 ki31     0B   128K CPU1     1 785.5H  91.70%\
+      \ idle{{idle: cpu1}}\n   11 root        155 ki31     0B   128K CPU3     3 785.6H\
+      \  90.67% idle{{idle: cpu3}}\n19880 root         25    0   801M    74M select\
+      \   2 132.6H  15.09% cosd\n19926 root         24    0   735M    27M select \
+      \  7 113.5H  11.87% snmpd\n19929 root         22    0   805M    86M select \
+      \  3  81.9H   9.28% mib2d\n19876 root         21    0    14G    13G kqread \
+      \  3 938.4H   2.69% rpd{{rpd}}\n19876 root         21    0    14G    13G kqread\
+      \   3  20.3H   2.69% rpd{{junos-bgpshard3}}\n19876 root         21    0    14G\
+      \    13G kqread   4  20.3H   1.76% rpd{{junos-bgpshard0}}\n19876 root      \
+      \   20    0    14G    13G kqread   0  24.6H   1.46% rpd{{junos-bgpshard2}}\n\
+      19914 root         21    0   839M   118M select   5  18.4H   1.37% jinsightd{{jinsightd}}\n\
+      19876 root         20    0    14G    13G kqread   1  22.2H   1.27% rpd{{junos-bgpshard1}}\n\
+      \   12 root        -60    -     0B   864K WAIT     0  69:18   1.17% intr{{swi4:\
+      \ clock (0)}}\n19315 root         21    0   880M    78M select   6 898:25  \
+      \ 0.98% chassisd{{chassisd}}\n19921 root         20    0   131M    49M select\
+      \   2 596:38   0.59% na-grpcd{{na-grpcd}}\n19876 root         20    0    14G\
+      \    13G kqread   6 489:58   0.59% rpd{{bgp-updio-3}}\n24926 remote       20\
+      \    0    95M    25M select   1   0:00   0.59% cli\n   12 root        -92  \
+      \  -     0B   864K WAIT     0 162:55   0.49% intr{{irq271: ixlv0:que 0}}\n24923\
+      \ root         22    0   756M    13M select   7   0:00   0.29% sshd\n   12 root\
+      \        -72    -     0B   864K WAIT     1 417:28   0.20% intr{{swi1: netisr\
+      \ 2}}\n19352 root         20    0   724M  8544K select   2 106:54   0.20% timingd{{ptp_stack}}\n\
+      24925 remote       20    0   756M    13M select   6   0:00   0.20% sshd\n19858\
+      \ root        -16    -     0B    16K select   1 184:43   0.10% ppt_11_80000010\n\
+      19743 root        -16    -     0B    16K select   7 172:15   0.10% ppt_11_80000013\n\
+      21670 root        -16    -     0B    16K select   0 166:12   0.10% ppt_11_80000015\n\
+      \    2 root        -16    -     0B    16K jfe_jo   2 138:19   0.10% jfe_job_0_0\n\
+      24931 root         20    0    14M  3636K CPU5     5   0:00   0.00% top\n"
+    help: execute the command "show system processes summary"
+    prompt: *id001

--- a/simnos/plugins/nos/platforms_yaml/paloalto_panos.yaml
+++ b/simnos/plugins/nos/platforms_yaml/paloalto_panos.yaml
@@ -294,3 +294,132 @@ commands:
       dropped          0\nmulticast packets received        0\n-------------------------------------------------------------------------------\n"
     help: execute the command "show interface management"
     prompt: "{base_prompt}>"
+  request license info:
+    output: "Current PDT Date: May 19, 2021\n\nLicense entry:\nFeature: WildFire License\n\
+      Description: WildFire signature feed, integrated WildFire logs, WildFire API\n\
+      Serial: 0000000xxxxxxxx\nIssued: January 13, 2020\nExpires: March 08, 2023\n\
+      Expired?: no\nBase license: PA-VM\n\nLicense entry:\nFeature: Premium\nDescription:
+      24 x 7 phone support; advanced replacement hardware service\nSerial: 0000000xxxxxxxx\n\
+      Issued: January 13, 2020\nExpires: January 09, 2023\nExpired?: no\nBase license:
+      PA-VM\n\nLicense entry:\nFeature: PAN-DB URL Filtering\nDescription: Palo Alto
+      Networks URL Filtering License\nSerial: 0000000xxxxxxxx\nIssued: January 13,
+      2020\nExpires: March 08, 2023\nExpired?: no\nBase license: PA-VM\n\nLicense
+      entry:\nFeature: GlobalProtect Portal\nDescription: GlobalProtect Portal License\n\
+      Serial: 0000000xxxxxxxx\nIssued: March 08, 2017\nExpires: Never\nExpired?: no\n\
+      Base license: PA-VM\n\nLicense entry:\nFeature: PA-VM\nDescription: Standard
+      VM-100\nSerial: 0000000xxxxxxxx\nIssued: March 08, 2017\nExpires: Never\nExpired?:
+      no\n\nLicense entry:\nFeature: Threat Prevention\nDescription: Threat Prevention\n\
+      Serial: 0000000xxxxxxxx\nIssued: January 13, 2020\nExpires: January 13, 2023\n\
+      Expired?: no\nBase license: PA-VM\n\nLicense entry:\nFeature: GlobalProtect
+      Gateway\nDescription: GlobalProtect Gateway License\nSerial: 0000000xxxxxxxx\n\
+      Issued: January 13, 2020\nExpires: March 08, 2023\nExpired?: no\nBase license:
+      PA-VM\nAuthcode: abc def\n"
+    help: execute the command "request license info"
+    prompt: '{base_prompt}>'
+  show high-availability path-monitoring:
+    output: "--------------------------------------------------------------------------------\n\
+      total paths monitored :                         2\nhold time to send probe packets
+      :               1000 ms\n  (after device becomes active)\n--------------------------------------------------------------------------------\n\
+      grp/name/type             destination     suc/total rtt min/max/avg (ms) probe
+      cnt/interval(ms)\n--------------------------------------------------------------------------------\n\
+      HA_PATH_NORTH/VR_HANDOFF/virtual-router 8.8.8.8         10/10     3.66/4.19/3.90\
+      \      10/1000    \nHA_PATH_NORTH/VR_HANDOFF/virtual-router 217.111.187.217
+      10/10     2.36/2.75/2.58      10/1000    \n--------------------------------------------------------------------------------"
+    help: execute the command "show high-availability path-monitoring"
+    prompt: '{base_prompt}>'
+  show routing protocol bgp summary:
+    output: "  ==========\n  router id:                     1.1.1.1\n  virtual router:\
+      \                VR_HANDOFF\n  reject default route:          no\n  redist default
+      route:          allow\n  Install BGP routes:            yes\n  Graceful Restart:\
+      \              supported\n  AS size:                       2\n  Local AS:  \
+      \                    65253\n  Local member AS:               0\n  Cluster id:\
+      \                    0.0.0.0\n  Default local preference:      100\n  Always
+      compare MED:            no\n  Aggregate regardless MED:      yes\n  Deterministic
+      MED processing:  yes\n  Accept ORF:                    no\n  Accept CISCO style
+      prefix:     yes\n  mp-bgp-enable:                 yes\n  afi-safi-ipv4-unicast:\
+      \         yes\n  rib-out entries:               current 46, peak 47 \n    peer
+      DC-N9K-BGW01 - BLU 301: AS 65253, Established, IP 192.168.1.1\n      bgpAfiIpv4/unicast
+      pfx:    Accepted pfx: 4, Advertised pfx: 4\n    peer DC-N9K-BGW02 - BLU 301:
+      AS 65301, Established, IP 192.168.1.2\n      bgpAfiIpv4/unicast pfx:    Accepted
+      pfx: 4, Advertised pfx: 4\n    peer DC-N9K-BGW01 - GRN 302: AS 65253, Established,
+      IP 192.168.2.9\n      bgpAfiIpv4/unicast pfx:    Accepted pfx: 3, Advertised
+      pfx: 4\n    peer DC-N9K-BGW02 - GRN 302: AS 65302, Established, IP 192.168.2.10\n\
+      \      bgpAfiIpv4/unicast pfx:    Accepted pfx: 3, Advertised pfx: 4\n    peer
+      DC-N9K-BGW01 - AMB 303: AS 65253, Established, IP 192.168.3.17\n      bgpAfiIpv4/unicast
+      pfx:    Accepted pfx: 2, Advertised pfx: 3\n    peer DC-N9K-BGW02 - AMB 303:
+      AS 65303, Established, IP 192.168.3.18\n      bgpAfiIpv4/unicast pfx:    Accepted
+      pfx: 2, Advertised pfx: 3\n"
+    help: execute the command "show routing protocol bgp summary"
+    prompt: '{base_prompt}>'
+  show routing resource:
+    output: "GLOBAL ROUTING RESOURCE USAGE:\n  ==========\n  All      Routes (total):\
+      \             18 \t(limit    10000)\n  All IPv4 Routes (total):            \
+      \ 18 \t(limit    10000)\n  All IPv6 Routes (total):              0 \t(limit\
+      \    10000)\n  All     Routes (active):             18\n  ==========\n  Static\
+      \   Routes (total):              5\n  Connect  Routes (total):             \
+      \ 4\n  BGP      Routes (total):              9\n  OSPF     Routes (total): \
+      \             0\n  RIP      Routes (total):              0"
+    help: execute the command "show routing resource"
+    prompt: '{base_prompt}>'
+  show routing route:
+    output: "flags: A:active, ?:loose, C:connect, H:host, S:static, ~:internal, R:rip,
+      O:ospf, B:bgp, \n       Oi:ospf intra-area, Oo:ospf inter-area, O1:ospf ext-type-1,
+      O2:ospf ext-type-2, E:ecmp, M:multicast\n\n  \nVIRTUAL ROUTER: VR_HANDOFF (id
+      3)\n  ==========\ndestination                                 nexthop      \
+      \                           metric flags      age   interface          next-AS\
+      \    \n0.0.0.0/0                                   192.168.2.49            \
+      \                       A?B        121661                    0          \n10.0.0.0/8\
+      \                                  discard                                 10\
+      \     A S                                            \n10.0.0.1/32         \
+      \                        192.168.2.44                                   A?B\
+      \        120738                    65213      \n10.0.0.2/32                \
+      \                 192.168.2.44                                   A?B       \
+      \ 120738                    65213           \n10.3.0.0/16                  \
+      \               discard                                 10     A S         \
+      \                                   \n10.3.0.0/20                          \
+      \       192.168.2.1                                    A?B        121661   \
+      \                 65213      \n10.3.0.0/21                                 192.168.2.1\
+      \                                    A?B        121661                    65213\
+      \          \n10.3.252.0/23                               192.168.2.49      \
+      \                             A?B        121661                    0       \
+      \   \n10.3.252.0/24                               192.168.2.49             \
+      \                      A?B        121661                    0          \n10.3.252.0/28\
+      \                               discard                                 10 \
+      \    A S                                            \n10.3.253.0/28        \
+      \                       discard                                 10     A S \
+      \                                           \n10.3.255.0/24                \
+      \               192.168.2.25                                   A?B        121661\
+      \                    65213      \n10.3.255.0/25                            \
+      \   192.168.2.25                                   A?B        121661       \
+      \             65213              \n172.16.0.0/12                           \
+      \    discard                                 10     A S                    \
+      \                        \n172.17.0.0/16                               discard\
+      \                                 10     A S                               \
+      \             \n172.17.0.0/17                               192.168.2.1    \
+      \                                A?B        121661                    65213\
+      \      \n172.17.128.0/18                             192.168.2.9           \
+      \                         A?B        121661                    65213       \
+      \  \n172.30.0.0/18                               192.168.2.49              \
+      \                     A?B        121661                    0          \n172.30.0.0/19\
+      \                               192.168.2.49                               \
+      \    A?B        121661                    0                  \n192.168.0.0/16\
+      \                              discard                                 10  \
+      \   A S                                            \n192.168.2.0/29        \
+      \                      192.168.2.3                             0      A C  \
+      \            ethernet1/8.3111              \n192.168.2.3/32                \
+      \              0.0.0.0                                 0      A H          \
+      \                                  \n192.168.2.8/29                        \
+      \      192.168.2.11                            0      A C              ethernet1/8.3112\
+      \              \n192.168.2.11/32                             0.0.0.0       \
+      \                          0      A H                                      \
+      \      \n192.168.2.16/29                             192.168.2.19          \
+      \                  0      A C              ethernet1/8.3113              \n\
+      192.168.2.19/32                             0.0.0.0                        \
+      \         0      A H                                                       \
+      \                       \n192.168.5.10/31                             192.168.2.41\
+      \                                   A?B        121661                    65213\
+      \      \n192.168.5.26/31                             192.168.2.41          \
+      \                         A?B        121661                    65213      \n\
+      total routes shown: 98"
+    help: execute the command "show routing route"
+    prompt: '{base_prompt}>'


### PR DESCRIPTION
## Summary

Add new commands detected by `sync_ntc_commands.py` against NTC Templates v9.1.0 (commit `e60dae39a28d`) for four non-Cisco platforms. cisco_ios was handled in #144; the Cisco family (cisco_nxos / cisco_xr / cisco_asa) in #152. This PR covers fortinet / juniper_junos / paloalto_panos / arista_eos together (30 commands).

| Platform | New commands | With `output_variants` |
|---|--:|--:|
| fortinet | 14 | 6 |
| juniper_junos | 7 | 2 |
| paloalto_panos | 5 | 0 |
| arista_eos | 4 | 2 |

`output_variants` is preserved in the YAML for future scenario / random response features but is currently ignored by the simnos runtime (#147 design).

**Juniper-specific note**: juniper_junos outputs contain literal `{xxx}` patterns from the device itself — `{master}` (routing-engine state indicator on dual-RE chassis), `{rpd}` / `{junos-bgpshard*}` / `{chassisd}` etc. (process thread names in `show system processes summary`). These are escaped as `{{...}}` in the YAML so simnos's runtime call to `output.format(base_prompt=...)` does not raise `KeyError`. Manual SSH login confirmed they render literally as expected.

Closes #154. Related: #128 (epic), #144 (cisco_ios), #152 (Cisco family), #147 (sync improvement).

---

NTC Templates v9.1.0 (commit `e60dae39a28d`) との差分で `sync_ntc_commands.py` が検出した non-Cisco 4 platforms の新規コマンドを追加する。cisco_ios は #144、Cisco family (cisco_nxos / cisco_xr / cisco_asa) は #152 で対応済み。本 PR は fortinet / juniper_junos / paloalto_panos / arista_eos を 1 PR で一括対応 (30 commands)。

| Platform | New commands | `output_variants` 付き |
|---|--:|--:|
| fortinet | 14 | 6 |
| juniper_junos | 7 | 2 |
| paloalto_panos | 5 | 0 |
| arista_eos | 4 | 2 |

`output_variants` は将来のシナリオ / ランダム応答機能向けに YAML へ保持するが、現状の simnos runtime では未参照 (#147 で確立した方針)。

**Juniper 特記事項**: juniper_junos の output には実機由来のリテラル `{xxx}` パターンが含まれる — `{master}` (デュアル RE シャーシでの routing engine 状態インジケータ)、`{rpd}` / `{junos-bgpshard*}` / `{chassisd}` 等 (`show system processes summary` のプロセススレッド名)。これらは YAML 上で `{{...}}` にエスケープし、simnos runtime の `output.format(base_prompt=...)` で `KeyError` を起こさない形にしている。手動 SSH ログインで literal 表示が正常であることを確認済み。

Closes #154. 関連: #128 (epic)、#144 (cisco_ios)、#152 (Cisco family)、#147 (sync 改善)。

## Test plan

- [x] `uv run yamllint` green (4 platforms)
- [x] `uv run pytest -k 'fortinet or juniper_junos or paloalto_panos or arista_eos'`: **30 passed**
- [x] Manual SSH login on all 4 platforms — confirmed by user, including verification that Juniper's `{master}` / `process{thread}` patterns render literally
- [x] CI green on PR

## Follow-up

- **All-platform literal-brace audit**: Today's discovery surfaced unescaped `{xxx}` patterns in juniper_junos output strings. Other platforms (huawei_smartax / mikrotik_routeros etc.) may have similar literal braces lurking in their existing or future synced outputs that pass yamllint but would fail at `output.format(...)` runtime if invoked. Out of scope for this PR (would need a YAML-wide scan and escape pass); worth a separate issue when more non-Cisco platforms are added under #128.

🤖 Generated with [Claude Code](https://claude.com/claude-code)