### PR TITLE
fix: catch (KeyError, IndexError, ValueError) in cmd_shell.default output format (#162)

### DIFF
--- a/simnos/plugins/shell/cmd_shell.py
+++ b/simnos/plugins/shell/cmd_shell.py
@@ -204,9 +204,9 @@ class CMDShell(Cmd):
                 # for the same situation; the asymmetry matches the context
                 # (interactive user session vs. CI-checked docs build).
                 log.error(
-                    "Error formatting output for command '%s' on '%s'",
-                    line,
+                    "shell.default '%s' error formatting output for command '%s'",
                     self.base_prompt,
+                    [line],
                 )
             self.writeline(ret)
         return False

--- a/simnos/plugins/shell/cmd_shell.py
+++ b/simnos/plugins/shell/cmd_shell.py
@@ -197,18 +197,22 @@ class CMDShell(Cmd):
         if ret is not None:
             try:
                 ret = ret.format(base_prompt=self.base_prompt)
-            except (KeyError, IndexError, ValueError):
+            except (KeyError, IndexError, ValueError) as exc:
                 # Runtime shell is intentionally lenient: yaml format errors
                 # are logged but do not crash the shell session. The build-
                 # time counterpart `tasks.render_template` raises RuntimeError
                 # for the same situation; the asymmetry is "raise vs silent",
                 # but the catch set is kept aligned (`(KeyError, IndexError,
                 # ValueError)`) so both paths cover the same `str.format()`
-                # failure modes.
+                # failure modes. The yaml author is expected to use only
+                # `{base_prompt}` substitution; the `{x.attr}` / `{x[k]}` /
+                # format-spec mini-language is unsupported and may surface
+                # as `AttributeError` / `TypeError` outside this catch set.
                 log.error(
-                    "shell.default '%s' error formatting output for command '%s'",
+                    "shell.default '%s' error formatting output for command '%s': %r",
                     self.base_prompt,
                     [line],
+                    exc,
                 )
             self.writeline(ret)
         return False

--- a/simnos/plugins/shell/cmd_shell.py
+++ b/simnos/plugins/shell/cmd_shell.py
@@ -197,12 +197,14 @@ class CMDShell(Cmd):
         if ret is not None:
             try:
                 ret = ret.format(base_prompt=self.base_prompt)
-            except (KeyError, ValueError):
+            except (KeyError, IndexError, ValueError):
                 # Runtime shell is intentionally lenient: yaml format errors
                 # are logged but do not crash the shell session. The build-
                 # time counterpart `tasks.render_template` raises RuntimeError
-                # for the same situation; the asymmetry matches the context
-                # (interactive user session vs. CI-checked docs build).
+                # for the same situation; the asymmetry is "raise vs silent",
+                # but the catch set is kept aligned (`(KeyError, IndexError,
+                # ValueError)`) so both paths cover the same `str.format()`
+                # failure modes.
                 log.error(
                     "shell.default '%s' error formatting output for command '%s'",
                     self.base_prompt,

--- a/simnos/plugins/shell/cmd_shell.py
+++ b/simnos/plugins/shell/cmd_shell.py
@@ -197,7 +197,7 @@ class CMDShell(Cmd):
         if ret is not None:
             try:
                 ret = ret.format(base_prompt=self.base_prompt)
-            except (KeyError, IndexError, ValueError) as exc:
+            except (KeyError, IndexError, ValueError) as e:
                 # Runtime shell is intentionally lenient: yaml format errors
                 # are logged but do not crash the shell session. The build-
                 # time counterpart `tasks.render_template` raises RuntimeError
@@ -212,7 +212,7 @@ class CMDShell(Cmd):
                     "shell.default '%s' error formatting output for command '%s': %r",
                     self.base_prompt,
                     [line],
-                    exc,
+                    e,
                 )
             self.writeline(ret)
         return False

--- a/simnos/plugins/shell/cmd_shell.py
+++ b/simnos/plugins/shell/cmd_shell.py
@@ -197,7 +197,16 @@ class CMDShell(Cmd):
         if ret is not None:
             try:
                 ret = ret.format(base_prompt=self.base_prompt)
-            except KeyError:
-                log.error("Error in formatting output")
+            except (KeyError, ValueError):
+                # Runtime shell is intentionally lenient: yaml format errors
+                # are logged but do not crash the shell session. The build-
+                # time counterpart `tasks.render_template` raises RuntimeError
+                # for the same situation; the asymmetry matches the context
+                # (interactive user session vs. CI-checked docs build).
+                log.error(
+                    "Error formatting output for command '%s' on '%s'",
+                    line,
+                    self.base_prompt,
+                )
             self.writeline(ret)
         return False

--- a/tests/plugins/test_cmd_shell.py
+++ b/tests/plugins/test_cmd_shell.py
@@ -314,9 +314,9 @@ class TestCmdShell(TestCase):
         """`ValueError` failure mode of `.format()` is silently logged.
 
         Pins #162: covers the malformed-brace path (a bare `{` with no
-        closing `}`). Same lenient-runtime contract as the keyerror case
-        — the catch set `(KeyError, IndexError, ValueError)` mirrors
-        `tasks.render_template`.
+        closing `}`). Same lenient-runtime contract as the `KeyError`
+        case — the catch set `(KeyError, IndexError, ValueError)`
+        mirrors `tasks.render_template`.
         """
         self.arguments["is_running"].set()
         shell = CMDShell(**self.arguments)

--- a/tests/plugins/test_cmd_shell.py
+++ b/tests/plugins/test_cmd_shell.py
@@ -293,7 +293,8 @@ class TestCmdShell(TestCase):
         when yaml output contains a brace pattern that `.format()` cannot
         resolve. The runtime is intentionally lenient (silent log + raw
         passthrough), in contrast to `tasks.render_template` which raises
-        RuntimeError at build time.
+        RuntimeError at build time. The catch set is kept aligned with
+        `tasks.render_template` (`(KeyError, IndexError, ValueError)`).
         """
         self.arguments["is_running"].set()
         shell = CMDShell(**self.arguments)
@@ -304,15 +305,16 @@ class TestCmdShell(TestCase):
         }
         with self.assertLogs("simnos.plugins.shell.cmd_shell", level="ERROR") as captured:
             shell.default("broken_key_cmd")
+        self.assertEqual(len(captured.output), 1)
         assert any("error formatting output" in msg and "broken_key_cmd" in msg for msg in captured.output)
         shell.writeline.assert_called_once_with("value is {unknown_key}")
 
     def test_default_silent_fallback_on_valueerror(self):
         """Malformed brace `{broken` in output triggers silent ValueError fallback.
 
-        Pins #162: covers the second `.format()` failure mode (a bare `{`
-        with no closing `}`) which previously crashed the shell because
-        only KeyError was caught.
+        Pins #162: covers the `ValueError` failure mode (a bare `{` with
+        no closing `}`) which previously crashed the shell because only
+        KeyError was caught.
         """
         self.arguments["is_running"].set()
         shell = CMDShell(**self.arguments)
@@ -323,8 +325,31 @@ class TestCmdShell(TestCase):
         }
         with self.assertLogs("simnos.plugins.shell.cmd_shell", level="ERROR") as captured:
             shell.default("broken_brace_cmd")
+        self.assertEqual(len(captured.output), 1)
         assert any("error formatting output" in msg and "broken_brace_cmd" in msg for msg in captured.output)
         shell.writeline.assert_called_once_with("value is {broken")
+
+    def test_default_silent_fallback_on_indexerror(self):
+        """Positional placeholder `{}` / `{0}` in output triggers silent IndexError fallback.
+
+        Pins #162: covers the `IndexError` failure mode (a `{}` or `{N}`
+        placeholder against an empty positional-args tuple). Without the
+        fix this crashed the shell because only `(KeyError, ValueError)`
+        were caught. Aligns the runtime catch set with the build-time
+        `tasks.render_template` (`(KeyError, IndexError, ValueError)`).
+        """
+        self.arguments["is_running"].set()
+        shell = CMDShell(**self.arguments)
+        shell.writeline = Mock()
+        shell.commands["broken_pos_cmd"] = {
+            "output": "value is {}",
+            "prompt": ["{base_prompt}>"],
+        }
+        with self.assertLogs("simnos.plugins.shell.cmd_shell", level="ERROR") as captured:
+            shell.default("broken_pos_cmd")
+        self.assertEqual(len(captured.output), 1)
+        assert any("error formatting output" in msg and "broken_pos_cmd" in msg for msg in captured.output)
+        shell.writeline.assert_called_once_with("value is {}")
 
     def test_default_command_new_prompt(self):
         """Test that the default method does nothing."""

--- a/tests/plugins/test_cmd_shell.py
+++ b/tests/plugins/test_cmd_shell.py
@@ -313,8 +313,8 @@ class TestCmdShell(TestCase):
         """Malformed brace `{broken` in output triggers silent ValueError fallback.
 
         Pins #162: covers the `ValueError` failure mode (a bare `{` with
