### PR TITLE
chore: sweep orphaned docs/platforms/*.md when yaml is deleted (#159)

### DIFF
--- a/tasks.py
+++ b/tasks.py
@@ -75,12 +75,43 @@ def render_template(template: str, platform: str, command: str, field: str) -> s
         ) from exc
 
 
+_PRESERVED_PLATFORM_DOCS: frozenset[str] = frozenset({"index.md", "index.ja.md"})
+
+
+def sweep_orphaned_platform_docs(
+    docs_folder: str,
+    valid_platforms: set[str],
+    preserve: frozenset[str] = _PRESERVED_PLATFORM_DOCS,
+) -> list[str]:
+    """Remove ``docs/platforms/*.md`` entries whose backing yaml is gone.
+
+    Keeps the docs idempotent with the yaml directory as the source of
+    truth: if a platform's yaml is deleted, the corresponding markdown
+    is also removed on the next regeneration. ``preserve`` lists hand-
+    authored markdown that has no yaml counterpart (index pages etc.)
+    and must never be swept.
+
+    Returns the sorted list of removed filenames for caller-side logging.
+    """
+    expected: set[str] = {f"{platform}.md" for platform in valid_platforms}
+    removed: list[str] = []
+    for entry in sorted(os.listdir(docs_folder)):
+        if not entry.endswith(".md"):
+            continue
+        if entry in expected or entry in preserve:
+            continue
+        os.remove(f"{docs_folder}/{entry}")
+        removed.append(entry)
+    return removed
+
+
 @task
 def gen_docs_platform_commands(ctx):
     """
     Generate platform specific commands in the docs.
     """
     platforms_folder: str = "simnos/plugins/nos/platforms_yaml"
+    docs_folder: str = "docs/platforms"
     files: list[str] = os.listdir(platforms_folder)
     platforms: list[str] = [platform.split(".yaml")[0] for platform in files]
 
@@ -88,7 +119,7 @@ def gen_docs_platform_commands(ctx):
         print(f"Generating Platform: {platform}")
         with open(f"{platforms_folder}/{platform}.yaml", encoding="utf-8") as file:
             data = yaml.safe_load(file)
-        with open(f"docs/platforms/{platform}.md", "w", encoding="utf-8") as platforms_file:
+        with open(f"{docs_folder}/{platform}.md", "w", encoding="utf-8") as platforms_file:
             platforms_file.write(f"# {platform}\n\n")
             platforms_file.write(WARNING_MESSAGE)
             platforms_file.write("## Commands\n\n")
@@ -109,6 +140,9 @@ def gen_docs_platform_commands(ctx):
                     rendered = render_template(prompt, platform, command, "prompt")
                     platforms_file.write(f"- {rendered}\n")
                 platforms_file.write("\n")
+
+    for orphan in sweep_orphaned_platform_docs(docs_folder, set(platforms)):
+        print(f"Removed orphaned doc: {orphan}")
 
 
 @task(help={"device_type": "The device type to connect to."})

--- a/tests/test_gen_docs_platform_commands.py
+++ b/tests/test_gen_docs_platform_commands.py
@@ -1,4 +1,4 @@
-"""Unit tests for `tasks.render_template`.
+"""Unit tests for `tasks.render_template` and `tasks.sweep_orphaned_platform_docs`.
 
 Pin the formatter semantics that `gen_docs_platform_commands` relies on:
 - substitutes `{base_prompt}` with the platform name
@@ -11,11 +11,15 @@ Without these tests, a future refactor switching `.format()` back to
 `.replace()` (or any other formatter) would silently break docs rendering
 for platforms that contain literal braces (e.g. `{master:0}` in
 `juniper_junos`, `{ <cr>||<K> }` in `huawei_smartax`).
+
+Also pin the sweep semantics so that deleting a yaml causes the matching
+markdown to be removed on the next regeneration, while hand-authored
+`index.md` / `index.ja.md` are preserved.
 """
 
 import pytest
 
-from tasks import render_template
+from tasks import render_template, sweep_orphaned_platform_docs
 
 
 class TestRenderTemplate:
@@ -56,3 +60,103 @@ class TestRenderTemplate:
         """Error message should point users at the escape rule."""
         with pytest.raises(RuntimeError, match=r"escape"):
             render_template("{oops}", "p", "c", "output")
+
+
+class TestSweepOrphanedPlatformDocs:
+    """Pin sweep semantics so docs regeneration stays idempotent with yaml."""
+
+    def _write(self, path, content=""):
+        path.write_text(content, encoding="utf-8")
+
+    def test_removes_md_without_matching_yaml(self, tmp_path):
+        """A `.md` whose platform is not in `valid_platforms` must be removed."""
+        self._write(tmp_path / "cisco_ios.md")
+        self._write(tmp_path / "deleted_platform.md")
+
+        removed = sweep_orphaned_platform_docs(
+            str(tmp_path),
+            valid_platforms={"cisco_ios"},
+        )
+
+        assert removed == ["deleted_platform.md"]
+        assert (tmp_path / "cisco_ios.md").exists()
+        assert not (tmp_path / "deleted_platform.md").exists()
+
+    def test_keeps_md_with_matching_yaml(self, tmp_path):
+        """Markdown whose platform is in `valid_platforms` must be kept."""
+        self._write(tmp_path / "juniper_junos.md")
+
+        removed = sweep_orphaned_platform_docs(
+            str(tmp_path),
+            valid_platforms={"juniper_junos"},
+        )
+
+        assert removed == []
+        assert (tmp_path / "juniper_junos.md").exists()
+
+    def test_preserves_default_index_pages(self, tmp_path):
+        """`index.md` and `index.ja.md` must never be swept (default preserve)."""
+        self._write(tmp_path / "index.md")
+        self._write(tmp_path / "index.ja.md")
+        self._write(tmp_path / "orphan.md")
+
+        removed = sweep_orphaned_platform_docs(
+            str(tmp_path),
+            valid_platforms=set(),
+        )
+
+        assert removed == ["orphan.md"]
+        assert (tmp_path / "index.md").exists()
+        assert (tmp_path / "index.ja.md").exists()
+
+    def test_preserve_list_is_overridable(self, tmp_path):
+        """Custom `preserve` argument must be honored (drops index defaults)."""
+        self._write(tmp_path / "index.md")
+        self._write(tmp_path / "keep_me.md")
+
+        removed = sweep_orphaned_platform_docs(
+            str(tmp_path),
+            valid_platforms=set(),
+            preserve=frozenset({"keep_me.md"}),
+        )
+
+        # index.md is no longer preserved by the custom list, so it is swept.
+        assert removed == ["index.md"]
+        assert (tmp_path / "keep_me.md").exists()
+        assert not (tmp_path / "index.md").exists()
+
+    def test_ignores_non_markdown_files(self, tmp_path):
+        """Non-`.md` siblings (images, indexes etc.) must not be touched."""
+        self._write(tmp_path / "diagram.png", "binary")
+        self._write(tmp_path / "notes.txt", "text")
+        self._write(tmp_path / "orphan.md")
+
+        removed = sweep_orphaned_platform_docs(
+            str(tmp_path),
+            valid_platforms=set(),
+        )
+
+        assert removed == ["orphan.md"]
+        assert (tmp_path / "diagram.png").exists()
+        assert (tmp_path / "notes.txt").exists()
+
+    def test_empty_directory(self, tmp_path):
+        """Empty docs folder must not raise."""
+        removed = sweep_orphaned_platform_docs(
+            str(tmp_path),
+            valid_platforms={"cisco_ios"},
+        )
+
+        assert removed == []
+
+    def test_returns_sorted_list(self, tmp_path):
+        """Return order must be deterministic for stable logging output."""
+        for name in ("zzz.md", "aaa.md", "mmm.md"):
+            self._write(tmp_path / name)
+
+        removed = sweep_orphaned_platform_docs(
+            str(tmp_path),
+            valid_platforms=set(),
+        )
+
+        assert removed == ["aaa.md", "mmm.md", "zzz.md"]


### PR DESCRIPTION
## Summary
- Add `sweep_orphaned_platform_docs()` helper and invoke it at the end of `gen_docs_platform_commands` — removes `docs/platforms/*.md` whose backing yaml has been deleted, keeping docs idempotent with yaml as the source of truth.
- Preserve hand-authored `index.md` / `index.ja.md` via a default `preserve` list (overridable for tests).
- Pin sweep semantics with 7 new tests in `TestSweepOrphanedPlatformDocs` (orphan removal, valid kept, default index preserve, custom preserve override, non-`.md` ignored, empty dir, sorted return).

Resolves the SUGGESTION raised in #158 cross-review (Phase 2 of #146).

Closes #159.

## Test plan
- [x] `uv run pytest tests/test_gen_docs_platform_commands.py -v` — 14 passed (7 existing + 7 new)
- [x] `uv run ruff check tasks.py tests/test_gen_docs_platform_commands.py` — clean
- [x] `uv run ruff format --check ...` — already formatted
- [x] Manual verification: temporarily delete `cisco_asa.yaml` → `uv run invoke gen-docs-platform-commands` → confirm `Removed orphaned doc: cisco_asa.md` log + file removed → restore yaml → md regenerated, `index.md` / `index.ja.md` untouched

🤖 Generated with [Claude Code](https://claude.com/claude-code)