### PR TITLE
fix: hp_comware を HP 慣習 (<> user view / [] system view) に書き直し netmiko interop を実現 (#136)

### DIFF
--- a/docs/platforms/hp_comware.md
+++ b/docs/platforms/hp_comware.md
@@ -7,34 +7,42 @@
     open an issue on the GitHub repository. Thanks! 🤗📖
 ## Commands
 
-### enable
+### system-view
 
 **Output:** None
 
-**Help:** enter enable mode
+**Help:** enter system view (HP Comware equivalent of configure terminal)
 
 **Prompt:**
-- hp_comware>
+- <hp_comware>
+
+### return
+
+**Output:** None
+
+**Help:** return to user view from system view
+
+**Prompt:**
+- [hp_comware]
+
+### quit
+
+**Output:** None
+
+**Help:** exit the terminal (user view only; from system view use `return` to go back to user view)
+
+**Prompt:**
+- <hp_comware>
 
 ### screen-length disable
 
 **Output:** None
 
-**Help:** set the terminal width to maximum
+**Help:** set the terminal width to maximum (kept available in user view for netmiko `disable_paging` interop; real HP requires system view)
 
 **Prompt:**
-- hp_comware>
-- hp_comware#
-
-### ex
-
-**Output:** None
-
-**Help:** exit the terminal
-
-**Prompt:**
-- hp_comware>
-- hp_comware#
+- <hp_comware>
+- [hp_comware]
 
 ### display vlan all
 
@@ -84,8 +92,8 @@
 **Help:** execute the command "display vlan all"
 
 **Prompt:**
-- hp_comware>
-- hp_comware#
+- <hp_comware>
+- [hp_comware]
 
 ### display interface brief
 
@@ -118,8 +126,8 @@ GE0/4                DOWN auto    A      A    1
 **Help:** execute the command "display interface brief"
 
 **Prompt:**
-- hp_comware>
-- hp_comware#
+- <hp_comware>
+- [hp_comware]
 
 ### display device manuinfo
 
@@ -140,8 +148,8 @@ The operation is not supported on the specified power.
 **Help:** execute the command "display device manuinfo"
 
 **Prompt:**
-- hp_comware>
-- hp_comware#
+- <hp_comware>
+- [hp_comware]
 
 ### display lldp neighbor-information list
 
@@ -159,8 +167,8 @@ XGE1/0/0/2      bcea-fa00-0033  Ten-GigabitEthernet2/0/47  SWITCH01
 **Help:** execute the command "display lldp neighbor-information list"
 
 **Prompt:**
-- hp_comware>
-- hp_comware#
+- <hp_comware>
+- [hp_comware]
 
 ### display arp
 
@@ -177,15 +185,13 @@ XGE1/0/0/2      bcea-fa00-0033  Ten-GigabitEthernet2/0/47  SWITCH01
 **Help:** execute the command "display arp"
 
 **Prompt:**
-- hp_comware>
-- hp_comware#
+- <hp_comware>
+- [hp_comware]
 
 ### display ip routing-table
 
 **Output:**
 ```
-<HS125X>dis ip routing-table 
-
 Destinations : 17604     Routes : 28601
 
 Destination/Mask    Proto  Pre  Cost         NextHop         Interface
@@ -226,8 +232,8 @@ Destination/Mask    Proto  Pre  Cost         NextHop         Interface
 **Help:** execute the command "display ip routing-table"
 
 **Prompt:**
-- hp_comware>
-- hp_comware#
+- <hp_comware>
+- [hp_comware]
 
 ### display ip vpn-instance
 
@@ -245,8 +251,8 @@ Destination/Mask    Proto  Pre  Cost         NextHop         Interface
 **Help:** execute the command "display ip vpn-instance"
 
 **Prompt:**
-- hp_comware>
-- hp_comware#
+- <hp_comware>
+- [hp_comware]
 
 ### display clock
 
@@ -258,8 +264,8 @@ Destination/Mask    Proto  Pre  Cost         NextHop         Interface
 **Help:** execute the command "display clock"
 
 **Prompt:**
-- hp_comware>
-- hp_comware#
+- <hp_comware>
+- [hp_comware]
 
 ### display link-aggregation verbose
 
@@ -291,8 +297,8 @@ Remote:
 **Help:** execute the command "display link-aggregation verbose"
 
 **Prompt:**
-- hp_comware>
-- hp_comware#
+- <hp_comware>
+- [hp_comware]
 
 ### display vlan brief
 
@@ -324,8 +330,8 @@ VLAN ID   Name                             Port
 **Help:** execute the command "display vlan brief"
 
 **Prompt:**
-- hp_comware>
-- hp_comware#
+- <hp_comware>
+- [hp_comware]
 
 ### display lldp neighbor-information verbose
 
@@ -479,8 +485,8 @@ LLDP neighbor-information of port 1[GigabitEthernet0/0]:
 **Help:** execute the command "display lldp neighbor-information verbose"
 
 **Prompt:**
-- hp_comware>
-- hp_comware#
+- <hp_comware>
+- [hp_comware]
 
 ### display interface
 
@@ -637,8 +643,8 @@ Output: 0 output errors, 0 underruns, 0 buffer failures
 **Help:** execute the command "display interface"
 
 **Prompt:**
-- hp_comware>
-- hp_comware#
+- <hp_comware>
+- [hp_comware]
 
 ### display ip vpn-instance instance-name
 
@@ -659,8 +665,8 @@ Output: 0 output errors, 0 underruns, 0 buffer failures
 **Help:** execute the command "display ip vpn-instance instance-name"
 
 **Prompt:**
-- hp_comware>
-- hp_comware#
+- <hp_comware>
+- [hp_comware]
 
 ### display ip interface
 
@@ -702,8 +708,8 @@ Policy routing is enabled, using route map TO_INTERNET
 **Help:** execute the command "display ip interface"
 
 **Prompt:**
-- hp_comware>
-- hp_comware#
+- <hp_comware>
+- [hp_comware]
 
 ### display mac-address
 
@@ -720,8 +726,8 @@ dead-beef-0042 20       Learned        GigabitEthernet1/0/10    AGING
 **Help:** execute the command "display mac-address"
 
 **Prompt:**
-- hp_comware>
-- hp_comware#
+- <hp_comware>
+- [hp_comware]
 
 ### display counters bound interface
 
@@ -745,6 +751,6 @@ XGE6/0/52                46490              16009               7582           0
 **Help:** execute the command "display counters bound interface"
 
 **Prompt:**
-- hp_comware>
-- hp_comware#
+- <hp_comware>
+- [hp_comware]
 

--- a/docs/platforms/index.ja.md
+++ b/docs/platforms/index.ja.md
@@ -48,7 +48,7 @@ SIMNOS がサポートするプラットフォームの一覧です。各プラ�
 | [extreme_exos](extreme_exos.md) | ✅ | ✅ | - | - | |
 | [extreme_slxos](extreme_slxos.md) | ✅ | ✅ | - | - | enable モードなし（常に特権モード）。v2.2.0 で追加 |
 | [fortinet](fortinet.md) | ✅ | ✅ | - | - | |
-| [hp_comware](hp_comware.md) | ✅ | ⚠️ | - | - | Netmiko が config モード遷移で `system-view` を送信するが、SIMNOS にこのコマンドがない。show コマンドは正常に動作。 |
+| [hp_comware](hp_comware.md) | ✅ | ✅ | - | - | HP Comware 慣習: `<host>` user view、`[host]` system view。separate enable mode は無く、`system-view` で system view (config) に遷移する。 |
 | [hp_procurve](hp_procurve.md) | ✅ | ✅ | - | - | |
 | [huawei_smartax](huawei_smartax.md) | ✅ | ⚠️ | - | - | callable コマンド（`return`/`disable`）がプロンプトを動的に変更するため、Netmiko が ReadTimeout になる。 |
 | [huawei_vrp](huawei_vrp.md) | ✅ | ✅ | - | - | |

--- a/docs/platforms/index.md
+++ b/docs/platforms/index.md
@@ -48,7 +48,7 @@ The following platforms are supported by SIMNOS. Each platform has been tested f
 | [extreme_exos](extreme_exos.md) | ✅ | ✅ | - | - | |
 | [extreme_slxos](extreme_slxos.md) | ✅ | ✅ | - | - | No enable mode (always privileged). New in v2.2.0 |
 | [fortinet](fortinet.md) | ✅ | ✅ | - | - | |
-| [hp_comware](hp_comware.md) | ✅ | ⚠️ | - | - | Netmiko sends `system-view` to enter config mode, but SIMNOS does not have this command. Show commands work normally. |
+| [hp_comware](hp_comware.md) | ✅ | ✅ | - | - | HP Comware convention: `<host>` user view, `[host]` system view. No separate enable mode; `system-view` enters system view (config). |
 | [hp_procurve](hp_procurve.md) | ✅ | ✅ | - | - | |
 | [huawei_smartax](huawei_smartax.md) | ✅ | ⚠️ | - | - | Has callable commands (`return`/`disable`) that dynamically change the prompt, causing Netmiko ReadTimeout. |
 | [huawei_vrp](huawei_vrp.md) | ✅ | ✅ | - | - | |

--- a/simnos/plugins/nos/platforms_yaml/hp_comware.yaml
+++ b/simnos/plugins/nos/platforms_yaml/hp_comware.yaml
@@ -14,11 +14,11 @@ commands:
     prompt: "[{base_prompt}]"
   quit:
     exit: true
-    help: exit the terminal
+    help: exit the terminal (user view only; from system view use `return` to go back to user view)
     prompt: "<{base_prompt}>"
   screen-length disable:
     output: null
-    help: set the terminal width to maximum
+    help: set the terminal width to maximum (kept available in user view for netmiko `disable_paging` interop; real HP requires system view)
     prompt:
     - "<{base_prompt}>"
     - "[{base_prompt}]"
@@ -119,7 +119,7 @@ commands:
     - "<{base_prompt}>"
     - "[{base_prompt}]"
   display ip routing-table:
-    output: "<HS125X>dis ip routing-table \n\nDestinations : 17604     Routes : 28601\n\
+    output: "Destinations : 17604     Routes : 28601\n\
       \nDestination/Mask    Proto  Pre  Cost         NextHop         Interface\n0.0.0.0/32\
       \          Direct 0    0            127.0.0.1       InLoop0\n9.72.47.0/24  \
       \      OSPF   150  1            172.16.43.2     Vlan1600\n                 \

--- a/simnos/plugins/nos/platforms_yaml/hp_comware.yaml
+++ b/simnos/plugins/nos/platforms_yaml/hp_comware.yaml
@@ -1,25 +1,27 @@
 name: hp_comware
-initial_prompt: "{base_prompt}>"
-enable_prompt: "{base_prompt}#"
-config_prompt: "{base_prompt}(config)#"
+initial_prompt: "<{base_prompt}>"
+config_prompt: "[{base_prompt}]"
 commands:
-  enable:
+  system-view:
     output: null
-    new_prompt: "{base_prompt}#"
-    help: enter enable mode
-    prompt: "{base_prompt}>"
+    new_prompt: "[{base_prompt}]"
+    help: enter system view (HP Comware equivalent of configure terminal)
+    prompt: "<{base_prompt}>"
+  return:
+    output: null
+    new_prompt: "<{base_prompt}>"
+    help: return to user view from system view
+    prompt: "[{base_prompt}]"
+  quit:
+    exit: true
+    help: exit the terminal
+    prompt: "<{base_prompt}>"
   screen-length disable:
     output: null
     help: set the terminal width to maximum
     prompt:
-    - "{base_prompt}>"
-    - "{base_prompt}#"
-  ex:
-    exit: true
-    help: exit the terminal
-    prompt:
-    - "{base_prompt}>"
-    - "{base_prompt}#"
+    - "<{base_prompt}>"
+    - "[{base_prompt}]"
   display vlan all:
     output: " VLAN ID: 1\n VLAN type: Static\n Route interface: Not configured\n Description:\
       \ VLAN 0001\n Name: VLAN 0001\n Tagged ports:   None\n Untagged ports: \n  \
@@ -37,8 +39,8 @@ commands:
       \     \n Untagged ports:\n    Ten-GigabitEthernet1/0/46     \n"
     help: execute the command "display vlan all"
     prompt:
-    - "{base_prompt}>"
-    - "{base_prompt}#"
+    - "<{base_prompt}>"
+    - "[{base_prompt}]"
   display interface brief:
     output: 'The brief information of interface(s) under route mode:
 
@@ -85,8 +87,8 @@ commands:
       '
     help: execute the command "display interface brief"
     prompt:
-    - "{base_prompt}>"
-    - "{base_prompt}#"
+    - "<{base_prompt}>"
+    - "[{base_prompt}]"
   display device manuinfo:
     output: "\n Slot 1 CPU 0:\n DEVICE_NAME          : SecPath F1000-AK115\n DEVICE_SERIAL_NUMBER\
       \ : 219801A1C39214Q00075\n MAC_ADDRESS          : 1451-7EB8-D4DE\n MANUFACTURING_DATE\
@@ -94,8 +96,8 @@ commands:
       \ supported on the specified power.\n"
     help: execute the command "display device manuinfo"
     prompt:
-    - "{base_prompt}>"
-    - "{base_prompt}#"
+    - "<{base_prompt}>"
+    - "[{base_prompt}]"
   display lldp neighbor-information list:
     output: "Chassis ID : * -- -- Nearest nontpmr bridge neighbor\n             #\
       \ -- -- Nearest customer bridge neighbor\n             Default -- -- Nearest\
@@ -104,8 +106,8 @@ commands:
       \  SWITCH01\nXGE1/0/0/2      bcea-fa00-0033  Ten-GigabitEthernet2/0/47  SWITCH01\n"
     help: execute the command "display lldp neighbor-information list"
     prompt:
-    - "{base_prompt}>"
-    - "{base_prompt}#"
+    - "<{base_prompt}>"
+    - "[{base_prompt}]"
   display arp:
     output: "  Type: S-Static   D-Dynamic   O-Openflow   R-Rule   M-Multiport  I-Invalid\n\
       \ IP address      MAC address    VLAN     Interface                Aging Type\n\
@@ -114,8 +116,8 @@ commands:
       \     2c23-3a40-7e18 1        XGE1/0/48                5     D\n"
     help: execute the command "display arp"
     prompt:
-    - "{base_prompt}>"
-    - "{base_prompt}#"
+    - "<{base_prompt}>"
+    - "[{base_prompt}]"
   display ip routing-table:
     output: "<HS125X>dis ip routing-table \n\nDestinations : 17604     Routes : 28601\n\
       \nDestination/Mask    Proto  Pre  Cost         NextHop         Interface\n0.0.0.0/32\
@@ -149,8 +151,8 @@ commands:
       10.211.0.0/16       BGP    130  0          10.6.12.86        GE9/1/1.1114\n"
     help: execute the command "display ip routing-table"
     prompt:
-    - "{base_prompt}>"
-    - "{base_prompt}#"
+    - "<{base_prompt}>"
+    - "[{base_prompt}]"
   display ip vpn-instance:
     output: "  Total VPN-Instances configured : 1\n  VPN-Instance Name           \
       \    RD                     Create time\n  red                             1:1\
@@ -160,14 +162,14 @@ commands:
       \                                2017/05/18 05:48:53\n"
     help: execute the command "display ip vpn-instance"
     prompt:
-    - "{base_prompt}>"
-    - "{base_prompt}#"
+    - "<{base_prompt}>"
+    - "[{base_prompt}]"
   display clock:
     output: 10:09:00 UTC Fri 03/16/2015
     help: execute the command "display clock"
     prompt:
-    - "{base_prompt}>"
-    - "{base_prompt}#"
+    - "<{base_prompt}>"
+    - "[{base_prompt}]"
   display link-aggregation verbose:
     output: "Loadsharing Type: Shar -- Loadsharing, NonS -- Non-Loadsharing\nPort\
       \ Status: S -- Selected, U -- Unselected\nFlags:  A -- LACP_Activity, B -- LACP_Timeout,\
@@ -182,8 +184,8 @@ commands:
       \  GE0/0/1          23      32768    7         0x8000, aaaa-bbbb-6485 {{ACDEF}}\n"
     help: execute the command "display link-aggregation verbose"
     prompt:
-    - "{base_prompt}>"
-    - "{base_prompt}#"
+    - "<{base_prompt}>"
+    - "[{base_prompt}]"
   display vlan brief:
     output: "Brief information about all VLANs:\nSupported Minimum VLAN ID: 1\nSupported\
       \ Maximum VLAN ID: 4094\nDefault VLAN ID: 1\nVLAN ID   Name                \
@@ -202,8 +204,8 @@ commands:
       200       VLAN 0200\n500       VLAN 0500"
     help: execute the command "display vlan brief"
     prompt:
-    - "{base_prompt}>"
-    - "{base_prompt}#"
+    - "<{base_prompt}>"
+    - "[{base_prompt}]"
   display lldp neighbor-information verbose:
     output: "LLDP neighbor-information of port 1[Ten-GigabitEthernet1/0/0/1]:\nLLDP\
       \ agent nearest-bridge:\n LLDP neighbor index : 1\n Update time         : 457\
@@ -286,8 +288,8 @@ commands:
       \ size         : 9216"
     help: execute the command "display lldp neighbor-information verbose"
     prompt:
-    - "{base_prompt}>"
-    - "{base_prompt}#"
+    - "<{base_prompt}>"
+    - "[{base_prompt}]"
   display interface:
     output: "Vlan-interface2000\nCurrent state: UP\nLine protocol state: UP\nDescription:\
       \ Servers\nBandwidth: 10000000 kbps\nMaximum transmission unit: 1500\nInternet\
@@ -369,8 +371,8 @@ commands:
       \ carrier, 0 no carrier\n"
     help: execute the command "display interface"
     prompt:
-    - "{base_prompt}>"
-    - "{base_prompt}#"
+    - "<{base_prompt}>"
+    - "[{base_prompt}]"
   display ip vpn-instance instance-name:
     output: "  VPN-Instance Name and Index : vpnb, 2\n  Route Distinguisher : 100:2\n\
       \  Interfaces : Vlan-interface20, FortyGigE1/0/53,\n               GigabitEthernet1/0/25\n\
@@ -378,8 +380,8 @@ commands:
       \ Targets :\n       222:2 111:1\n"
     help: execute the command "display ip vpn-instance instance-name"
     prompt:
-    - "{base_prompt}>"
-    - "{base_prompt}#"
+    - "<{base_prompt}>"
+    - "[{base_prompt}]"
   display ip interface:
     output: "Route-Aggregation1.4 current state :UP\nLine protocol current state :UP\n\
       \ Internet Address is 10.1.1.1/24 Primary\nBroadcast address : 10.1.1.255\n\
@@ -399,8 +401,8 @@ commands:
       \                 0\nPolicy routing is enabled, using route map TO_INTERNET\n"
     help: execute the command "display ip interface"
     prompt:
-    - "{base_prompt}>"
-    - "{base_prompt}#"
+    - "<{base_prompt}>"
+    - "[{base_prompt}]"
   display mac-address:
     output: "MAC ADDR       VLAN ID  STATE          PORT INDEX               AGING\
       \ TIME(s)\n0000-1111-2222 1        Learned        Bridge-Aggregation1      AGING\n\
@@ -409,8 +411,8 @@ commands:
       \       Learned        GigabitEthernet1/0/10    AGING\n"
     help: execute the command "display mac-address"
     prompt:
-    - "{base_prompt}>"
-    - "{base_prompt}#"
+    - "<{base_prompt}>"
+    - "[{base_prompt}]"
   display counters bound interface:
     output: "Interface         Total (pkts)   Broadcast (pkts)   Multicast (pkts)\
       \  Err (pkts)\nGE1/0/1                 573422               2580           \
@@ -425,5 +427,5 @@ commands:
       \ More than 14 digits (7 digits for column \"Err\").\n       --: Not supported.\n"
     help: execute the command "display counters bound interface"
     prompt:
-    - "{base_prompt}>"
-    - "{base_prompt}#"
+    - "<{base_prompt}>"
+    - "[{base_prompt}]"

--- a/tests/plugins/test_platforms.py
+++ b/tests/plugins/test_platforms.py
@@ -177,9 +177,6 @@ class TestPlatforms:
             "linux": "Linux-based, requires sudo -s for enable",
             "yamaha": "requires enable with secret",
         }
-        # hp_comware: config_mode() fails (system-view not available) AND netmiko
-        # cleanup after enable() also triggers config check, causing test failure.
-        skip_enable_platforms["hp_comware"] = "system-view unavailable, cleanup triggers config check"
         device_type = NETMIKO_DEVICE_TYPE_MAP.get(platform, platform)
         free_port: int = get_free_port()
         credentials: dict = {


### PR DESCRIPTION
## Summary

- `hp_comware.yaml` を cisco 風 prompt (`>` / `#` / `(config)#`) から HP Comware 実機慣習 (`<HOST>` user view / `[HOST]` system view) に全面書き換え
- netmiko `HPComwareBase` driver との interop を実現 (driver は `enable()` で `system-view` を送り、`check_config_mode` が prompt 内の `]` で判定するため、cisco 風 prompt では `conn.enable()` 自体が失敗していた)
- 新規 transition commands: `system-view` (user→system), `return` (system→user), `quit` (user view で exit)
- 削除: `enable`, `ex` (HP 実機に存在しない)
- `test_platforms.py` の `skip_enable_platforms` から `hp_comware` を解除 → enable/config テスト経路もカバーされるように

## Background

issue description (#136) は実態と乖離していた:
- 旧 description: 「enable() succeeds, cleanup で `system-view` 検出が失敗」
- 実態: `HPComwareBase.enable()` は内部で `config_mode(cmd="system-view")` を呼ぶため、**enable() 自体が即時失敗**

netmiko HP driver の特徴 (`netmiko/hp/hp_comware.py:120-129`):
- HP Comware には separate enable mode が無く、`enable()` ≡ `config_mode(system-view)`
- `check_config_mode` (line 39-53): prompt 内の `]` で判定
- `set_base_prompt` (line 115): 先頭 1 文字を strip (HP の `<` or `[` 前提) → 修正前は `'test_device'` の `'t'` が誤って strip され `'est_device'` になっていた

## Changes

| ファイル | 変更 |
|---|---|
| `simnos/plugins/nos/platforms_yaml/hp_comware.yaml` | header `initial_prompt`/`config_prompt` 書き換え、`enable_prompt` 削除、全 command の prompt 列を HP 慣習形式に、`enable`/`ex` 削除、`system-view`/`return`/`quit` 追加 |
| `tests/plugins/test_platforms.py` | `skip_enable_platforms` から `hp_comware` 解除 |
| `docs/platforms/hp_comware.md` | 自動再生成 |
| `docs/platforms/index.md` / `index.ja.md` | hp_comware 行を ⚠️→✅ + HP 慣習注記に書き換え |

## Test plan

- [x] `pytest tests/plugins/test_platforms.py -k hp_comware --timeout 60`: 3/3 PASS (yaml format, commands format, all commands running)
- [x] `pytest tests/ -k "not docker" --timeout 600`: 749 passed, 7 skipped, 1 xfailed (huawei_smartax 既知)
- [x] `ruff check .` + `ruff format --check .`: クリーン
- [x] netmiko probe script: `base_prompt = 'test_device'` (先頭1文字 strip bug 解消), `<test_device>` → `[test_device]` 遷移成功

## Review notes

1st cross-review (gemini + claude) は両方 LGTM/SUGGESTION 判定。指摘事項はすべて取り込み済 (commit `b840a3d`):
- docs 再生成 + index 注記更新 (claude SHOULD FIX)
- `quit` / `screen-length disable` help に意図注記 (gemini + claude SUGGESTION)
- `display ip routing-table` の preexisting echo 先頭削除 (gemini + claude SUGGESTION)

defer 2 件 (別 issue 起票候補):
- `tests/utils.py:86-92` の `get_host_commands` bucket 分類仕様コメント (汎用ヘルパなので scope 外)
- `conn.enable()` smoke test (現状 `config_mode()` で透過カバー、`HPComwareBase.enable` は単純委譲)

🤖 Generated with [Claude Code](https://claude.com/claude-code)