-        no closing `}`) which previously crashed the shell because only
-        KeyError was caught.
+        no closing `}`). Without the silent-fallback `cmd_shell.default()`
+        would propagate the exception and break the shell session.
         """
         self.arguments["is_running"].set()
         shell = CMDShell(**self.arguments)
@@ -334,9 +334,8 @@ class TestCmdShell(TestCase):
 
         Pins #162: covers the `IndexError` failure mode (a `{}` or `{N}`
         placeholder against an empty positional-args tuple). Without the
-        fix this crashed the shell because only `(KeyError, ValueError)`
-        were caught. Aligns the runtime catch set with the build-time
-        `tasks.render_template` (`(KeyError, IndexError, ValueError)`).
+        silent-fallback the exception would propagate and break the shell
+        session.
         """
         self.arguments["is_running"].set()
         shell = CMDShell(**self.arguments)

--- a/tests/plugins/test_cmd_shell.py
+++ b/tests/plugins/test_cmd_shell.py
@@ -287,14 +287,15 @@ class TestCmdShell(TestCase):
         shell.writeline.assert_called_once_with("% Invalid input detected at '^' marker.")
 
     def test_default_silent_fallback_on_keyerror(self):
-        """Unknown `{placeholder}` in output triggers silent KeyError fallback.
+        """`KeyError` failure mode of `.format()` is silently logged.
 
