### PR TITLE
chore: enable pytest-xdist parallel execution by default (#164)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -117,7 +117,7 @@ directory = "coverage_html_report"
 
 [tool.pytest.ini_options]
 testpaths = ["tests"]
-addopts = "-vv"
+addopts = "-vv -n auto"
 
 [tool.uv.build-backend]
 module-name = "simnos"


### PR DESCRIPTION
## Summary

- `pyproject.toml` の `[tool.pytest.ini_options].addopts` を `"-vv"` → `"-vv -n auto"`
- ローカル開発の pytest 実行時間が 18:06 → 3:01 (**6.0x speedup**) に短縮
- pytest-xdist 3.8.0 は既に dev dep に含まれているので追加インストール不要

## Measurement (local, 8-core)

| | Time | Passed | Speedup |
|---|---|---|---|
| **Serial (1 worker)** | 18:06 (1086.53s) | 739 | 1.0x |
| **Parallel (-n auto)** | 3:01 (181.14s) | 739 | **6.0x** |

`-k "not docker" --timeout 600` で同じ条件、結果も同じ (739 passed / 7 skipped / 1 xfailed)。

## Safety

- **Port collision**: `tests/utils.py::get_free_port` が `bind(("", 0))` で OS 割当 port を使うので static port 衝突なし
- **Global state**: 並列実行で順序依存 / shared state failures なし、PR #161 中に確認
- **TOCTOU race**: `get_free_port` の docstring に "acceptable for controlled tests" の認知あり、実害観測なし

## CI への影響

- GitHub Actions standard runner は 2-4 cores → speedup は 2-3x くらいの想定
- xdist 自体は CI で広く使われているので副作用リスク低い
- CI の green を確認してマージ

## Test plan

- [x] `uv run pytest tests/ -k "not docker" --timeout 600` でローカル動作確認 — 3:01 / 739 passed
- [x] `uv run ruff check` / `uv run ruff format --diff` — All checks passed (Python 修正なし)
- [ ] CI の green 待ち

## Refs

- Closes #164
- 親 PR: #161 (#160) で待ち時間長すぎ問題を発見、ローカル測定済

🤖 Generated with [Claude Code](https://claude.com/claude-code)