### PR TITLE
feat: auto-escape literal {xxx} patterns in sync_ntc_commands.py output (#156)

### DIFF
--- a/sync_ntc_commands.py
+++ b/sync_ntc_commands.py
@@ -112,6 +112,23 @@ def select_primary_raw(platform: str, folder: str, raw_files: list[str]) -> str:
     return raw_files[0]
 
 
+def escape_format_braces(text: str) -> str:
+    """Double every ``{`` / ``}`` so the text survives ``str.format()`` unchanged.
+
+    NTC fixtures may contain literal ``{xxx}`` patterns (e.g. Juniper's
+    ``{master}`` routing-engine indicator, ``{rpd}`` / ``{junos-bgpshard*}``
+    process-thread names). simnos's runtime calls
+    ``output.format(base_prompt=...)`` on every command output, which would
+    otherwise interpret these as named placeholders and raise ``KeyError``.
+    Doubling the braces makes them literal under ``str.format()``.
+
+    NTC fixtures never contain simnos-specific placeholders like
+    ``{base_prompt}``, so a blanket replace is safe — anything that comes
+    from NTC is content meant to be displayed verbatim.
+    """
+    return text.replace("{", "{{").replace("}", "}}")
+
+
 def get_ntc_commands(target_dir: str, platform: str) -> dict[str, dict]:
     """Extract commands and outputs from NTC Templates test data.
 
@@ -144,7 +161,7 @@ def get_ntc_commands(target_dir: str, platform: str) -> dict[str, dict]:
         primary = select_primary_raw(platform, folder, raw_files)
         primary_path = os.path.join(folder_path, primary)
         with open(primary_path, encoding="utf-8") as f:
-            output = f.read()
+            output = escape_format_braces(f.read())
 
         variant_outputs: list[str] = []
         variant_paths: list[str] = []
@@ -153,7 +170,7 @@ def get_ntc_commands(target_dir: str, platform: str) -> dict[str, dict]:
                 continue
             variant_path = os.path.join(folder_path, variant)
             with open(variant_path, encoding="utf-8") as f:
-                variant_outputs.append(f.read())
+                variant_outputs.append(escape_format_braces(f.read()))
             variant_paths.append(variant_path)
 
         command_name = folder.replace("_", " ")

--- a/tests/test_sync_ntc_commands.py
+++ b/tests/test_sync_ntc_commands.py
@@ -27,6 +27,45 @@ sys.modules["sync_ntc_commands"] = sync_ntc_commands
 _spec.loader.exec_module(sync_ntc_commands)
 
 select_primary_raw = sync_ntc_commands.select_primary_raw
+escape_format_braces = sync_ntc_commands.escape_format_braces
+
+
+class TestEscapeFormatBraces:
+    """`escape_format_braces` doubles ``{`` and ``}`` so NTC outputs survive
+    simnos's runtime ``output.format(base_prompt=...)`` call without
+    ``KeyError``. The motivating real-world cases are Juniper's ``{master}``
+    routing-engine indicator and ``rpd{junos-bgpshard0}`` process-thread
+    names from ``show system processes summary``.
+    """
+
+    def test_juniper_master_indicator(self):
+        """`{master}` becomes `{{master}}` — the most common Juniper case."""
+        assert escape_format_braces("...\n{master}\n") == "...\n{{master}}\n"
+
+    def test_juniper_process_thread_names(self):
+        """Nested-looking patterns like `rpd{junos-bgpshard0}` are escaped."""
+        assert (
+            escape_format_braces("rpd{junos-bgpshard0}\nchassisd{chassisd}")
+            == "rpd{{junos-bgpshard0}}\nchassisd{{chassisd}}"
+        )
+
+    def test_already_escaped_double_braces_get_quadrupled(self):
+        """Pre-escaped `{{x}}` becomes `{{{{x}}}}` — by design.
+
+        Inputs to this function are raw NTC fixtures, which never carry
+        pre-escaped braces. We pin the literal behaviour here to make
+        the contract explicit: callers must pass untouched fixture text.
+        """
+        assert escape_format_braces("{{x}}") == "{{{{x}}}}"
+
+    def test_passthrough_when_no_braces(self):
+        """Strings without braces are returned unchanged."""
+        assert escape_format_braces("plain output text\n") == "plain output text\n"
+
+    def test_preserves_other_characters(self):
+        """Newlines, percent signs, backslashes are not affected."""
+        text = "line1\nline2\n100%\\path\n"
+        assert escape_format_braces(text) == text
 
 
 class TestSelectPrimaryRaw:


### PR DESCRIPTION
## Summary

NTC fixtures may contain literal `{xxx}` patterns sourced from real device output (e.g. Juniper's `{master}` routing-engine indicator, `{rpd}` / `{junos-bgpshard*}` / `{chassisd}` process thread names, hp_comware's LACP `{ACDEF}` flags, huawei_smartax's `{ <cr>||<K> }` help syntax). simnos's runtime calls `output.format(base_prompt=...)` on every command output, which would interpret these as named placeholders and raise `KeyError`.

PR #155 hit this for juniper_junos and applied a one-off escape via a throwaway script. This PR moves the escape into `sync_ntc_commands.py` itself so future syncs always emit `{{xxx}}` for literal braces — removing the manual fix-up step from the workflow.

- `sync_ntc_commands.py`: add `escape_format_braces` helper and apply it to `output` and each `output_variants` entry inside `get_ntc_commands`
- `tests/test_sync_ntc_commands.py`: add `TestEscapeFormatBraces` (5 cases — Juniper master indicator / process-thread names / pre-escaped passthrough / no-brace passthrough / other-character preservation)

Audit of all current platform YAMLs (Phase 1 of #156) found 0 unescaped patterns since #155 already cleaned up juniper_junos, so no existing-file fixes are needed.

Closes #156.

---

NTC fixture には実機 CLI 由来のリテラル `{xxx}` パターンが含まれることがある (Juniper の `{master}` RE インジケータ、`{rpd}` / `{junos-bgpshard*}` / `{chassisd}` プロセススレッド名、hp_comware の LACP `{ACDEF}` flag、huawei_smartax の `{ <cr>||<K> }` ヘルプ構文等)。simnos の runtime は `output.format(base_prompt=...)` を呼ぶため、未エスケープだと named placeholder と解釈され `KeyError` を起こす。

PR #155 で juniper_junos が引っかかった際は使い捨て script で escape を適用したが、本 PR で escape 処理を `sync_ntc_commands.py` 本体に組み込み、今後の sync では literal brace を含む output が常に `{{xxx}}` で出力される形にする — 手動 fixup の手順を workflow から不要化する preventive 投入。

- `sync_ntc_commands.py`: `escape_format_braces` helper を追加、`get_ntc_commands` の `output` / `output_variants` に適用
- `tests/test_sync_ntc_commands.py`: `TestEscapeFormatBraces` クラス追加 (Juniper master / process-thread / 事前エスケープ済 passthrough / brace なし passthrough / 他文字保持の 5 ケース)

既存全 platform YAML の audit (#156 Phase 1) は #155 で juniper_junos が処理済のため 0 件 unescaped、既存ファイルの修正は不要。

Closes #156.

## Test plan

- [x] `uv run invoke ruff` green
- [x] `uv run invoke yamllint` green
- [x] `uv run pytest tests/test_sync_ntc_commands.py`: 12 passed (新規 `TestEscapeFormatBraces` 5 + 既存 `TestSelectPrimaryRaw` 7)
- [x] `uv run pytest tests/plugins/test_platforms.py`: 167 passed / 1 xfailed (xfailed は #115 の pre-existing、本変更と無関係)
- [x] 実 sync 再実行で hp_comware (`{{ACDEF}}` LACP flag) と huawei_smartax (`{{ <cr>||<K> }}` help syntax) で escape 発動を end-to-end で確認
- [x] 既存 platform YAML 監査: 0 件 unescaped (Phase 1 audit)
- [ ] CI green on PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)