-        Pins #162: `cmd_shell.default()` must not crash the shell session
-        when yaml output contains a brace pattern that `.format()` cannot
-        resolve. The runtime is intentionally lenient (silent log + raw
-        passthrough), in contrast to `tasks.render_template` which raises
-        RuntimeError at build time. The catch set is kept aligned with
-        `tasks.render_template` (`(KeyError, IndexError, ValueError)`).
+        Pins #162: `cmd_shell.default()` is intentionally lenient about
+        yaml format errors (silent log + raw passthrough), in contrast
+        to `tasks.render_template` which raises `RuntimeError` at build
+        time. The runtime catch set is kept aligned with the build-time
+        counterpart at `(KeyError, IndexError, ValueError)`, so both
+        paths cover the same `str.format()` failure modes; only the
+        action (raise vs silent) differs.
         """
         self.arguments["is_running"].set()
         shell = CMDShell(**self.arguments)
@@ -306,15 +307,16 @@ class TestCmdShell(TestCase):
         with self.assertLogs("simnos.plugins.shell.cmd_shell", level="ERROR") as captured:
             shell.default("broken_key_cmd")
         self.assertEqual(len(captured.output), 1)
-        assert any("error formatting output" in msg and "broken_key_cmd" in msg for msg in captured.output)
+        self.assertTrue(any("error formatting output" in msg and "broken_key_cmd" in msg for msg in captured.output))
         shell.writeline.assert_called_once_with("value is {unknown_key}")
 
     def test_default_silent_fallback_on_valueerror(self):
-        """Malformed brace `{broken` in output triggers silent ValueError fallback.
+        """`ValueError` failure mode of `.format()` is silently logged.
 
-        Pins #162: covers the `ValueError` failure mode (a bare `{` with
-        no closing `}`). Without the silent-fallback `cmd_shell.default()`
-        would propagate the exception and break the shell session.
+        Pins #162: covers the malformed-brace path (a bare `{` with no
+        closing `}`). Same lenient-runtime contract as the keyerror case
+        — the catch set `(KeyError, IndexError, ValueError)` mirrors
+        `tasks.render_template`.
         """
         self.arguments["is_running"].set()
         shell = CMDShell(**self.arguments)
@@ -326,16 +328,17 @@ class TestCmdShell(TestCase):
         with self.assertLogs("simnos.plugins.shell.cmd_shell", level="ERROR") as captured:
             shell.default("broken_brace_cmd")
         self.assertEqual(len(captured.output), 1)
-        assert any("error formatting output" in msg and "broken_brace_cmd" in msg for msg in captured.output)
+        self.assertTrue(any("error formatting output" in msg and "broken_brace_cmd" in msg for msg in captured.output))
         shell.writeline.assert_called_once_with("value is {broken")
 
     def test_default_silent_fallback_on_indexerror(self):
-        """Positional placeholder `{}` / `{0}` in output triggers silent IndexError fallback.
+        """`IndexError` failure mode of `.format()` is silently logged.
 
-        Pins #162: covers the `IndexError` failure mode (a `{}` or `{N}`
-        placeholder against an empty positional-args tuple). Without the
-        silent-fallback the exception would propagate and break the shell
-        session.
+        Pins #162: covers the positional-placeholder path (`{}` / `{N}`
+        against an empty positional-args tuple). Same lenient-runtime
+        contract as the other two cases; together the three tests pin
+        each member of the catch set `(KeyError, IndexError, ValueError)`
+        shared with `tasks.render_template`.
         """
         self.arguments["is_running"].set()
         shell = CMDShell(**self.arguments)
@@ -347,7 +350,7 @@ class TestCmdShell(TestCase):
         with self.assertLogs("simnos.plugins.shell.cmd_shell", level="ERROR") as captured:
             shell.default("broken_pos_cmd")
         self.assertEqual(len(captured.output), 1)
-        assert any("error formatting output" in msg and "broken_pos_cmd" in msg for msg in captured.output)
+        self.assertTrue(any("error formatting output" in msg and "broken_pos_cmd" in msg for msg in captured.output))
         shell.writeline.assert_called_once_with("value is {}")
 
     def test_default_command_new_prompt(self):

--- a/tests/plugins/test_cmd_shell.py
+++ b/tests/plugins/test_cmd_shell.py
@@ -304,7 +304,7 @@ class TestCmdShell(TestCase):
         }
         with self.assertLogs("simnos.plugins.shell.cmd_shell", level="ERROR") as captured:
             shell.default("broken_key_cmd")
-        assert any("Error formatting output" in msg and "broken_key_cmd" in msg for msg in captured.output)
+        assert any("error formatting output" in msg and "broken_key_cmd" in msg for msg in captured.output)
         shell.writeline.assert_called_once_with("value is {unknown_key}")
 
     def test_default_silent_fallback_on_valueerror(self):
@@ -323,7 +323,7 @@ class TestCmdShell(TestCase):
         }
         with self.assertLogs("simnos.plugins.shell.cmd_shell", level="ERROR") as captured:
             shell.default("broken_brace_cmd")
-        assert any("Error formatting output" in msg and "broken_brace_cmd" in msg for msg in captured.output)
+        assert any("error formatting output" in msg and "broken_brace_cmd" in msg for msg in captured.output)
         shell.writeline.assert_called_once_with("value is {broken")
 
     def test_default_command_new_prompt(self):

--- a/tests/plugins/test_cmd_shell.py
+++ b/tests/plugins/test_cmd_shell.py
@@ -286,6 +286,46 @@ class TestCmdShell(TestCase):
         shell.default("test")
         shell.writeline.assert_called_once_with("% Invalid input detected at '^' marker.")
 
+    def test_default_silent_fallback_on_keyerror(self):
+        """Unknown `{placeholder}` in output triggers silent KeyError fallback.
+
+        Pins #162: `cmd_shell.default()` must not crash the shell session
+        when yaml output contains a brace pattern that `.format()` cannot
+        resolve. The runtime is intentionally lenient (silent log + raw
+        passthrough), in contrast to `tasks.render_template` which raises
+        RuntimeError at build time.
+        """
+        self.arguments["is_running"].set()
+        shell = CMDShell(**self.arguments)
+        shell.writeline = Mock()
+        shell.commands["broken_key_cmd"] = {
+            "output": "value is {unknown_key}",
+            "prompt": ["{base_prompt}>"],
+        }
+        with self.assertLogs("simnos.plugins.shell.cmd_shell", level="ERROR") as captured:
+            shell.default("broken_key_cmd")
+        assert any("Error formatting output" in msg and "broken_key_cmd" in msg for msg in captured.output)
+        shell.writeline.assert_called_once_with("value is {unknown_key}")
+
+    def test_default_silent_fallback_on_valueerror(self):
+        """Malformed brace `{broken` in output triggers silent ValueError fallback.
+
+        Pins #162: covers the second `.format()` failure mode (a bare `{`
+        with no closing `}`) which previously crashed the shell because
+        only KeyError was caught.
+        """
+        self.arguments["is_running"].set()
+        shell = CMDShell(**self.arguments)
+        shell.writeline = Mock()
+        shell.commands["broken_brace_cmd"] = {
+            "output": "value is {broken",
+            "prompt": ["{base_prompt}>"],
+        }
+        with self.assertLogs("simnos.plugins.shell.cmd_shell", level="ERROR") as captured:
+            shell.default("broken_brace_cmd")
+        assert any("Error formatting output" in msg and "broken_brace_cmd" in msg for msg in captured.output)
+        shell.writeline.assert_called_once_with("value is {broken")
+
     def test_default_command_new_prompt(self):
         """Test that the default method does nothing."""
         self.arguments["is_running"].set()


### PR DESCRIPTION
## Summary

Harden `cmd_shell.default()` output format error handling so yaml format errors no longer crash the runtime shell session.

Previously only `KeyError` was caught around `ret.format(base_prompt=...)` at the tail of `default()`. Any other `str.format()` failure (`ValueError` for malformed braces, `IndexError` for positional placeholders) propagated and broke the shell. Extend the catch to `(KeyError, IndexError, ValueError)` — the **same catch set** as the build-time `tasks.render_template`, so both paths cover the same `str.format()` failure modes. The runtime / build-time asymmetry is now purely **silent log vs. raise**, not the catch set itself.

The decision and Yaml-author constraints (`{base_prompt}` substitution + `{{` / `}}` literal escape only; `{x.attr}` / `{x[k]}` / format-spec mini-language is unsupported and surfaces as `AttributeError` / `TypeError` outside this catch set) are documented inline in the changed code and in the design doc Notes.

Closes #162.

## Cross-review trail

3 rounds of cross-review (codex / gemini / claude) drove this PR; full review trail is in `worklogs/20260514_173136_claude_issue-162-cmd-shell-format-error-handling.md`.

- **1st**: All 3 reviewers flagged `IndexError` missing from the catch set → fixed in `602f1f9` + test added.
- **2nd**: codex/gemini flagged `AttributeError`/`TypeError`; claude flagged docstring drift (3 tests inconsistent) and TestCase assertion style. Adopted: docstring unification, `log.error` with `as e:` + `%r` exception detail, `self.assertTrue(any(...))` consistency. Deferred (scope): `AttributeError`/`TypeError` — added Yaml-author constraint as a future note in the design doc.
- **3rd**: All 3 reviewers **LGTM**. Only blocker-free SUGGESTIONs remain (squash, inline comment compression, future scope expansion).

## Changes

- `simnos/plugins/shell/cmd_shell.py`: `except KeyError:` → `except (KeyError, IndexError, ValueError) as e:`, with a multi-line inline comment that records the asymmetry rationale and the supported-vs-unsupported brace syntax. `log.error` includes command, base_prompt, and the exception (`%r`).
- `tests/plugins/test_cmd_shell.py`: 3 new `test_default_silent_fallback_on_{keyerror,valueerror,indexerror}` tests pinning silent fallback for each catch-set member. Each test asserts: (a) log captured at `simnos.plugins.shell.cmd_shell` ERROR level with command-name substring, (b) `len(captured.output) == 1` as a log-spam regression guard, (c) `writeline` called with the raw (unformatted) output.

## Deferred (separate issue candidates)

- **`new_prompt` / `_check_prompt` format paths**: same `.format()` lenient-error-handling could apply (gemini SHOULD FIX in 3rd review). Currently covered by `default()`'s outer `except Exception as e:`, so the shell does not crash, but traceback leaks into the user-facing output. Worth a dedicated issue/PR.
- **`AttributeError` / `TypeError` in the catch set**: surfaces only when yaml uses `{x.attr}` / `{x[k]}` / format-spec mini-language. Adding it to runtime alone would break the catch-set symmetry with `tasks.render_template`; should be extended on both sides in a coordinated change.

## Test plan

- [x] `uv run pytest tests/ -k "not docker" --timeout 600` — **749 passed, 7 skipped, 1 xfailed** in 2:50
- [x] `uv run ruff check .` — clean
- [x] `uv run ruff format --check .` — clean
- [x] `uv run ty check simnos/plugins/shell/cmd_shell.py tests/plugins/test_cmd_shell.py` — no new errors introduced (existing info-level diagnostics only)
- [x] Stash verification (twice): the new `IndexError` test fails without `602f1f9`, all three new tests fail without `16535e6` baseline — confirms regression-pin behavior is real.

🤖 Generated with [Claude Code](https://claude.com/claude-code)