### PR TITLE
feat: NTC Templates v9.1 のコマンドを 10 platform に一括追加 (#128)

### DIFF
--- a/docs/platforms/alcatel_aos.md
+++ b/docs/platforms/alcatel_aos.md
@@ -46,3 +46,451 @@
 - alcatel_aos>
 - alcatel_aos#
 
+### show chassis
+
+**Output:**
+```
+Chassis 1
+  Model Name:                    OS6350-P24,
+  Description:                   Chassis,
+  Part Number:                   000000-00,
+  Hardware Revision:             01,
+  Serial Number:                 AAA000000000,
+  Manufacture Date:              JAN  1 2000,
+  Admin Status:                  POWER ON,
+  Operational Status:            UP,
+  Number Of Resets:              1
+  MAC Address:                   00:00:00:00:00:00,
+
+Chassis 2
+  Model Name:                    OS6350-P24,
+  Description:                   6350 24 PORT COPPER GE POE ,
+  Part Number:                   000000-00,
+  Hardware Revision:             01,
+  Serial Number:                 AAA000000000,
+  Manufacture Date:              JAN  1 2000,
+  Admin Status:                  POWER ON,
+  Operational Status:            UP,
+  MAC Address:                   00:00:00:00:00:00,
+
+
+```
+
+**Help:** execute the command "show chassis"
+
+**Prompt:**
+- alcatel_aos>
+- alcatel_aos#
+
+### show interfaces alias
+
+**Output:**
+```
+ Chas/
+ Slot/     Admin     Link        WTR      WTS       Alias
+ Port      Status   Status      (sec)    (msec)
+--------+----------+---------+----------+----------+-----------------------
+ 1/1/1     enable     up      0          0          "This is an example"
+ 2/1/10    enable     down    0          0          "This_is_an_example"
+ 2/1/11    enable     down    0          0          "This"
+
+```
+
+**Help:** execute the command "show interfaces alias"
+
+**Prompt:**
+- alcatel_aos>
+- alcatel_aos#
+
+### show interfaces ethernet
+
+**Output:**
+```
+Slot/Port  1/1  :
+  Operational Status     : up, ""
+  Last Time Link Changed : MON JAN 08 20:38:47 ,
+  Number of Status Change: 2,
+  Type                   : Ethernet,
+  SFP/SFP+/XFP           : Not Present,
+  MAC address            : aa:aa:aa:aa:aa:aa,
+  BandWidth (Megabits)   :     1000,            Duplex           : Full,
+  Autonegotiation        :   1  [ 1000-F 100-F 100-H 10-F 10-H ],
+  Long Frame Size(Bytes) : 9216,
+  Rx              :
+  Bytes Received  :          28902644070, Unicast Frames :             62119123,
+  Broadcast Frames:               123797, M-cast Frames  :               358499,
+  UnderSize Frames:                    0, OverSize Frames:                    0,
+  Lost Frames     :                    0, Error Frames   :                    0,
+  CRC Error Frames:                    0, Alignments Err :                    0,
+  Tx              :
+  Bytes Xmitted   :         274375376582, Unicast Frames :             97599952,
+  Broadcast Frames:           1746630116, M-cast Frames  :             87217616,
+  UnderSize Frames:                    0, OverSize Frames:                    0,
+  Lost Frames     :                    0, Collided Frames:                    0,
+  Error Frames    :                    0
+Slot/Port  1/2 :
+  Operational Status     : down, "Admin-Down"
+  Last Time Link Changed : WED JAN 10 10:00:26 ,
+  Number of Status Change: 2,
+  Type                   : Ethernet,
+  SFP/SFP+/XFP           : GBIC_LX,
+  MAC address            : bb:bb:bb:bb:bb:bb,
+  BandWidth (Megabits)   :     -  ,            Duplex           : -,
+  Autonegotiation        :   1  [ 1000-F                       ],
+  Long Frame Size(Bytes) : 9216,
+  Rx              :
+  Bytes Received  :        1602614019301, Unicast Frames :           1423093884,
+  Broadcast Frames:            131096783, M-cast Frames  :              9298965,
+  UnderSize Frames:                    0, OverSize Frames:                    0,
+  Lost Frames     :                    0, Error Frames   :                    0,
+  CRC Error Frames:                    0, Alignments Err :                    0,
+  Tx              :
+  Bytes Xmitted   :         313945899784, Unicast Frames :            702405038,
+  Broadcast Frames:                94040, M-cast Frames  :              3193107,
+  UnderSize Frames:                    0, OverSize Frames:                    0,
+  Lost Frames     :                    0, Collided Frames:                    0,
+  Error Frames    :                    0
+
+```
+
+**Help:** execute the command "show interfaces ethernet"
+
+**Prompt:**
+- alcatel_aos>
+- alcatel_aos#
+
+### show interfaces port
+
+**Output:**
+```
+Legends: WTR - Wait To Restore
+         #   - WTR Timer is Running & Port is in wait-to-restore state
+         *   - Permanent Shutdown
+
+Slot/    Admin     Link    Violations  Recovery   Recovery      WTR            Alias
+Port     Status   Status                 Time       Max        (sec)
+------+----------+---------+----------+----------+----------+----------+-----------------------------------------
+ *1/1    enable      up        none           300         10          0 "Hello"
+  1/2    enable      down      none           300         10          0 ""
+  1/11   enable      down      none           300         10       # 10 ""
+  1/17   disable     down      none           300         10          0 ""
+  1/23   disable     down      none           300         10          0 ""
+  1/25   enable      up        none           300         10          0 ""
+  1/26   enable      down      none           300         10          0 ""
+  1/28   enable      down      none             0          0          0 ""
+
+```
+
+**Help:** execute the command "show interfaces port"
+
+**Prompt:**
+- alcatel_aos>
+- alcatel_aos#
+
+### show interfaces status
+
+**Output:**
+```
+                       DETECTED           CONFIGURED
+Slot/ AutoNego  Speed Duplex Hybrid  Speed   Duplex Hybrid  Trap
+Port           (Mbps)         Type   (Mbps)         Mode   LinkUpDown
+-----+--------+------+------+------+--------+------+------+------
+ 1/1   Enable   1000   Full    NA      Auto   Auto    NA      -  
+ 1/2   Enable    -      -      -       Auto   Auto    NA      -  
+ 1/3   Enable    -      -      -       Auto   Auto    NA      -  
+ 1/4   Enable    -      -      -       Auto   Auto    NA      -  
+ 1/5   Enable    -      -      -       Auto   Auto    NA      -  
+ 1/6   Enable    -      -      -       Auto   Auto    NA      -  
+ 1/7   Enable    -      -      -       Auto   Auto    NA      -  
+ 1/8   Enable    -      -      -       Auto   Auto    NA      -  
+ 1/9   Enable    -      -      -       Auto   Auto    NA      -  
+ 1/10  Enable    -      -      -       Auto   Auto    NA      -  
+ 1/11  Enable    -      -      -       Auto   Auto    NA      -  
+ 1/12  Enable    -      -      -       Auto   Auto    NA      -  
+ 1/13  Enable    -      -      -       Auto   Auto    NA      -  
+ 1/14  Enable    -      -      -       Auto   Auto    NA      -  
+ 1/15  Enable    -      -      -       Auto   Auto    NA      -  
+ 1/16  Enable    -      -      -       Auto   Auto    NA      -  
+ 1/17  Enable    -      -      -       Auto   Auto    NA      -  
+ 1/18  Enable    -      -      -       Auto   Auto    NA      -  
+ 1/19  Enable    -      -      -       Auto   Auto    NA      -  
+ 1/20  Enable    -      -      -       Auto   Auto    NA      -  
+ 1/21  Enable    -      -      -       Auto   Auto    NA      -  
+ 1/22  Enable    -      -      -       Auto   Auto    NA      -  
+ 1/23  Enable    -      -      -       Auto   Auto    NA      -  
+ 1/24  Enable    -      -      -       Auto   Auto    NA      -  
+ 1/25  Enable   1000   Full    NA       1000  Full    NA      -  
+ 1/26  Enable    -      -      -        1000  Full    NA      -  
+
+FF - ForcedFiber PF - PreferredFiber  F - Fiber
+FC - ForcedCopper PC - PreferredCopper C - Copper
+
+```
+
+**Help:** execute the command "show interfaces status"
+
+**Prompt:**
+- alcatel_aos>
+- alcatel_aos#
+
+### show linkagg alias
+
+**Output:**
+```
+
+                         Admin        Oper     Att/Sel  
+Number  Aggregate  Size  state        state      Ports      Name 
+-------+----------+----+------------+-------+---------+--------------
+   2     Dynamic      2    ENABLED    UP      2  2     LINK_LACP_CORE
+  31     Dynamic      8    ENABLED    DOWN    0  0     Created by Auto-Fabric on Mon Oct 6 00:00:00 2000
+  32     Dynamic      8    ENABLED    DOWN    0  0     Created by Auto-Fabric on Mon Oct 01 00:00:00 2000
+
+```
+
+**Help:** execute the command "show linkagg alias"
+
+**Prompt:**
+- alcatel_aos>
+- alcatel_aos#
+
+### show linkagg port
+
+**Output:**
+```
+
+Slot/Port Aggregate SNMP Id   Status   Agg  Oper Link Prim
+---------+---------+-------+----------+----+----+----+----
+   1/1    Dynamic     1000  ATTACHED     1  UP   UP   YES
+   1/2    Dynamic     1001  ATTACHED     1  UP   UP   NO 
+   1/3    Dynamic     1002  ATTACHED     2  UP   UP   YES
+   1/4    Dynamic     1003  ATTACHED     2  UP   UP   NO 
+
+```
+
+**Help:** execute the command "show linkagg port"
+
+**Prompt:**
+- alcatel_aos>
+- alcatel_aos#
+
+### show lldp remote-system
+
+**Output:**
+```
+Remote LLDP Agents on Local Slot/Port 1/1:
+
+    Chassis aa:aa:aa:aa:aa:aa, Port bb:bb:bb:bb:bb:bb:
+      Remote ID                   = 1,
+      Chassis Subtype             = 1 (MAC Address),
+      Port Subtype                = 1 (MAC address),
+      Port Description            = Alcatel-Lucent Enterprise OAW-AP1201H eth0-4094,
+      System Name                 = AP,
+      System Description          = Alcatel-Lucent Enterprise OAW-AP1201H 1.0.0.10,
+      Capabilities Supported      = Bridge WLAN AP Router Station Only,
+      Capabilities Enabled        = Bridge WLAN AP Router,
+      Management IP Address       = 1.1.1.1,
+      MED Device Type             = Network Connectivity,
+      MED Capabilities            = Capabilities | Power via MDI-PD(33),
+      MED Extension TLVs Present  = Network Policy| Inventory,
+      MED Power Type              = PD Device,
+      MED Power Source            = PSE and Local,
+      MED Power Priority          = Low,
+      MED Power Value             = 25.4 W
+
+Remote LLDP Agents on Local Slot/Port 1/2:
+
+    Chassis aa:aa:aa:aa:aa:aa, Port bb:bb:bb:bb:bb:bb:
+      Remote ID                   = 1,
+      Chassis Subtype             = 1 (MAC Address),
+      Port Subtype                = 1 (MAC address),
+      Port Description            = Alcatel-Lucent Enterprise OAW-AP1321 eth1,
+      System Name                 = AP,
+      System Description          = Alcatel-Lucent Enterprise OAW-AP1321 1.0.0.10,
+      Capabilities Supported      = Bridge WLAN AP Router Station Only,
+      Capabilities Enabled        = Bridge WLAN AP Router,
+      Management IP Address       = 1.1.1.1,
+      MED Device Type             = Network Connectivity,
+      MED Capabilities            = Capabilities | Power via MDI-PD(33),
+      MED Extension TLVs Present  = Network Policy| Inventory,
+      MED Power Type              = PD Device,
+      MED Power Source            = PSE and Local,
+      MED Power Priority          = Low,
+      MED Power Value             = 25.4 W,
+      Remote port MAC/PHY AutoNeg = Supported Enabled Capability 0x8336,
+      Mau Type                    = 1000BaseTFD - Four-pair Category 5 UTP full duplex mode
+
+Remote LLDP Agents on Local Slot/Port 1/3:
+
+    Chassis aa:aa:aa:aa:aa:aa, Port bb:bb:bb:bb:bb:bb:
+      Remote ID                   = 1,
+      Chassis Subtype             = 1 (MAC Address),
+      Port Subtype                = 1 (MAC address),
+      Port Description            = Alcatel-Lucent Enterprise OAW-AP1361 eth0,
+      System Name                 = AP,
+      System Description          = Alcatel-Lucent Enterprise OAW-AP1361 1.0.0.10,
+      Capabilities Supported      = Bridge WLAN AP Router Station Only,
+      Capabilities Enabled        = Bridge WLAN AP Router,
+      Management IP Address       = 1.1.1.1,
+      MED Device Type             = Network Connectivity,
+      MED Capabilities            = Capabilities | Power via MDI-PD(33),
+      MED Extension TLVs Present  = Network Policy| Inventory,
+      Remote port MAC/PHY AutoNeg = Supported Enabled Capability 0x8337,
+      Mau Type                    = 1000BaseTFD - Four-pair Category 5 UTP full duplex mode
+
+Remote LLDP Agents on Local Slot/Port 1/4:
+
+    Chassis aa:aa:aa:aa:aa:aa, Port 1001:
+      Remote ID                   = 123,
+      Chassis Subtype             = 1 (MAC Address),
+      Port Subtype                = 1 (Locally assigned),
+      Port Description            = Alcatel-Lucent OS6860 GNI 1/1/1,
+      System Name                 = SW,
+      System Description          = (null),
+      Capabilities Supported      = Bridge Router,
+      Capabilities Enabled        = Bridge Router,
+      Management IP Address       = 1.1.1.1
+
+Remote LLDP Agents on Local Slot/Port 1/24:
+
+    Chassis aa:aa:aa:aa:aa:aa, Port GigabitEthernet0/0/47:
+      Remote ID                   = 223,
+      Chassis Subtype             = 4 (MAC Address),
+      Port Subtype                = 5 (Interface name),
+      Port Description            = UPLINK,
+      System Name                 = super_mega_switch,
+      System Description          = S5700-52P-PWR-LI-AC
+Huawei Versatile Routing Platform Software
+VRP (R) software, Version 1.110 (S5700 A000A000A00AAA000)
+Copyright (C) 2000-2001 HUAWEI TECH Co., Ltd.,
+      Capabilities Supported      = Bridge Router,
+      Capabilities Enabled        = Bridge Router,
+      Management IP Address       = 1.1.1.1
+      Remote port default vlan    = 2000,
+      Vlan ID                     = 1,
+      Vlan Name                   = VLAN 0001,
+      Protocol vlan Id            = 0 (Flags = 0),
+      Remote port MAC/PHY AutoNeg = Supported Enabled Capability 0xa03e,
+      Mau Type                    = 1000BaseTFD - Four-pair Category 5 UTP full duplex mode
+
+```
+
+**Help:** execute the command "show lldp remote-system"
+
+**Prompt:**
+- alcatel_aos>
+- alcatel_aos#
+
+### show mac-address-table
+
+**Output:**
+```
+Legend: Mac Address: * = address not valid
+
+   Vlan      Mac Address          Type       Protocol    Operation    Interface 
+  ------+-------------------+--------------+-----------+------------+-----------
+   * 1    aa:aa:aa:aa:aa:aa      permanent         ---      bridging      1/1  
+     2    bb:bb:bb:bb:bb:bb        learned         ---      bridging      1/1  
+     3    cc:cc:cc:cc:cc:cc        learned         ---      bridging      1/1  
+     4    dd:dd:dd:dd:dd:dd        learned         ---      bridging      1/1
+ * 999    ee:ee:ee:ee:ee:ee      permanent           0      bridging      1/11
+
+Total number of Valid MAC addresses above = 4
+
+```
+
+**Help:** execute the command "show mac-address-table"
+
+**Prompt:**
+- alcatel_aos>
+- alcatel_aos#
+
+### show port-security
+
+**Output:**
+```
+
+Legend: Mac Address: * = Duplicate Static
+        Mac Address: # = Pseudo Static
+
+
+Port:  1/11
+ Operation Mode   :                ENABLED,
+ Max MAC bridged  :                      1,
+ Trap Threshold   :               DISABLED,
+ Max MAC filtered :                      5,
+ Violation        :               RESTRICT,
+ Violating MAC    :                   NULL
+
+ MAC Address        VLAN   TYPE
+-------------------+------+------------
+ aa:aa:aa:aa:aa:aa    10   STATIC
+
+ 
+Legend: Mac Address: * = Duplicate Static
+        Mac Address: # = Pseudo Static
+
+
+Port:  1/12
+ Operation Mode   :                ENABLED,
+ Max MAC bridged  :                      1,
+ Trap Threshold   :               DISABLED,
+ Max MAC filtered :                      5,
+ Violation        :               RESTRICT,
+ Violating MAC    :                   NULL
+
+ MAC Address        VLAN   TYPE
+-------------------+------+------------
+ aa:aa:aa:aa:aa:bb    10   STATIC
+
+```
+
+**Help:** execute the command "show port-security"
+
+**Prompt:**
+- alcatel_aos>
+- alcatel_aos#
+
+### show system
+
+**Output:**
+```
+System:
+  Description:  Alcatel-Lucent Enterprise OS6350-P24 6.7.1.001.R01 GA, January 01, 2000.,
+  Object ID:    0.0.0.0.0.0.0000.000.0.0.0.0.00.0.0,
+  Up Time:      22 days 2 hours 20 minutes and 20 seconds,
+  Contact:      Alcatel-Lucent Enterprise, https://www.al-enterprise.com,
+  Name:         SWA_0001,
+  Location:     Espoo - Finland,
+  Services:     2,
+  Date & Time:  MON JAN 01 2001  00:00:00 (CET)
+
+Flash Space:
+    Primary CMM:
+      Available (bytes):  39243776,
+      Comments         :  None
+
+```
+
+**Help:** execute the command "show system"
+
+**Prompt:**
+- alcatel_aos>
+- alcatel_aos#
+
+### show vlan port
+
+**Output:**
+```
+  vlan       port         type         status
+--------+------------+------------+--------------
+  1         1/1/23       default    inactive
+  1         1/1/25       qtagged    forwarding
+
+```
+
+**Help:** execute the command "show vlan port"
+
+**Prompt:**
+- alcatel_aos>
+- alcatel_aos#
+

--- a/docs/platforms/alcatel_sros.md
+++ b/docs/platforms/alcatel_sros.md
@@ -946,3 +946,241 @@ TO_R4                 0.0.0.0         0.0.0.0         0.0.0.0         Up   PToP
 - alcatel_sros>
 - alcatel_sros#
 
+### ping
+
+**Output:**
+```
+PING 10.252.117.158 56 data bytes
+64 bytes from 10.252.117.158: icmp_seq=1 ttl=255 time=1.93ms.
+64 bytes from 10.252.117.158: icmp_seq=2 ttl=255 time=1.89ms.
+64 bytes from 10.252.117.158: icmp_seq=3 ttl=255 time=1.80ms.
+64 bytes from 10.252.117.158: icmp_seq=4 ttl=255 time=1.84ms.
+64 bytes from 10.252.117.158: icmp_seq=5 ttl=255 time=1.70ms.
+
+---- 10.252.117.158 PING Statistics ----
+5 packets transmitted, 5 packets received, 0.00% packet loss
+round-trip min = 1.70ms, avg = 1.83ms, max = 1.93ms, stddev = 0.079ms
+
+```
+
+**Help:** execute the command "ping"
+
+**Prompt:**
+- alcatel_sros>
+- alcatel_sros#
+
+### show lag port
+
+**Output:**
+```
+
+===============================================================================
+Lag Port States
+LACP Status: e - Enabled, d - Disabled
+===============================================================================
+Lag-id Port-id        Adm   Act/     Opr   Primary Sub-group      Forced Prio
+                            Stdby
+-------------------------------------------------------------------------------
+5(d)   1/1/15         up    active   down  yes     1              -      32768
+       1/1/16         up    active   down          2              -      32768
+10(e)  1/1/1          down  active   down  yes     1              -      32768
+11(d)  1/1/2          up    active   down  yes     1              -      32768
+12(d)  1/1/3          up    active   down  yes     1              -      32768
+13(d)  1/1/4          up    active   down  yes     1              -      32768
+14(d)  1/1/5          up    active   down  yes     1              -      32768
+15(d)  1/1/6          up    active   down  yes     1              -      32768
+16(d)  1/1/7          up    active   down  yes     1              -      32768
+17(d)  1/1/8          up    active   down  yes     1              -      32768
+18(d)  1/1/9          up    active   down  yes     1              -      32768
+19(e)  1/1/10         up    active   down  yes     1              -      32768
+20(d)  1/1/12         up    active   down  yes     1              -      32768
+51(d)  1/1/13         up    active   down  yes     1              -      32768
+       1/1/14         up    active   down          1              -      32768
+52(d)  1/1/18         up    active   down  yes     1              -      32768
+53(d)  1/1/19         up    active   down  yes     1              -      32768
+54(d)  1/1/20         down  active   down  yes     1              -      32768
+115(e) 3/2/2          up    active   up    yes     2              -      32768
+       7/2/3          up    standby  down          1              -      32768
+116(e) esat-1/1/6     up    active   up    yes     1              -      32768
+       esat-2/1/6     up    standby  down          2              -      32768
+120(e) 2/1/13         up    active   up    yes     1              -      32768
+       3/1/4          up    standby  down          2              -      32768
+121(e) 3/2/6          up    standby  down  yes     1              -      32768
+       8/1/5          up    active   up            2              -      32768
+122(e) A/6            up    standby  down  yes     1              -      32768
+       B/5            up    active   up            2              -      32768
+===============================================================================
+
+```
+
+**Help:** execute the command "show lag port"
+
+**Prompt:**
+- alcatel_sros>
+- alcatel_sros#
+
+### show port description
+
+**Output:**
+```
+===============================================================================
+Port Descriptions on Slot 1
+===============================================================================
+Port Id        Description
+-------------------------------------------------------------------------------
+1/1/1          some_gig1_test
+1/1/2          some2_gig1_test
+1/1/3          some3_gig1_test
+1/1/4          some4_gig1_test
+1/1/5          some5_gig1_test
+1/1/6          10/100/Gig Ethernet SFP
+1/1/7          10/100/Gig Ethernet SFP
+1/1/8          10/100/Gig Ethernet SFP
+1/1/9          10/100/Gig Ethernet SFP
+1/1/10         10/100/Gig Ethernet SFP
+1/1/11         10/100/Gig Ethernet SFP
+1/1/12         TEST_AGG_TOGGLE
+1/1/13         TNET_RAN_TEST1
+1/1/14         TNET_RAN_TEST2
+1/1/15         test 1
+1/1/16         test 2
+1/1/17         TEST_3
+1/1/18         TNET_RAN_TEST3
+1/1/19         TNET_RAN_TEST4
+1/1/20         TNET_RAN_TEST5
+1/5/1          10-Gig Ethernet
+1/5/2          10-Gig Ethernet
+
+===============================================================================
+Port Descriptions on Slot A
+===============================================================================
+Port Id        Description
+-------------------------------------------------------------------------------
+A/1            10/100 Ethernet TX
+===============================================================================
+
+===============================================================================
+Port Descriptions on Satellite esat-3
+===============================================================================
+Port Id        Description
+-------------------------------------------------------------------------------
+esat-3/1/21    TNET_RAN_TEST9999
+===============================================================================
+
+
+```
+
+**Help:** execute the command "show port description"
+
+**Prompt:**
+- alcatel_sros>
+- alcatel_sros#
+
+### show service id 0 sap
+
+**Output:**
+```
+===============================================================================
+SAP(Summary), Service 24731
+===============================================================================
+PortId                          SvcId      Ing.  Ing.    Egr.  Egr.   Adm  Opr
+                                           QoS   Fltr    QoS   Fltr
+-------------------------------------------------------------------------------
+lag-54:950                      24731      1     none    1     none   Up   Down
+-------------------------------------------------------------------------------
+Number of SAPs : 1
+-------------------------------------------------------------------------------
+===============================================================================
+
+```
+
+**Help:** execute the command "show service id 0 sap"
+
+**Prompt:**
+- alcatel_sros>
+- alcatel_sros#
+
+### show service id interface
+
+**Output:**
+```
+
+==============================================================================
+Interface Table
+==============================================================================
+Interface-Name                   Adm       Opr(v4/v6)  Type    Port/SapId
+   IP-Address                                                  PfxState
+------------------------------------------------------------------------------
+Gigaesat-1/1/5:7                 Up        Up/Up       IES     esat-1/1/5:7.0
+   10.42.255.73/30                                            n/a
+   fe80:a8:2:90::8d5/126                                       PREFERRED
+   fe80::22e0:9cff:fe20:d401/64                                PREFERRED
+------------------------------------------------------------------------------
+Interfaces : 1
+==============================================================================
+
+```
+
+**Help:** execute the command "show service id interface"
+
+**Prompt:**
+- alcatel_sros>
+- alcatel_sros#
+
+### show service service-name-using
+
+**Output:**
+```
+===============================================================================
+Services By Name
+===============================================================================
+Service Name                                                 Type   Service Id
+-------------------------------------------------------------------------------
+ROYAL_CUSTOMER:3581                                           Vprn         1200
+LLC:3293                                                      Vprn         1246
+OLD_UNIVERSE AC                                               Ies          1042
+OLD_M PUB UNION                                               Ies          1041
+TLS_TCE-AC                                                    Ies          1170
+ABC_MPLS:6666                                                 Vprn         1171
+_tmnx_InternalVplsService                                     intV*  2147487649
+_tmnx_InternalSatVpls                                         Vpls   2148667979
+_tmnx_InternalSatVprn                                         Vprn   2141237980
+-------------------------------------------------------------------------------
+Matching Services : 9
+===============================================================================
+
+```
+
+**Help:** execute the command "show service service-name-using"
+
+**Prompt:**
+- alcatel_sros>
+- alcatel_sros#
+
+### show service service-using
+
+**Output:**
+```
+
+===============================================================================
+Services [vpls]  Customer 4020
+===============================================================================
+ServiceId    Type      Adm  Opr  CustomerId Service Name
+-------------------------------------------------------------------------------
+24728        VPLS      Up   Down 4020       testservice1
+24729        VPLS      Up   Up   4020       test-service2
+24730        VPLS      Up   Down 4020       testservice3
+24731        VPLS      Up   Down 4020       testservice5
+-------------------------------------------------------------------------------
+Matching Services : 4
+-------------------------------------------------------------------------------
+===============================================================================
+
+```
+
+**Help:** execute the command "show service service-using"
+
+**Prompt:**
+- alcatel_sros>
+- alcatel_sros#
+

--- a/docs/platforms/aruba_aoscx.md
+++ b/docs/platforms/aruba_aoscx.md
@@ -1547,19 +1547,6 @@ Member ID                        : 2
 - aruba_aoscx>
 - aruba_aoscx#
 
-### _default_
-
-**Output:**
-```
-% Invalid input detected
-```
-
-**Help:** default output for unknown commands
-
-**Prompt:**
-- aruba_aoscx>
-- aruba_aoscx#
-
 ### show vrf
 
 **Output:**
@@ -1789,6 +1776,19 @@ VRF Name   : VOIP
 ```
 
 **Help:** execute the command "show vrf"
+
+**Prompt:**
+- aruba_aoscx>
+- aruba_aoscx#
+
+### _default_
+
+**Output:**
+```
+% Invalid input detected
+```
+
+**Help:** default output for unknown commands
 
 **Prompt:**
 - aruba_aoscx>

--- a/docs/platforms/aruba_aoscx.md
+++ b/docs/platforms/aruba_aoscx.md
@@ -1560,3 +1560,237 @@ Member ID                        : 2
 - aruba_aoscx>
 - aruba_aoscx#
 
+### show vrf
+
+**Output:**
+```
+VRF Configuration:
+------------------
+VRF Name   : default
+        Interfaces             Status
+        -----------------------------
+        1/1/9                    down
+        1/1/10                   down
+        1/1/11                   down
+        1/1/12                   down
+        1/1/15                   down
+        1/1/20                   down
+        1/1/21                   down
+        1/1/22                   down
+        1/1/23                   down
+        1/1/24                   down
+        1/1/37                   down
+        1/1/38                   down
+        1/1/39                   down
+        1/1/40                   down
+        1/1/41                   down
+        1/1/42                   down
+        1/1/43                   down
+        1/1/44                   down
+        1/1/45                   down
+        1/1/46                   down
+        1/1/47                   down
+        1/1/52                   down
+        1/1/54                   down
+        1/1/55                   down
+        1/1/56                   down
+
+VRF Name   : VRF_GREEN
+        Interfaces             Status
+        -----------------------------
+        loopback117              up
+        vlan704                  up
+        vlan917                  up
+
+VRF Name   : VRF_BLUE
+        Interfaces             Status
+        -----------------------------
+        loopback102              up
+        vlan7                    up
+        vlan9                    up
+        vlan903                  up
+
+VRF Name   : CCTV
+        Interfaces             Status
+        -----------------------------
+        loopback103              up
+        vlan904                  up
+
+VRF Name   : CLIENT
+        Interfaces             Status
+        -----------------------------
+        loopback109              up
+        vlan10                   up
+        vlan910                  up
+
+VRF Name   : DMZ
+        Interfaces             Status
+        -----------------------------
+        loopback129              up
+        vlan1300                 up
+        vlan1302                 up
+        vlan1325                 up
+
+VRF Name   : VRF_INT_A
+        Interfaces             Status
+        -----------------------------
+        loopback126              up
+        vlan502                  up
+        vlan924                  up
+        vlan926                  up
+
+VRF Name   : INTERNET_DMZ
+        Interfaces             Status
+        -----------------------------
+        loopback127              up
+        vlan707                  up
+        vlan927                  up
+        vlan2540                 up
+
+VRF Name   : INTERNET_ISP
+        Interfaces             Status
+        -----------------------------
+        vlan714                  up
+        vlan715                  up
+        vlan716                  up
+        vlan717                  up
+
+VRF Name   : VRF_INT_B
+        Interfaces             Status
+        -----------------------------
+        loopback125              up
+        vlan501                  up
+        vlan923                  up
+        vlan925                  up
+
+VRF Name   : VRF_MAGENTA
+        Interfaces             Status
+        -----------------------------
+        1/1/48                   up
+
+VRF Name   : VRF_YELLOW
+        Interfaces             Status
+        -----------------------------
+        loopback121              up
+        vlan830                  up
+        vlan831                  up
+        vlan876                  up
+        vlan922                  up
+
+VRF Name   : MEDICAL
+        Interfaces             Status
+        -----------------------------
+        loopback108              up
+        vlan31                   up
+        vlan909                  up
+
+VRF Name   : MGMT
+        Interfaces             Status
+        -----------------------------
+        loopback110              up
+        vlan2                    up
+        vlan5                    up
+        vlan60                   up
+        vlan61                   up
+        vlan62                   up
+        vlan63                   up
+        vlan64                   up
+        vlan65                   up
+        vlan66                   up
+        vlan67                   up
+        vlan911                  up
+
+VRF Name   : MULTIMEDIA
+        Interfaces             Status
+        -----------------------------
+        loopback100              up
+        vlan901                  up
+
+VRF Name   : PCI
+        Interfaces             Status
+        -----------------------------
+        loopback104              up
+        vlan12                   up
+        vlan905                  up
+
+VRF Name   : POS
+        Interfaces             Status
+        -----------------------------
+        loopback107              up
+        vlan30                   up
+        vlan40                   up
+        vlan140                  up
+        vlan908                  up
+
+VRF Name   : SD-WAN
+        Interfaces             Status
+        -----------------------------
+        loopback111              up
+        vlan102                  up
+        vlan801                  up
+        vlan912                  up
+
+VRF Name   : VRF_RED
+        Interfaces             Status
+        -----------------------------
+        loopback101              up
+        vlan11                   up
+        vlan902                  up
+
+VRF Name   : SERVICE
+        Interfaces             Status
+        -----------------------------
+        loopback130              up
+        vlan1600                 up
+        vlan1660                 up
+        vlan1661                 up
+        vlan1665                 up
+        vlan1670                 up
+
+VRF Name   : VRF_ORANGE
+        Interfaces             Status
+        -----------------------------
+        loopback113              up
+        vlan914                  up
+
+VRF Name   : VRF_PURPLE
+        Interfaces             Status
+        -----------------------------
+
+VRF Name   : TELEPHONY
+        Interfaces             Status
+        -----------------------------
+
+VRF Name   : VRF_CYAN
+        Interfaces             Status
+        -----------------------------
+        loopback105              up
+        vlan385                  up
+        vlan906                  up
+
+VRF Name   : VENDOR
+        Interfaces             Status
+        -----------------------------
+        loopback106              up
+        vlan20                   up
+        vlan907                  up
+        vlan2070                 up
+
+VRF Name   : VOIP
+        Interfaces             Status
+        -----------------------------
+        loopback128              up
+        vlan55                   up
+        vlan75                   up
+        vlan305                  up
+        vlan310                  up
+        vlan928                  up
+
+```
+
+**Help:** execute the command "show vrf"
+
+**Prompt:**
+- aruba_aoscx>
+- aruba_aoscx#
+

--- a/docs/platforms/aruba_os.md
+++ b/docs/platforms/aruba_os.md
@@ -238,3 +238,154 @@ loopback                    [  up/up  ]
 - aruba_os>
 - aruba_os#
 
+### show hostname
+
+**Output:**
+```
+
+Hostname is WLC-AMC72-LAB01
+```
+
+**Help:** execute the command "show hostname"
+
+**Prompt:**
+- aruba_os>
+- aruba_os#
+
+### show inventory
+
+**Output:**
+```
+
+Supervisor Card slot            : 0
+System Serial#                  : CV123ABC2 (Date:08/25/18)
+CPU Card Serial#                : ABC123XYZ (Date:08/25/18)
+CPU Card Assembly#              : 2010151H
+CPU Card Revision               : (Rev:11.00)
+Interface Card Serial#          : AI3ABC12379 (Date:08/25/18)
+Interface Card Assembly#        : 2010085E
+Interface Card Revision         : (Rev:04.00)
+SC Model#                       : Aruba7210-US
+HW MAC Addr                     : 00:1a:1e:05:27:60 to 00:1a:1e:05:27:67
+CPLD Version                    : (Rev: 3.0)
+Power Supply 0                  : Present               : No
+Power Supply 1                  : Present               : Yes
+                                : 12V OK                : Yes
+                                : Fan OK                : Yes
+                                : Aruba Model No        : 2510057
+                                : Vendor & Model No     : QCS DCJ3501-01P
+                                : Serial No             : QC1234506L
+                                : MFG Date              : 7/2/18
+                                : Output 1 Config       : 12V 350W
+                                : Input Min             : 90V AC
+                                : Input Max             : 264V AC
+Main Board Temperatures         :                  
+                                : U24 - Local Temp      25 C (shadow of XLP heatsink)
+                                : Q1  - Remote 1 Temp   27 C (shadow of VRM, VDD_CPU)
+                                : Q2  - Remote 2 Temp   26 C (shadow of VRM, VDD_SOC)
+                                : U44 - Local Temp      20 C (shadow of DPI connector)
+                                : U29  - Remote 1 Temp  24 C (XLP die temperature)
+                                : Q36  - Remote 2 Temp  21 C (shadow of 98X1422)
+                                : J2  - DDR A Temp      18 C (DDR3 A temp)
+                                : J4  - DDR B Temp      22 C (DDR3 B temp)
+                                : J1  - DDR C Temp      19 C (DDR3 C temp)
+                                : J3  - DDR D Temp      20 C (DDR3 D temp)
+                                : Port 0 Temp           23 C (1G PHY temp)
+                                : Port 1 Temp           23 C (1G PHY temp)
+Interface Board Temperatures    :
+                                : U21 - Local Temp      23 C (shadow of port 1 RJ45)
+                                : Q4 - Remote 1 Temp    22 C (shadow of 88E1543)
+                                : Q3 - Remote 2 Temp    25 C (shadow of 88X2140)
+Fan  0                          : 9070 rpm (5.831 V),Speed Low
+Fan  1                          : 9112 rpm (5.921 V),Speed Low
+Fan  2                          : 8916 rpm (5.809 V),Speed Low
+Fan  3                          : 9049 rpm (5.876 V),Speed Low
+Main Board Voltages             :
+ispPAC_POWR1014A_A              :
+                                : 1V2                  1.20V sense 1.208 V
+                                : VDD SOC              0.943V sense 0.928 V
+                                : VCC IOBD 1V5         1.50V sense 1.538 V
+                                : DDR3BD_VTT           0.75V sense 0.760 V
+                                : VCC 1A               1.00V sense 1.026 V
+                                : IV8_DIGITAL          1.80V sense 1.852 V
+                                : 3V3_MAIN             3.30V sense 3.348 V
+                                : VCC1                 1.00V sense 1.024 V
+                                : VCC25                2.50V sense 2.538 V
+                                : 3V3 SB               3.30V sense 3.366 V
+ispPAC_POWR1014A_B              :
+                                : VDD                  0.837V sense 0.850 V
+                                : VCC IOAC 1V5         1.50V sense 1.546 V
+                                : DDR3AC_VTT           0.75V sense 0.760 V
+                                : VDD_SRAM             1.00V sense 1.048 V
+                                : VCC1B                1.00V sense 1.030 V
+                                : 1V8_ANALOG           1.80V sense 1.842 V
+                                : 1V8                  1.80V sense 1.848 V
+                                : VDDIO12_XAUI         1.20V sense 1.212 V
+                                : 5V                   5.00V sense 5.016 V
+Interface Board Voltages        :
+ispPAC_POWR6AT6                 :
+                                : VCC33                3.30V sense 3.342 V
+                                : VCC 18               1.80V sense 1.840 V
+                                : VCC1                 1.00V sense 1.024 V
+                                : VCC12                1.20V sense 1.220 V
+                                : VCC12-DVDD           1.20V sense 1.214 V
+                                : VCC9                 0.90V sense 0.932 V
+```
+
+**Help:** execute the command "show inventory"
+
+**Prompt:**
+- aruba_os>
+- aruba_os#
+
+### show version
+
+**Output:**
+```
+
+Image stamp:    /ws/swbuildm/rel_venice_qaoff/code/build/lvm(swbuildm_rel_venice_qaoff_rel_venice)
+                Mar 26 2018 23:16:08
+                WC.16.05.0007
+                570
+Boot Image:     Primary
+
+Boot ROM Version:    WC.16.01.0005
+Active Boot ROM:     Primary
+
+```
+
+**Help:** execute the command "show version"
+
+**Prompt:**
+- aruba_os>
+- aruba_os#
+
+### show vlan
+
+**Output:**
+```
+ Status and Counters - VLAN Information
+
+  Maximum VLANs to support : 128
+  Primary VLAN : DEFAULT_VLAN
+  Management VLAN :
+
+  VLAN ID Name                             | Status     Voice Jumbo
+  ------- -------------------------------- + ---------- ----- -----
+  1       DEFAULT_VLAN                     | Port-based No    No
+  102     Printers                         | Port-based No    No
+  103     Workstations                     | Port-based No    No
+  104     Management                       | Port-based No    No
+  105     AP_Management                    | Port-based No    No
+  106     WiFi_ot                          | Port-based No    No
+  107     WiFi_main                        | Port-based No    No
+  108     WiFi_guest                       | Port-based No    No
+
+```
+
+**Help:** execute the command "show vlan"
+
+**Prompt:**
+- aruba_os>
+- aruba_os#
+

--- a/docs/platforms/ciena_saos.md
+++ b/docs/platforms/ciena_saos.md
@@ -276,3 +276,148 @@
 - ciena_saos>
 - ciena_saos#
 
+### lldp show neighbors
+
+**Output:**
+```
++--------------------------------------------------------------------------------------------------------------+
+|                                                LLDP Neighbors                                                |
++--------------------------------------------------------------------------------------------------------------+
+| Remote Addr: 10.8.91.1                                                                                       |
+| Remote Addr: 10.8.128.39                                                                                     |
+| Remote Addr: fe80::9e7a:3ff:fed1:cd1                                                                         |
+| Remote Addr: fe80::9e7a:3ff:fed1:cdf                                                                         |
+| System Name: LAB_00009-SDS39-100                                                                             |
+| System Desc: Ciena 3916 Service Delivery Switch                                                              |
++-------------+------------------------------------------------------------------------------------------------+
+|Local        |                                              Remote                                            |
++-------------+--------------------------------+---------------------------------------------------------------+
+|Port         |Port                            |Info                                                           |
++-------------+--------------------------------+---------------------------------------------------------------+
+|5            |6                               |  Chassis Id: 9C7A03A10D60                                     |
+|             |                                |   Mgmt Addr: 10.8.91.2                                        |
+|             |                                |              10.8.128.40                                      |
+|             |                                |              fe80::9e7a:3ff:fed1:d61                          |
+|             |                                |              fe80::9e7a:3ff:fed1:d6f                          |
+|             |                                | System Name: LAB_SDS39-200                                    |
+|             |                                | System Desc: Ciena 3916 Service Delivery Switch               |
+|             |                                | SyncE Suppt: Not Supported                                    |
+|             |                                | SyncE Confg: Not Configured                                   |
++-------------+--------------------------------+---------------------------------------------------------------+
+|6            |3                               |  Chassis Id: 9C7A03B86040                                     |
+|             |                                |   Mgmt Addr: 10.8.90.250                                      |
+|             |                                |              10.8.130.1                                       |
+|             |                                |              fe80::9e7a:3ff:fec8:6040                         |
+|             |                                |              fe80::9e7a:3ff:fec8:6041                         |
+|             |                                | System Name: LAB_SAS51-100                                    |
+|             |                                | System Desc: Ciena 5142 Service Aggregation Switch            |
+|             |                                | SyncE Suppt: Input and Output                                 |
+|             |                                | SyncE Confg: Not Configured                                   |
++-------------+--------------------------------+---------------------------------------------------------------+
+
+```
+
+**Help:** execute the command "lldp show neighbors"
+
+**Prompt:**
+- ciena_saos>
+- ciena_saos#
+
+### port show ethernet-config
+
+**Output:**
+```
++------------------------ PORT ETHERNET CONFIGURATION -------------------------+
+|        |         |       |      |     |    |    |     |      |    Mirror     |
+| Port   | Port    | Admin |      |     |    | FC | Auto| MTU  |    Status     |
+| Name   | Type    | Status| Speed| Dplx| FC | Adv| Neg | Size |State| Eg | Ig |
++--------+---------+-------+------+-----+----+----+-----+------+-----+----+----+
+| 1      | 10/100/G| Dis   | Auto | ??  |off |off | On  | 9100 | Off | 0  | 0  |
+| 2      | 10/100/G| Ena   | Auto | ??  |off |off | On  | 9100 | Off | 0  | 0  |
+| 3      | 100/G   | Ena   | 100  | ??  |off |off | Off | 9100 | Off | 0  | 0  |
+| 4      | 100/G   | Ena   | 1000 | ??  |off |off | On  | 9100 | Off | 0  | 0  |
+| 5      | Gig     | Ena   | 1000 | Full|off |off | Off | 9216 | Off | 0  | 0  |
+| 6      | Gig     | Ena   | 1000 | Full|off |off | Off | 9216 | Off | 0  | 0  |
++--------+---------+-------+------+-----+----+----+-----+------+-----+----+----+
+
+```
+
+**Help:** execute the command "port show ethernet-config"
+
+**Prompt:**
+- ciena_saos>
+- ciena_saos#
+
+### port show network-config
+
+**Output:**
+```
++----------------------------- PORT NETWORK CONFIGURATION ------------------------------+
+|         |     | Accpt  |Untag  |VLAN   |VS     |Egress |VS     |Ingress| VPLS  |Eth VC|
+| Port    |     | Frame  |Ingress|Ingress|Ingress|Untag  |Egress |CoS    | Port  |Ether-|
+| Name    |PVID | Type   |Vid    |Filter |Filter |VLAN   |Filter |Policy | Type  |Type  |
++---------+-----+--------+-------+-------+-------+-------+-------+-------+-------+------+
+| 1       | 1   | All    | 0     | Ena   | Dis   | 1     | Dis   | leave | Subsc | 8100 |
+| 2       | 1   | All    | 0     | Ena   | Dis   | 1     | Dis   | leave | Subsc | 8100 |
+| 3       | 1   | All    | 0     | Ena   | Dis   | 1     | Dis   | leave | Subsc | 8100 |
+| 4       | 1   | All    | 0     | Ena   | Ena   | 1     | Dis   | leave | Subsc | 8100 |
+| 5       | 1   | All    | 0     | Ena   | Ena   | 1     | Dis   | leave | Ntwrk | 8100 |
+| 6       | 1   | All    | 0     | Ena   | Dis   | 1     | Dis   | leave | Ntwrk | 8100 |
++---------+-----+--------+-------+-------+-------+-------+-------+-------+-------+------+
+
+```
+
+**Help:** execute the command "port show network-config"
+
+**Prompt:**
+- ciena_saos>
+- ciena_saos#
+
+### port show status
+
+**Output:**
+```
++---------------------------- PORT OPERATIONAL STATUS ----------------------------+
+|    |                               |    |Link State|    |   |Speed/ |MTU  |Flow |
+| ## | Description                   |Link|Duration  |XCVR|STP|Duplex |Size |Ctrl |
++----+-------------------------------+----+----------+----+---+-------+-----+-----+
+|1   |ACL_3360610_71CHA              |Down|  0h 0m 0s|    |Dis|       | 9100|     |
+|2   |UNI-Port2                      |Down|  0h 0m 0s|    |Dis|       | 9100|     |
+|3   |UNI-Port3                      |Down|  0h 0m 0s|    |Dis|       | 9100|     |
+|4   |NNI-Ringport                   |Down|  0h 0m 0s|    |Dis|       | 9100|     |
+|5   |NNI-Ringport                   | Up |268d 1h12m|Ena |FWD|1000/FD| 9216|off  |
+|6   |NNI-Ringport                   | Up |268d 1h14m|Ena |FWD|1000/FD| 9216|off  |
++----+-------------------------------+----+----------+----+---+-------+-----+-----+
+
+```
+
+**Help:** execute the command "port show status"
+
+**Prompt:**
+- ciena_saos>
+- ciena_saos#
+
+### port xcvr show
+
+**Output:**
+```
++----+-----+-----+---------Transceiver-Status------------+-----+----------------+----+
+|    |Admin| Oper|                                       |Ciena|Ether Medium &  |Diag|
+|Port|State|State|      Vendor Name & Part Number        | Rev |Connector Type  |Data|
++----+-----+-----+---------------------------------------+-----+----------------+----+
+|1   |Empty|     |                                       |     |                |    |
+|2   |Empty|     |                                       |     |                |    |
+|3   |Empty|     |                                       |     |                |    |
+|4   |Empty|     |                                       |     |                |    |
+|5   |Ena  |Ena  |CIENA-LMT XCVR-A40Y31 Rev0003          |A    |1000BASE-LX/LC  |Yes |
+|6   |Ena  |Ena  |CIENA-LMT XCVR-A40Y31 Rev0003          |A    |1000BASE-LX/LC  |Yes |
++----+-----+-----+---------------------------------------+-----+----------------+----+
+
+```
+
+**Help:** execute the command "port xcvr show"
+
+**Prompt:**
+- ciena_saos>
+- ciena_saos#
+

--- a/docs/platforms/extreme_exos.md
+++ b/docs/platforms/extreme_exos.md
@@ -481,3 +481,66 @@ Total number of VLAN(s) : 3469
 - extreme_exos>
 - extreme_exos#
 
+### show fdb
+
+**Output:**
+```
+MAC                                      VLAN Name( Tag)  Age  Flags          Port / Virtual Port List
+------------------------------------------------------------------------------------------------------
+00:0c:29:4b:34:cf                             v101(0101) 0041  d m D          1:2
+00:0c:29:4b:34:cf                             v100(0100) 0041  d m P          1:2
+00:0c:29:d2:2d:48                             v102(0102) 0045  d miM          1:3, 1:45
+00:0c:29:d2:2d:48                             v100(0100) 0045  d m P          1:3
+00:0c:29:f1:f2:f5                             v100(0100) 0045  d miM          1:51:1, 1:45
+00:0c:29:f1:f2:f5                             v102(0102) 0045  d m P          1:1
+00:0c:29:f1:f2:f5                             v101(0101) 0000  d m P          1:1
+
+Flags : d - Dynamic, s - Static, p - Permanent, n - NetLogin, m - MAC, i - IP,
+        x - IPX, l - lockdown MAC, L - lockdown-timeout MAC, M- Mirror, B - Egress Blackhole,
+        b - Ingress Blackhole, v - MAC-Based VLAN, P - Private VLAN, T - VLAN translation,
+        D - drop packet, h - Hardware Aging (Age=0), o - IEEE 802.1ah Backbone MAC,
+        S - Software Controlled Deletion, r - MSRP,
+        X - VXLAN, E - EVPN
+
+Total: 3 Static: 0  Perm: 0  Dyn: 3  Dropped: 1  Locked: 0  Locked with Timeout: 0
+FDB Aging time: 300
+
+```
+
+**Help:** execute the command "show fdb"
+
+**Prompt:**
+- extreme_exos>
+- extreme_exos#
+
+### show iparp
+
+**Output:**
+```
+VR            Destination      Mac                Age  Static  VLAN          VID   Port
+VR-Default    10.128.32.4      00:d0:59:17:74:83   20      NO  bluered       4092  1:25
+VR-Default    10.128.32.8      00:01:30:ba:6a:a0    7      NO  Default       4095
+
+Dynamic Entries  :           4             Static Entries            :          0
+Pending Entries  :           0
+
+ARP address check:    Enabled              ARP refresh               :    Enabled
+Timeout          :          20 minutes     ARP Sender-Mac Learning   :   Disabled
+Locktime         :        1000 milliseconds
+Retransmit Time  :        1000 milliseconds
+Reachable Time   :      900000 milliseconds (Auto)
+Fast Convergence :         Off 
+
+ARP Global Settings
+Max Entries         :    12288 
+Max Pending Entries :      256 
+Max Proxy Entries   :      256
+
+```
+
+**Help:** execute the command "show iparp"
+
+**Prompt:**
+- extreme_exos>
+- extreme_exos#
+

--- a/docs/platforms/hp_procurve.md
+++ b/docs/platforms/hp_procurve.md
@@ -935,3 +935,85 @@ Allocation statistics for MSG buffer pool:
 - hp_procurve>
 - hp_procurve#
 
+### show version
+
+**Output:**
+```
+Aruba Operating System Software.
+ArubaOS (MODEL: 310), Version 01.01.0.1 SSR
+Website: http://www.arubanetworks.com
+(c) Copyright 2001 Hewlett Packard Enterprise Development LP.
+Compiled on 2001-01-01 at 01:01:01 UTC (build 00001) by jenkins
+FIPS Mode :disabled
+
+AP uptime is 01 hours 01 minutes 01 seconds
+Reboot Time and Cause: AP rebooted caused by cold HW reset(power loss)
+
+```
+
+**Help:** execute the command "show version"
+
+**Prompt:**
+- hp_procurve>
+- hp_procurve#
+
+### show vsf detail
+
+**Output:**
+```
+VSF Domain ID    : 1
+ MAC Address      : 94f128-aabbcc
+ VSF Topology     : Chain
+ VSF Status       : Active
+ Uptime           : 134d 1h 55m
+ VSF MAD          : None
+ VSF Port Speed   : 10G
+ Software Version : WC.16.11.0021
+
+Name             : SWITCH-1
+Contact          : Network Team (email@address.com)
+Location         : Datacenter Generic
+
+
+Member ID        : 1
+MAC Address      : 94f128-aabbcd
+Type             : JL256A
+Model            : Aruba JL256A 2930F-48G-PoE+-4SFP+ Switch
+Priority         : 255
+Status           : Commander
+ROM Version      : WC.16.01.0010
+Serial Number    : SN0000001A
+Uptime           : 134d 1h 55m
+CPU Utilization  : 10%
+Memory - Total   : 333,513,216 bytes
+Free             : 212,192,464 bytes
+VSF Links -
+#1 : Active, Peer member 2
+#2 : Inactive
+
+
+
+Member ID        : 2
+MAC Address      : 94f128-aabbce
+Type             : JL256A
+Model            : Aruba JL256A 2930F-48G-PoE+-4SFP+ Switch
+Priority         : 128
+Status           : Standby
+ROM Version      : WC.16.01.0010
+Serial Number    : SN0000002A
+Uptime           : 134d 1h 55m
+CPU Utilization  : 4%
+Memory - Total   : 333,513,216 bytes
+Free             : 227,871,324 bytes
+VSF Links -
+#1 : Active, Peer member 1
+#2 : Inactive
+
+```
+
+**Help:** execute the command "show vsf detail"
+
+**Prompt:**
+- hp_procurve>
+- hp_procurve#
+

--- a/docs/platforms/linux.md
+++ b/docs/platforms/linux.md
@@ -142,3 +142,668 @@ broadcast 10.0.0.255 dev brblue proto kernel scope link src 10.0.0.1
 - linux$
 - linux#
 
+### bluetoothctl show
+
+**Output:**
+```
+Controller AA:AA:AA:AA:AA:AA (public)
+        Manufacturer: 0x005d (93)
+        Version: 0x0a (10)
+        Name: ntc-AA-AAAA
+        Alias: ntc-AA-AAAA
+        Class: 0x00000000 (0)
+        Powered: no
+        Discoverable: no
+        DiscoverableTimeout: 0x000000b4 (180)
+        Pairable: yes
+        UUID: Message Notification Se.. (00001133-0000-1000-8000-00805f9b34fb)
+        UUID: A/V Remote Control        (0000110e-0000-1000-8000-00805f9b34fb)
+        UUID: OBEX Object Push          (00001105-0000-1000-8000-00805f9b34fb)
+        UUID: Message Access Server     (00001132-0000-1000-8000-00805f9b34fb)
+        UUID: PnP Information           (00001200-0000-1000-8000-00805f9b34fb)
+        UUID: IrMC Sync                 (00001104-0000-1000-8000-00805f9b34fb)
+        UUID: Vendor specific           (00005005-0000-1000-8000-0002ee000001)
+        UUID: A/V Remote Control Target (0000110c-0000-1000-8000-00805f9b34fb)
+        UUID: Generic Attribute Profile (00001801-0000-1000-8000-00805f9b34fb)
+        UUID: Phonebook Access Server   (0000112f-0000-1000-8000-00805f9b34fb)
+        UUID: Audio Sink                (0000110b-0000-1000-8000-00805f9b34fb)
+        UUID: Device Information        (0000180a-0000-1000-8000-00805f9b34fb)
+        UUID: Generic Access Profile    (00001800-0000-1000-8000-00805f9b34fb)
+        UUID: Handsfree Audio Gateway   (0000111f-0000-1000-8000-00805f9b34fb)
+        UUID: Audio Source              (0000110a-0000-1000-8000-00805f9b34fb)
+        UUID: OBEX File Transfer        (00001106-0000-1000-8000-00805f9b34fb)
+        UUID: Handsfree                 (0000111e-0000-1000-8000-00805f9b34fb)
+        Modalias: usb:v1D6Bp0246d0548
+        Discovering: no
+        Roles: central
+        Roles: peripheral
+Advertising Features:
+        ActiveInstances: 0x00 (0)
+        SupportedInstances: 0x04 (4)
+        SupportedIncludes: tx-power
+        SupportedIncludes: appearance
+        SupportedIncludes: local-name
+        SupportedSecondaryChannels: 1M
+        SupportedSecondaryChannels: 2M
+        SupportedSecondaryChannels: Coded
+
+```
+
+**Help:** execute the command "bluetoothctl show"
+
+**Prompt:**
+- linux$
+- linux#
+
+### dmidecode -t bios
+
+**Output:**
+```
+# dmidecode 1.12
+SMBIOS 1.1 present.
+
+Handle 0x0000, DMI type 0, 24 bytes
+BIOS Information
+	Vendor: Dell
+	Version: O11   
+	Release Date: 01/11/1011
+	Address: 0xA1110
+	Runtime Size: 111111 bytes
+	ROM Size: 2048 kB
+	Characteristics:
+		PCI is supported
+		PNP is supported
+		APM is supported
+		BIOS is upgradeable
+		BIOS shadowing is allowed
+		ESCD support is available
+		Boot from CD is supported
+		Selectable boot is supported
+		BIOS ROM is socketed
+		EDD is supported
+		Print screen service is supported (int 5h)
+		8042 keyboard services are supported (int 9h)
+		Serial services are supported (int 14h)
+		Printer services are supported (int 17h)
+		CGA/mono video services are supported (int 10h)
+		ACPI is supported
+		USB legacy is supported
+		Smart battery is supported
+		 BIOS boot specification is supported
+		Function key-initiated network boot is supported
+		Targeted content distribution is supported
+
+```
+
+**Help:** execute the command "dmidecode -t bios"
+
+**Prompt:**
+- linux$
+- linux#
+
+### dmidecode -t memory
+
+**Output:**
+```
+# dmidecode 1.11
+SMBIOS 1.1 present.
+
+Handle 0x001A, DMI type 11, 11 bytes
+Physical Memory Array
+	Location: System Board Or Motherboard
+	 Use: System Memory
+	Error Correction Type: Multi-bit ECC
+	Maximum Capacity: 16 GB
+	Error Information Handle: Not Provided
+	Number Of Devices: 4
+
+Handle 0x001A, DMI type 11, 11 bytes
+Memory Device
+	Array Handle: 0x001A
+	Error Information Handle: No Error
+	Total Width: 10 bits
+	Data Width: 10 bits
+	Size: 1111 MB
+	Form Factor: DIMM
+	Set: 1
+	Locator: DIMM1A
+	Bank Locator: Not Specified
+	Type: DDR2
+	Type Detail: Synchronous
+	Speed: 1111 MHz
+	Manufacturer: Not Specified
+	Serial Number: Not Specified
+	Asset Tag: Not Specified
+	Part Number: Not Specified
+	Rank: Unknown
+
+Handle 0x001A, DMI type 11, 11 bytes
+Memory Device
+	Array Handle: 0x001A
+	Error Information Handle: No Error
+	Total Width: Unknown
+	Data Width: Unknown
+	Size: No Module Installed
+	Form Factor: DIMM
+	Set: 1
+	Locator: DIMM1C
+	Bank Locator: Not Specified
+	Type: Reserved
+	Type Detail: Synchronous
+	Speed: Unknown
+	Manufacturer: Not Specified
+	Serial Number: Not Specified
+	Asset Tag: Not Specified
+	Part Number: Not Specified
+	Rank: Unknown
+
+Handle 0x001A, DMI type 11, 11 bytes
+Memory Device
+	Array Handle: 0x001A
+	Error Information Handle: No Error
+	Total Width: Unknown
+	Data Width: Unknown
+	Size: No Module Installed
+	Form Factor: DIMM
+	Set: 1
+	Locator: DIMM1B
+	Bank Locator: Not Specified
+	Type: Reserved
+	Type Detail: Synchronous
+	Speed: Unknown
+	Manufacturer: Not Specified
+	Serial Number: Not Specified
+	Asset Tag: Not Specified
+	Part Number: Not Specified
+	Rank: Unknown
+
+Handle 0x001A, DMI type 11, 11 bytes
+Memory Device
+	Array Handle: 0x001A
+	Error Information Handle: No Error
+	Total Width: Unknown
+	Data Width: Unknown
+	Size: No Module Installed
+	Form Factor: DIMM
+	Set: 1
+	Locator: DIMM1D
+	Bank Locator: Not Specified
+	Type: Reserved
+	Type Detail: Synchronous
+	Speed: Unknown
+	Manufacturer: Not Specified
+	Serial Number: Not Specified
+	Asset Tag: Not Specified
+	Part Number: Not Specified
+	Rank: Unknown
+
+```
+
+**Help:** execute the command "dmidecode -t memory"
+
+**Prompt:**
+- linux$
+- linux#
+
+### dmidecode -t processor
+
+**Output:**
+```
+# dmidecode 1.1
+SMBIOS 1.1 present.
+
+Handle 0x0004, DMI type 4, 42 bytes
+Processor Information
+	Socket Designation: CPU 1   
+	Type: Central Processor
+	Family: Core 2 Quad
+	Manufacturer: AMD
+	ID: AA AA AA AA AA AA AA AA
+	Signature: Type 0, Family 1, Model 2, Stepping 3
+	Flags:
+		 FPU (Floating-point unit on-chip)
+		VME (Virtual mode extension)
+		DE (Debugging extension)
+		PSE (Page size extension)
+		TSC (Time stamp counter)
+		MSR (Model specific registers)
+		PAE (Physical address extension)
+	 	MCE (Machine check exception)
+		CX8 (CMPXCHG8 instruction supported)
+	 	APIC (On-chip APIC hardware supported)
+		SEP (Fast system call)
+		MTRR (Memory type range registers)
+		PGE (Page global enable)
+		MCA (Machine check architecture)
+		CMOV (Conditional move instruction supported)
+		 PAT (Page attribute table)
+		PSE-36 (36-bit page size extension)
+		CLFSH (CLFLUSH instruction supported)
+		DS (Debug store)
+		ACPI (ACPI supported)
+		MMX (MMX technology supported)
+		FXSR (FXSAVE and FXSTOR instructions supported)
+		SSE (Streaming SIMD extensions)
+		SSE2 (Streaming SIMD extensions 2)
+		SS (Self-snoop)
+		HTT (Multi-threading)
+		TM (Thermal monitor supported)
+		PBE (Pending break enabled)
+	Version: Intel(R) AAAA(R) CPU           A1111  @ 1.10GHz
+	Voltage: 1.2 V
+	External Clock: 133 MHz
+	 Max Speed: 1100 MHz
+	Current Speed: 1100 MHz
+	Status: Populated, Enabled
+	Upgrade: Slot 1
+	L1 Cache Handle: 0x0001
+	L2 Cache Handle: 0x0002
+	L3 Cache Handle: 0x0003
+	Serial Number: Not Specified
+	Asset Tag: Not Specified
+	Part Number: Not Specified
+	Core Count: 1
+	Core Enabled: 1
+	Thread Count: 1
+	Characteristics:
+		128-bit capable
+
+```
+
+**Help:** execute the command "dmidecode -t processor"
+
+**Prompt:**
+- linux$
+- linux#
+
+### dmidecode -t system
+
+**Output:**
+```
+# dmidecode 1.11
+SMBIOS 1.1 present.
+
+Handle 0x0001, DMI type 1, 11 bytes
+System Information
+	Manufacturer: HP
+	Product Name: ProG4 Deepseek G6
+	Version:        
+	Serial Number: AA111100AA
+	UUID: 1111AA1A-AA1A-11A1-1AAA-A1111AAAA1AA
+	Wake-up Type: Power Switch
+	SKU Number: 000000-000
+	Family: Not Specified
+
+Handle 0x0011, DMI type 12, 1 bytes
+System Configuration Options
+	Option 1: Jumper settings can be described here.
+
+Handle 0x0011, DMI type 11, 11 bytes
+System Event Log
+	Area Length: 32 bytes
+	Header Start Offset: 0x0000
+	Header Length: 32 bytes
+	Data Start Offset: 0x0010
+	Access Method: General-purpose non-volatile data functions
+	Access Address: 0x0000
+	Status: Valid, Not Full
+	Change Token: 0x0000001D
+	Header Format: Type 1
+	Supported Log Type Descriptors: 3
+	Descriptor 1: POST error
+	Data Format 1: POST results bitmap
+	Descriptor 2: Single-bit ECC memory error
+	Data Format 2: Multiple-event
+	Descriptor 3: Multi-bit ECC memory error
+	Data Format 3: Multiple-event
+
+Handle 0x001A, DMI type 23, 13 bytes
+System Reset
+	Status: Enabled
+	Watchdog Timer: Present
+	Boot Option: Do Not Reboot
+	Boot Option On Limit: Do Not Reboot
+	Reset Count: Unknown
+	Reset Limit: Unknown
+	Timer Interval: Unknown
+	Timeout: Unknown
+
+Handle 0x001A, DMI type 32, 20 bytes
+System Boot Information
+	Status: No errors detected
+
+```
+
+**Help:** execute the command "dmidecode -t system"
+
+**Prompt:**
+- linux$
+- linux#
+
+### iwconfig
+
+**Output:**
+```
+lo        no wireless extensions.
+
+eth0      no wireless extensions.
+
+wlan0     IEEE 802.11  ESSID:"My_home"  
+          Mode:Managed  Frequency:5.18 GHz  Access Point: AA:AA:AA:AA:AA:AA   
+          Bit Rate=24 Mb/s   Tx-Power=31 dBm   
+          Retry short limit:7   RTS thr:off   Fragment thr:off
+          Encryption key:off
+          Power Management:on
+          Link Quality=56/70  Signal level=-54 dBm  
+          Rx invalid nwid:0  Rx invalid crypt:0  Rx invalid frag:0
+          Tx excessive retries:155  Invalid misc:0   Missed beacon:0
+
+wlan1     IEEE 802.11  ESSID:off/any  
+          Mode:Managed  Access Point: Not-Associated   Tx-Power=20 dBm   
+          Retry short limit:7   RTS thr:off   Fragment thr:off
+          Power Management:off
+
+wlan2     IEEE 802.11  ESSID:"My_other_home"  
+          Mode:Managed  Frequency:5.22 GHz  Access Point: AA:AA:AA:AA:AA:AA   
+          Bit Rate=200 Mb/s   Tx-Power=31 dBm   
+          Retry short limit:7   RTS thr:off   Fragment thr:off
+          Encryption key:off
+          Power Management:on
+          Link Quality=62/70  Signal level=-48 dBm  
+          Rx invalid nwid:0  Rx invalid crypt:0  Rx invalid frag:0
+          Tx excessive retries:7  Invalid misc:0   Missed beacon:0
+
+wlan3     unassociated  Nickname:"<WIFI@REALTEK>"
+          Mode:Managed  Frequency=5.18 GHz  Access Point: Not-Associated   
+          Sensitivity:0/0  
+          Retry:off   RTS thr:off   Fragment thr:off
+          Power Management:off
+          Link Quality:0  Signal level:0  Noise level:0
+          Rx invalid nwid:0  Rx invalid crypt:0  Rx invalid frag:0
+          Tx excessive retries:0  Invalid misc:0   Missed beacon:0
+        
+wlan4     IEEE 802.11AX  ESSID:"My_home"  Nickname:"<WIFI@REALTEK>"
+          Mode:Managed  Frequency:5.18 GHz  Access Point: AA:AA:AA:AA:AA:AA   
+          Bit Rate:574 Mb/s   Sensitivity:0/0  
+          Retry:off   RTS thr:off   Fragment thr:off
+          Power Management:off
+          Link Quality=58/100  Signal level=58/100  Noise level=0/100
+          Rx invalid nwid:0  Rx invalid crypt:0  Rx invalid frag:0
+          Tx excessive retries:0  Invalid misc:0   Missed beacon:0
+
+wlan5     IEEE 802.11bgn  ESSID:"HS"  Nickname:"<WIFI@REALTEK>"
+          Mode:Managed  Frequency:2.452 GHz  Access Point: AA:AA:AA:AA:AA:AA   
+          Bit Rate:300 Mb/s   Sensitivity:0/0  
+          Retry:off   RTS thr:off   Fragment thr:off
+          Power Management:off
+          Link Quality=60/100  Signal level=60/100  Noise level=0/100
+          Rx invalid nwid:0  Rx invalid crypt:0  Rx invalid frag:0
+          Tx excessive retries:0  Invalid misc:0   Missed beacon:0
+
+wlan6    IEEE 802.11  ESSID:"HS"  
+          Mode:Managed  Frequency:2.452 GHz  Access Point: AA:AA:AA:AA:AA:AA   
+          Bit Rate=72.2 Mb/s   Tx-Power=31 dBm   
+          Retry short limit:7   RTS thr:off   Fragment thr:off
+          Power Management:on
+          Link Quality=62/70  Signal level=-48 dBm  
+          Rx invalid nwid:0  Rx invalid crypt:0  Rx invalid frag:0
+          Tx excessive retries:4  Invalid misc:0   Missed beacon:0
+
+```
+
+**Help:** execute the command "iwconfig"
+
+**Prompt:**
+- linux$
+- linux#
+
+### iwlist wlan0 scanning
+
+**Output:**
+```
+wlan1     Scan completed :
+          Cell 01 - Address: AA:AA:AA:AA:AA:AA
+                    ESSID:""
+                    Protocol:IEEE 802.11bgn
+                    Mode:Master
+                    Frequency:2.422 GHz (Channel 3)
+                    Encryption key:on
+                    Bit Rates:780 Mb/s
+                    Extra:rsn_ie=30140100000fac040100000fac040100000fac020000
+                    IE: IEEE 802.11i/WPA2 Version 1
+                        Group Cipher : CCMP
+                        Pairwise Ciphers (1) : CCMP
+                        Authentication Suites (1) : PSK
+                    Quality=0/100  Signal level=57/100  
+                    Extra:fm=0002
+          Cell 03 - Address: AA:AA:AA:AA:AA:AA
+                    ESSID:"Awdin"
+                    Protocol:IEEE 802.11bgn
+                    Mode:Master
+                    Frequency:2.422 GHz (Channel 3)
+                    Encryption key:on
+                    Bit Rates:780 Mb/s
+                    Extra:rsn_ie=30140100000fac040100000fac040100000fac020000
+                    IE: IEEE 802.11i/WPA2 Version 1
+                        Group Cipher : CCMP
+                        Pairwise Ciphers (1) : CCMP
+                        Authentication Suites (1) : PSK
+                    IE: Unknown: DD9F0050F204104A0001101044000102103B00010310470010BC329E001DD811B286010000000000011021001852616C696E6B20546563686E6F6C6F67792C20436F72702E1023001C52616C696E6B20576972656C6573732041636365737320506F696E74102400065254323836301042000831323334353637381054000800060050F20400011011000B52616C696E6B4150535F3010080002008C103C000101
+                    Quality=36/100  Signal level=56/100  
+                    Extra:fm=0003
+          Cell 05 - Address: AA:AA:AA:AA:AA:AA
+                    ESSID:"HS"
+                    Protocol:IEEE 802.11bgn
+                    Mode:Master
+                    Frequency:2.452 GHz (Channel 9)
+                    Encryption key:off
+                    Bit Rates:300 Mb/s
+                    Quality=59/100  Signal level=59/100  
+                    Extra:fm=0003
+          Cell 07 - Address: AA:AA:AA:AA:AA:AA
+                    ESSID:"Some-SSID2"
+                    Protocol:IEEE 802.11gn
+                    Mode:Master
+                    Frequency:2.462 GHz (Channel 11)
+                    Encryption key:on
+                    Bit Rates:1.17 Gb/s
+                    Extra:rsn_ie=30140100000fac040100000fac040100000fac020000
+                    IE: IEEE 802.11i/WPA2 Version 1
+                        Group Cipher : CCMP
+                        Pairwise Ciphers (1) : CCMP
+                        Authentication Suites (1) : PSK
+                    Quality=20/100  Signal level=72/100  
+                    Extra:fm=0003
+          Cell 49 - Address: AA:AA:AA:AA:AA:AA
+                    ESSID:"Some-SSID"
+                    Protocol:IEEE 802.11AC
+                    Mode:Master
+                    Frequency:5.805 GHz
+                    Encryption key:on
+                    Bit Rates:867 Mb/s
+                    Extra:rsn_ie=30160100000fac040100000fac040100000fac023c000000
+                    IE: IEEE 802.11i/WPA2 Version 1
+                        Group Cipher : CCMP
+                        Pairwise Ciphers (1) : CCMP
+                        Authentication Suites (1) : PSK
+                    IE: Unknown: DD5C0050F204104A00011010440001021049000600372A0001201054000800070050F20000001011000A53595332312D303033341049002600013720010001072002000A53595332312D303033342005000C3137322E32302E322E323032
+                    Quality=0/100  Signal level=38/100  
+                    Extra:fm=0002
+
+
+```
+
+**Help:** execute the command "iwlist wlan0 scanning"
+
+**Prompt:**
+- linux$
+- linux#
+
+### nmcli connection show
+
+**Output:**
+```
+NAME                        UUID                                  TYPE      DEVICE 
+Wired connection 1          4c73e12a-1934-3ea9-96bc-b13580626d18  ethernet  eth0   
+lo                          8fa1d0f5-729e-47d6-b791-ba82a1ecff0c  loopback  lo     
+My_other_home               a48f5437-163b-4fb0-983f-c98d0fa117c6  wifi      wlan0  
+My_home                     2c794a07-a61d-4276-bc16-c90459cb17ab  wifi      --  
+
+```
+
+**Help:** execute the command "nmcli connection show"
+
+**Prompt:**
+- linux$
+- linux#
+
+### pct config 1
+
+**Output:**
+```
+
+arch: amd11
+cores: 1111
+cpulimit: 1
+cpuunits: 1111
+description:  Something really bad
+features: nesting=1
+hostname: ntc_templates
+memory: 1111
+net0: name=eth0,bridge=vmbr0,firewall=1,gw=1.1.1.1,hwaddr=AA:AA:AA:AA:AA:AA,ip=1.1.1.2/8,type=veth
+onboot: 1
+ostype: ubuntu
+rootfs: local:1/vm-1-disk-0.raw,size=1000G
+swap: 1111
+unprivileged: 0
+lxc.apparmor.profile: unconfined
+lxc.cgroup.devices.allow: a
+lxc.apparmor.profile: unconfined
+lxc.cgroup.devices.allow: a
+tags: tag1,tag2,tag3
+
+```
+
+**Help:** execute the command "pct config 1"
+
+**Prompt:**
+- linux$
+- linux#
+
+### pct list
+
+**Output:**
+```
+
+VMID       Status     Lock         Name                
+100        stopped                 netmiko       
+101        stopped                 ntc_templates    
+1001       running                 something
+```
+
+**Help:** execute the command "pct list"
+
+**Prompt:**
+- linux$
+- linux#
+
+### pveversion
+
+**Output:**
+```
+pve-manager/1.1-1/101a1111 (running kernel: 1.1.11-11-pve)
+```
+
+**Help:** execute the command "pveversion"
+
+**Prompt:**
+- linux$
+- linux#
+
+### qm config 1
+
+**Output:**
+```
+
+bootdisk: ide0
+cores: 2
+cpulimit: 1
+ide0: local:111/vm-111-disk-0.qcow2,size=10G
+ide2: local:iso/ubuntu-24.04-live-server-amd64.iso,media=cdrom
+memory: 1111
+name: Super-Linux-Proxmox
+net0: e1000=AA:AA:AA:AA:AA:AA,bridge=vmbr0
+numa: 0
+onboot: 1
+ostype: other
+smbios1: uuid=00a0a000-0aa0-0a00-a0aa-0aa0a0000a00
+sockets: 1
+
+```
+
+**Help:** execute the command "qm config 1"
+
+**Prompt:**
+- linux$
+- linux#
+
+### qm list
+
+**Output:**
+```
+
+      VMID NAME                 STATUS     MEM(MB)    BOOTDISK(GB) PID       
+       100 Screen-Sun-AAAAAAA   running    1111              11.00 1111111   
+
+```
+
+**Help:** execute the command "qm list"
+
+**Prompt:**
+- linux$
+- linux#
+
+### top
+
+**Output:**
+```
+top - 12:33:53 up  2:11,  5 users,  load average: 0.12, 0.40, 0.66
+Tasks: 200 total,   1 running, 189 sleeping,   5 stopped,   5 zombie
+%Cpu(s): 12.5 us, 12.5 sy,  0.0 ni, 62.5 id, 12.5 wa,  0.0 hi,  0.0 si,  0.0 st 
+MiB Mem :   7809.9 total,   4753.7 free,   2052.9 used,   1126.5 buff/cache     
+MiB Swap:    512.0 total,    512.0 free,      0.0 used.   5757.0 avail Mem 
+
+    PID USER      PR  NI    VIRT    RES    SHR S  %CPU  %MEM     TIME+ COMMAND
+  19516 admin     20   0   28.7g 880836  52224 S  12.5  11.0   6:51.26 node
+  30427 admin     20   0   11708   4864   2816 R   6.2   0.1   0:00.03 top
+      1 root      20   0  168332  11152   8400 S   0.0   0.1   0:01.14 systemd
+      4 root       0 -20       0      0      0 I   0.0   0.0   0:00.00 kworker/R-rcu_g
+    395 systemd+  20   0   90708   6784   5888 S   0.0   0.1   0:00.18 systemd-timesyn
+    397 root       0 -20       0      0      0 I   0.0   0.0   0:00.68 kworker/u13:1-brcmf_wq/mmc1:0001:1
+    402 root     -51   0       0      0      0 S   0.0   0.0   0:00.00 irq/41-vc4 hdmi hpd connected
+  30343 admin     20   0    5200   1408   1408 S   0.0   0.0   0:00.00 sleep
+```
+
+**Help:** execute the command "top"
+
+**Prompt:**
+- linux$
+- linux#
+
+### vzlist
+
+**Output:**
+```
+      CTID      NPROC STATUS    IP_ADDR         HOSTNAME
+      1110          1 running   -               something
+      1111        111 running   192.168.0.1     something-bad
+      1112         11 running   -               something-ugly
+      1113         11 running   -               something-good
+```
+
+**Help:** execute the command "vzlist"
+
+**Prompt:**
+- linux$
+- linux#
+

--- a/docs/platforms/mikrotik_routeros.md
+++ b/docs/platforms/mikrotik_routeros.md
@@ -467,3 +467,464 @@ add address=10.80.90.5/27 comment="test comment" disabled=yes interface=eth3_vla
 **Prompt:**
 - [admin@mikrotik_routeros] >
 
+### interface bonding print detail
+
+**Output:**
+```
+Flags: X - disabled, R - running
+ 0  R ;;; To Cisco Te1/3 - Te1/4
+      name="bond1" mtu=9000 mac-address=4C:5E:0C:14:3F:9D arp=enabled arp-timeout=auto slaves=sfp-sfpplus7,sfp-sfpplus8 mode=802.3ad primary=none link-monitoring=mii arp-interval=100ms arp-ip-targets="" mii-interval=100ms down-delay=0ms up-delay=0ms lacp-rate=1sec transmit-hash-policy=layer-3-and-4 min-links=0
+
+```
+
+**Help:** execute the command "interface bonding print detail"
+
+**Prompt:**
+- [admin@mikrotik_routeros] >
+
+### interface bridge host print terse without-paging
+
+**Output:**
+```
+0 D E  mac-address=11:22:33:44:55:01 interface=ether4 bridge=lan-bridge on-interface=ether4
+1 D E  mac-address=11:22:33:44:55:02 interface=ether3 bridge=lan-bridge on-interface=ether3
+2 DLE  mac-address=11:22:33:44:55:03 interface=lan-bridge bridge=lan-bridge on-interface=lan-bridge
+3 DL   mac-address=11:22:33:44:55:04 interface=ether4 bridge=lan-bridge on-interface=ether4
+4  I   mac-address=11:22:33:44:55:05 interface=lan-bridge bridge=lan-bridge
+5  I   comment=test comment mac-address=11:22:33:44:55:06 interface=lan-bridge bridge=lan-bridge
+6 XI   mac-address=11:22:33:44:55:07 interface=lan-bridge bridge=lan-bridge
+7 XI   mac-address=11:22:33:44:55:08 vid=123 interface=lan-bridge bridge=lan-bridge
+
+```
+
+**Help:** execute the command "interface bridge host print terse without-paging"
+
+**Prompt:**
+- [admin@mikrotik_routeros] >
+
+### interface print brief
+
+**Output:**
+```
+Flags: D - dynamic, X - disabled, R - running, S - slave
+ #     NAME                                TYPE       ACTUAL-MTU L2MTU  MAX-L2MTU MAC-ADDRESS
+ 0     ether1                              ether            1500  1598       2028 12:34:56:78:90:AA
+ 1 D   ether2                              ether            1500  1598            12:34:56:78:90:AB
+ 2  R  ether3                              ether            1500                  12:34:56:78:90:AC
+ 3   S ether4                              ether            1500  1598
+ 4 DR  ether5                              ether            1500
+ 5  RS ether6                              ether            1500  1598       2028 12:34:56:78:90:AD
+ 6 D S lte1                                lte              1500  1598       2028 12:34:56:78:90:AE
+ 7 DRS pptp-out1                           pptp-out         1450  1598       2028
+
+```
+
+**Help:** execute the command "interface print brief"
+
+**Prompt:**
+- [admin@mikrotik_routeros] >
+
+### interface print detail
+
+**Output:**
+```
+Flags: D - dynamic, X - disabled, R - running, S - slave
+ 0     name="ether1" default-name="ether1" type="ether" mtu=1500 actual-mtu=1500 l2mtu=1598 max-l2mtu=2028 mac-address=12:34:56:78:90:AA last-link-down-time=jul/09/2023 07:18:33 last-link-up-time=jul/09/2023 07:18:42 link-downs=20
+
+ 1 D   name="ether2" default-name="ether2" type="ether" mtu=1500 actual-mtu=1500 l2mtu=1598 max-l2mtu=2028 mac-address=12:34:56:78:90:AB last-link-down-time=jul/09/2023 07:18:34 last-link-up-time=jul/09/2023 07:18:43 link-downs=20
+
+ 2  R  name="ether3" default-name="ether3" type="ether" mtu=1500 actual-mtu=1500 l2mtu=1598 max-l2mtu=2028 mac-address=12:34:56:78:90:AC link-downs=0
+
+ 3   S name="ether4" default-name="ether4" type="ether" mtu=1500 actual-mtu=1500 l2mtu=1598 max-l2mtu=2028 mac-address=12:34:56:78:90:AD link-downs=0
+
+ 4 DR  name="ether5" default-name="ether5" type="ether" mtu=1500 actual-mtu=1500 l2mtu=1598 max-l2mtu=2028 mac-address=12:34:56:78:90:AE link-downs=0
+
+ 5  RS name="ether6" default-name="ether6" type="ether" mtu=1500 actual-mtu=1500 l2mtu=1598 max-l2mtu=2028 mac-address=12:34:56:78:90:AF link-downs=0
+
+ 6 D S name="lte1" type="lte" mtu=1500 actual-mtu=1500 mac-address=12:34:56:78:90:BA last-link-down-time=jul/21/2023 07:47:40 last-link-up-time=jul/21/2023 07:47:46 link-downs=114
+
+ 7 DRS ;;; very very long
+multiline description 
+       name="pptp-out1" type="pptp-out" mtu=1450 actual-mtu=1450 last-link-down-time=jul/21/2023 07:47:03 last-link-up-time=jul/21/2023 07:47:56 link-downs=304
+ 
+ 8  RS ;;; Free Wi-Fi HTTPS
+       name="pptp-to-AH1100-HS" type="pptp-out" mtu=1596 actual-mtu=1596 last-link-down-time=nov/03/1970 12:24:10 last-link-up-time=nov/03/1970 12:24:10 link-downs=38 
+
+```
+
+**Help:** execute the command "interface print detail"
+
+**Prompt:**
+- [admin@mikrotik_routeros] >
+
+### interface vlan print detail
+
+**Output:**
+```
+Flags: X - disabled, R - running
+ 0 R ;;; MGMT
+     name="vlan1@bond1" mtu=1574 l2mtu=9212 mac-address=AA:BB:CC:11:22:33 arp=enabled arp-timeout=auto loop-protect=default loop-protect-status=off loop-protect-send-interval=5s loop-protect-disable-time=5m vlan-id=1 interface=bond1 use-service-tag=no
+
+ 1 R ;;; INET
+     name="vlan2@bond1" mtu=1574 l2mtu=9212 mac-address=AA:BB:CC:11:22:33 arp=enabled arp-timeout=auto loop-protect=default loop-protect-status=off loop-protect-send-interval=5s loop-protect-disable-time=5m vlan-id=2 interface=bond1 use-service-tag=no
+
+ 2 R ;;; MGMT
+     name="vlan10@vlan975@sfp-sfpplus1" mtu=1574 l2mtu=9208 mac-address=AA:BB:CC:11:22:33 arp=enabled arp-timeout=auto loop-protect=default loop-protect-status=off loop-protect-send-interval=5s loop-protect-disable-time=5m vlan-id=10 interface=vlan975@sfp-sfpplus1 use-service-tag=no
+
+ 3 R ;;; INET
+     name="vlan11@vlan975@sfp-sfpplus1" mtu=1500 l2mtu=9208 mac-address=AA:BB:CC:11:22:33 arp=enabled arp-timeout=auto loop-protect=default loop-protect-status=off loop-protect-send-interval=5s loop-protect-disable-time=5m vlan-id=11 interface=vlan975@sfp-sfpplus1 use-service-tag=no
+
+ 4 R ;;; INET
+     name="vlan12@vlan975@sfp-sfpplus1" mtu=1500 l2mtu=9208 mac-address=AA:BB:CC:11:22:33 arp=enabled arp-timeout=auto loop-protect=default loop-protect-status=off loop-protect-send-interval=5s loop-protect-disable-time=5m vlan-id=12 interface=vlan975@sfp-sfpplus1 use-service-tag=no
+
+ 5 R ;;; INET
+     name="vlan111@sfp-sfpplus1" mtu=1500 l2mtu=9212 mac-address=AA:BB:CC:11:22:33 arp=enabled arp-timeout=auto loop-protect=default loop-protect-status=off loop-protect-send-interval=5s loop-protect-disable-time=5m vlan-id=111 interface=sfp-sfpplus1 use-service-tag=no
+
+ 6 R ;;; Intercap
+     name="vlan975@sfp-sfpplus1" mtu=1500 l2mtu=9212 mac-address=AA:BB:CC:11:22:33 arp=enabled arp-timeout=auto loop-protect=default loop-protect-status=off loop-protect-send-interval=5s loop-protect-disable-time=5m vlan-id=975 interface=sfp-sfpplus1 use-service-tag=no
+
+ 7 R name="vlan4050@sfp-sfpplus11" mtu=9212 l2mtu=9212 mac-address=AA:BB:CC:11:22:33 arp=enabled arp-timeout=auto loop-protect=default loop-protect-status=off loop-protect-send-interval=5s loop-protect-disable-time=5m vlan-id=4050 interface=sfp-sfpplus11 use-service-tag=no
+
+```
+
+**Help:** execute the command "interface vlan print detail"
+
+**Prompt:**
+- [admin@mikrotik_routeros] >
+
+### interface wireguard peers print terse without-paging
+
+**Output:**
+```
+0 interface=wg1 name=peer2 public-key=dcKiJ0TpLjtSWZh3G0ILJ9cL56fTIfHBAsZsXdDIlFM= private-key= endpoint-address= endpoint-port=0 current-endpoint-address=192.168.93.254 current-endpoint-port=50610 allowed-address=192.168.100.0/24 preshared-key= client-address=192.168.100.2/32 client-endpoint= rx=180 tx=92 last-handshake=20s
+1 interface=wg1 name=peer2 public-key=dcKiJ0TpLjtSWZh3G0ILJ9cL56fTIfHBAsZsXdDIlFM= private-key= endpoint-address= endpoint-port=0 current-endpoint-address=192.168.93.254 current-endpoint-port=50610 allowed-address=192.168.100.0/24 preshared-key= client-address=192.168.100.2/32 client-endpoint= rx=5.3KiB tx=1472 last-handshake=1m45s
+```
+
+**Help:** execute the command "interface wireguard peers print terse without-paging"
+
+**Prompt:**
+- [admin@mikrotik_routeros] >
+
+### interface wireguard print terse without-paging
+
+**Output:**
+```
+0 R name=wg1 mtu=1420 listen-port=13231 private-key=+NLZfYaDm6qMfroVg6wf0pZ+0PyriGCd8oO/HkyQqFg= public-key=oeyOeBGeRb8UfvpqFT8XkaG1euGU0viW7Ep4fZEQKyM=
+1 R name=wg2 mtu=1420 listen-port=13232 private-key=YEvXxfzV5w8hiS4qZ4keoCe2gsYBJWuOxS3V38rpWH8= public-key=LZoLYLOGTqe2p+S3jcdNAKABYEEFRChELB1p34H2STY=
+```
+
+**Help:** execute the command "interface wireguard print terse without-paging"
+
+**Prompt:**
+- [admin@mikrotik_routeros] >
+
+### ip arp print
+
+**Output:**
+```
+Flags: X - disabled, I - invalid, H - DHCP, D - dynamic, P - published, C - complete
+ #    ADDRESS         MAC-ADDRESS       INTERFACE
+ 0 DC 10.160.1.230    12:34:56:78:90:AA ether2
+ 1    10.152.1.230    12:34:56:78:90:AB ether5
+ 2    10.152.1.231    12:34:56:78:90:AC
+ 3    10.152.1.232                      ether4
+ 4 DC 10.152.1.233
+
+```
+
+**Help:** execute the command "ip arp print"
+
+**Prompt:**
+- [admin@mikrotik_routeros] >
+
+### ip arp print terse without-paging
+
+**Output:**
+```
+ 0 DC address=10.160.1.230 mac-address=12:34:56:78:90:AA interface=ether2_BOX published=no
+ 1    address=10.152.1.230 mac-address=12:34:56:78:90:AB interface=ether5_KFCcisco published=no
+
+```
+
+**Help:** execute the command "ip arp print terse without-paging"
+
+**Prompt:**
+- [admin@mikrotik_routeros] >
+
+### ip dhcp-server lease print
+
+**Output:**
+```
+Flags: X - disabled, R - radius, D - dynamic, B - blocked
+ #   ADDRESS          MAC-ADDRESS        HOST-NAME  SERVER         RATE-LIMIT  STATUS  LAST-SEEN
+ 0   192.168.60.254                                 *1                         bound   35w13h13m15s
+ 1 X 192.168.61.254                      MikroTik   DHCPv4_Server              waiting never
+ 1   192.168.62.254   12:34:56:78:90:AA             DHCPv4_Server              waiting never
+ 2 D 192.168.88.254   12:34:56:78:90:AB  MikroTik   DHCPv4_Server              waiting never
+
+```
+
+**Help:** execute the command "ip dhcp-server lease print"
+
+**Prompt:**
+- [admin@mikrotik_routeros] >
+
+### ip dhcp-server lease print terse without-paging
+
+**Output:**
+```
+ 0 D address=192.168.69.254 address-lists="" server=*1 dhcp-option="" status=conflict expires-after=6m59s last-seen=35w12h24m42s active-address=192.168.69.254 active-server=*1 src-mac-address=12:34:56:78:90:AB
+ 1   address=172.16.16.120 mac-address=30:07:4D:F5:07:49 client-id="1:30:7:4d:f5:7:49" address-lists="" server=defconf dhcp-option="" status=bound expires-after=8m55s last-seen=1m5s active-address=172.16.16.120 active-mac-address=30:07:4D:F5:07:49 active-client-id="1:30:7:4d:f5:7:49" active-server=defconf host-name="Galaxy-S8"
+
+```
+
+**Help:** execute the command "ip dhcp-server lease print terse without-paging"
+
+**Prompt:**
+- [admin@mikrotik_routeros] >
+
+### ip dns cache print terse without-paging
+
+**Output:**
+```
+0 type=A data=216.58.215.142 name=google.com ttl=1m44s
+1 type=AAAA data=2a00:1450:4003:804::200e name=google.com ttl=1m24s
+```
+
+**Help:** execute the command "ip dns cache print terse without-paging"
+
+**Prompt:**
+- [admin@mikrotik_routeros] >
+
+### ip firewall connection print terse without-paging
+
+**Output:**
+```
+0 SAC protocol=tcp src-address=172.31.255.29 src-port=56454 dst-address=172.31.255.30 dst-port=22 reply-src-address=172.31.255.30 reply-src-port=22 reply-dst-address=172.31.255.29 reply-dst-port=56454 tcp-state=established timeout=23h59m52s orig-packets=520 orig-bytes=47 603 orig-fasttrack-packets=0 orig-fasttrack-bytes=0 repl-packets=363 repl-bytes=53 460 repl-fasttrack-packets=0 repl-fasttrack-bytes=0 orig-rate=1760bps repl-rate=6.4kbps
+1 S Cs protocol=icmp src-address=192.168.80.254 dst-address=216.58.215.142 reply-src-address=216.58.215.142 reply-dst-address=172.31.255.30 icmp-type=8 icmp-code=0 icmp-id=69 timeout=9s orig-packets=7 269 orig-bytes=610 596 orig-fasttrack-packets=0 orig-fasttrack-bytes=0 repl-packets=7 269 repl-bytes=610 596 repl-fasttrack-packets=0 repl-fasttrack-bytes=0 orig-rate=1344bps repl-rate=1344bps
+
+```
+
+**Help:** execute the command "ip firewall connection print terse without-paging"
+
+**Prompt:**
+- [admin@mikrotik_routeros] >
+
+### ip hotspot ip-binding print terse without-paging
+
+**Output:**
+```
+0 P comment=Sonda_Mantenimiento mac-address=D8:3A:DD:48:B6:1C server=server1 type=bypassed
+1   mac-address=B0:4A:B4:76:A9:5D address=10.0.1.98 to-address=10.0.1.98 server=server1
+
+```
+
+**Help:** execute the command "ip hotspot ip-binding print terse without-paging"
+
+**Prompt:**
+- [admin@mikrotik_routeros] >
+
+### ip neighbor print detail
+
+**Output:**
+```
+ 0 interface=ether1 address=10.159.1.159 address4=10.159.1.159 mac-address=12:34:56:78:90:AB identity="MikroTik-Dev" platform="MikroTik" version="6.48.6 (long-term)" unpack=none age=17s uptime=1w5d2h31m30s software-id="1234-ABCD" board="RB750UPr2" interface-name="ether2" system-description="MikroTik RouterOS 6.48.6 (long-term) RB750UPr2" system-caps=bridge,router system-caps-enabled=bridge,wlan-ap,router
+
+```
+
+**Help:** execute the command "ip neighbor print detail"
+
+**Prompt:**
+- [admin@mikrotik_routeros] >
+
+### ip route print detail
+
+**Output:**
+```
+Flags: X - disabled, A - active, D - dynamic, C - connect, S - static, r - rip, b - bgp, o - ospf, m - mme, B - blackhole, U - unreachable, P - prohibit
+ 0 ADS  dst-address=0.0.0.0/0 gateway=192.168.8.1 gateway-status=192.168.8.1 reachable via  lte1 distance=2 scope=30 target-scope=10 vrf-interface=lte1
+
+ 1 ADC  dst-address=10.160.1.228/30 pref-src=10.160.1.230 gateway=ether1 gateway-status=ether1 reachable distance=0 scope=10
+
+ 2 A S  dst-address=10.213.20.64/32 gateway=10.160.1.229 gateway-status=10.160.1.229 reachable via  ether1 distance=1 scope=30 target-scope=10
+
+ 3 A S  ;;; to Internet
+        dst-address=0.0.0.0/0 gateway=10.160.1.230 gateway-status=10.160.1.230 reachable via ether2 distance=1 scope=30 target-scope=10 routing-mark=to-reserve
+
+ 4 A S  dst-address=0.0.0.0/0 gateway=1.2.3.4 gateway-status=1.2.3.4 recursive via 10.152.1.230 ether5 distance=1 scope=30 target-scope=10 routing-mark=Free_Wi-Fi
+
+ 5 A SB dst-address=10.0.0.0/8 type=blackhole distance=100 routing-mark=Free_Wi-Fi
+
+ 6 A S  dst-address=0.0.0.0/0 gateway=1.2.3.4 gateway-status=1.2.3.4 recursive via 10.152.1.230 ether5 check-gateway=ping distance=1 scope=30 target-scope=10
+
+```
+
+**Help:** execute the command "ip route print detail"
+
+**Prompt:**
+- [admin@mikrotik_routeros] >
+
+### ip route print terse without-paging
+
+**Output:**
+```
+ 0 A S  dst-address=0.0.0.0/0 gateway=192.168.8.1 gateway-status=192.168.8.1 reachable via  lte1 distance=2 scope=30 target-scope=10 vrf-interface=lte1
+ 1 ADC  dst-address=10.160.1.228/30 pref-src=10.160.1.230 gateway=ether1 gateway-status=ether1 reachable distance=0 scope=10
+ 2 A S  comment=to Internet dst-address=134.0.0.0/8 gateway=10.160.1.230 gateway-status=10.160.1.230 reachable via  ether2 distance=1 scope=30 target-scope=10 routing-mark=reserve
+ 3 A S  dst-address=172.0.0.0/8 gateway=1.2.3.4 gateway-status=1.2.3.4 recursive via 10.152.1.230 ether5 distance=1 scope=30 target-scope=10 routing-mark=Free_Wi-Fi
+ 4 A SB dst-address=10.0.0.0/8 type=blackhole distance=100 routing-mark=Free_Wi-Fi
+
+```
+
+**Help:** execute the command "ip route print terse without-paging"
+
+**Prompt:**
+- [admin@mikrotik_routeros] >
+
+### routing bgp peer print status
+
+**Output:**
+```
+Flags: X - disabled, E - established
+ 0   name="peer1" instance=default remote-address=192.168.1.134 remote-as=65001 tcp-md5-key="" nexthop-choice=default multihop=no route-reflect=no hold-time=3m
+     ttl=255 in-filter="" out-filter="" address-families=ip,ipv6 default-originate=never remove-private-as=no as-override=no passive=no use-bfd=no state=opensent
+
+```
+
+**Help:** execute the command "routing bgp peer print status"
+
+**Prompt:**
+- [admin@mikrotik_routeros] >
+
+### routing ospf interface print terse
+
+**Output:**
+```
+ 0  P interface=all cost=10 priority=1 authentication=none authentication-key=foo authentication-key-id=1 network-type=broadcast instance-id=0 retransmit-interval=5s transmit-delay=1s hello-interval=10s dead-interval=40s use-bfd=no
+ 1    comment=ospf comment interface=vlan906@bond1 cost=10 priority=1 authentication=none authentication-key="bar" authentication-key-id=1 network-type=broadcast instance-id=0 retransmit-interval=5s transmit-delay=1s hello-interval=10s dead-interval=40s use-bfd=no
+ 2 DP interface=lo0 cost=10 priority=1 authentication=none authentication-key="" authentication-key-id=1 network-type=broadcast instance-id=0 retransmit-interval=5s transmit-delay=1s hello-interval=10s dead-interval=40s use-bfd=no
+
+```
+
+**Help:** execute the command "routing ospf interface print terse"
+
+**Prompt:**
+- [admin@mikrotik_routeros] >
+
+### routing ospf neighbor print
+
+**Output:**
+```
+ 0 instance=default router-id=89.188.172.2 address=89.188.172.81 interface=vlan68 priority=128 dr-address=0.0.0.0 backup-dr-address=0.0.0.0 state="Full" state-changes=5 ls-retransmits=0 ls-requests=0 db-summaries=0 adjacency=7w5d8h40m21s
+
+ 1 instance=default router-id=89.188.172.3 address=89.188.172.93 interface=vlan71 priority=128 dr-address=0.0.0.0 backup-dr-address=0.0.0.0 state="Full" state-changes=5 ls-retransmits=0 ls-requests=0 db-summaries=0 adjacency=7w5d8h40m21s
+
+```
+
+**Help:** execute the command "routing ospf neighbor print"
+
+**Prompt:**
+- [admin@mikrotik_routeros] >
+
+### system identity print
+
+**Output:**
+```
+  name: Mikrotik-Device_Name
+
+```
+
+**Help:** execute the command "system identity print"
+
+**Prompt:**
+- [admin@mikrotik_routeros] >
+
+### system resource print
+
+**Output:**
+```
+                   uptime: 6w5d11h55m45s
+                  version: 6.48.6 (long-term)
+               build-time: Dec/03/2021 12:15:05
+              free-memory: 40.2MiB
+             total-memory: 64.0MiB
+                      cpu: MIPS 24Kc V7.4
+                cpu-count: 1
+            cpu-frequency: 650MHz
+                 cpu-load: 1%
+           free-hdd-space: 1196.0KiB
+          total-hdd-space: 16.0MiB
+  write-sect-since-reboot: 44663
+         write-sect-total: 572180
+               bad-blocks: 0%
+        architecture-name: mipsbe
+               board-name: hEX PoE lite
+                 platform: MikroTik
+
+```
+
+**Help:** execute the command "system resource print"
+
+**Prompt:**
+- [admin@mikrotik_routeros] >
+
+### tool profile
+
+**Output:**
+```
+NAME                    CPU        USAGE
+spi                                   1%
+console                               0%
+firewall                            0.5%
+networking                            0%
+management                          0.5%
+profiling                             0%
+unclassified                        0.5%
+total                               2.5%
+
+```
+
+**Help:** execute the command "tool profile"
+
+**Prompt:**
+- [admin@mikrotik_routeros] >
+
+### tool speed-test address
+
+**Output:**
+```
+address: 192.168.88.1
+              status: tcp upload
+      time-remaining: 23s
+    ping-min-avg-max: 52.4ms / 86.1ms / 246ms
+  jitter-min-avg-max: 12us / 21.3ms / 158ms
+                loss: 0% (0/200)
+        tcp-download: 921Mbps local-cpu-load:30%
+          tcp-upload: 920Mbps local-cpu-load:30% remote-cpu-load:25%
+        udp-download: 917Mbps local-cpu-load:6% remote-cpu-load:21%
+          udp-upload: 916Mbps local-cpu-load:20% remote-cpu-load:6%
+
+```
+
+**Help:** execute the command "tool speed-test address"
+
+**Prompt:**
+- [admin@mikrotik_routeros] >
+
+### user print
+
+**Output:**
+```
+Flags: X - disabled
+ #   NAME                     GROUP  ADDRESS            LAST-LOGGED-IN
+ 0   ;;; system default user
+     admin                    full                      jun/30/2023 01:08:59
+ 1   user1                    full                      jul/18/2023 05:12:46
+
+```
+
+**Help:** execute the command "user print"
+
+**Prompt:**
+- [admin@mikrotik_routeros] >
+

--- a/docs/platforms/paloalto_panos.md
+++ b/docs/platforms/paloalto_panos.md
@@ -877,3 +877,136 @@ total routes shown: 98
 **Prompt:**
 - paloalto_panos>
 
+### show interface all
+
+**Output:**
+```
+total configured hardware interfaces: 12
+name                    id    speed/duplex/state/fec        mac address
+--------------------------------------------------------------------------------
+ethernet1/8             23    1000/full/up/auto             00:1b:17:aa:bb:01
+ethernet1/13            28    1000/full/up/auto             00:1b:17:aa:bb:02
+ethernet1/14            29    1000/full/up/auto             00:1b:17:aa:bb:03
+ethernet1/19            34    10000/full/up/auto            00:1b:17:aa:bb:04
+ae1                     64    [n/a]/[n/a]/up/[n/a]          00:1b:17:aa:bb:40
+ae2                     65    [n/a]/[n/a]/up/[n/a]          00:1b:17:aa:bb:41
+ha1-a                   5     1000/full/up/ukn              8c:36:7a:aa:bb:b5
+ha1-b                   7     ukn/ukn/down((autoneg))/ukn   8c:36:7a:aa:bb:b4
+vlan                    1     [n/a]/[n/a]/up/[n/a]          00:1b:17:aa:bb:01
+loopback                3     [n/a]/[n/a]/up/[n/a]          00:1b:17:aa:bb:03
+tunnel                  4     [n/a]/[n/a]/up/[n/a]          00:1b:17:aa:bb:04
+hsci                    8     10000/full/up/ukn             64:7c:e8:aa:bb:08
+
+aggregation groups: 2
+ae1 members:
+  ethernet1/19 ethernet1/20
+ae2 members:
+  ethernet1/11
+
+
+total configured logical interfaces: 14
+
+name                      id    vsys zone             forwarding               tag    address
+
+------------------- ----- ---- ---------------- ------------------------ ------ ------------------
+ethernet1/8               23    3    ZONE_TECH        vr:vrf01                 0      192.0.2.1/28
+ethernet1/8.81            300   3    ZONE_TECH        vr:vrf01                 81     192.0.2.17/27
+ethernet1/13              28    5    ZONE_INET        vr:vrf02                 0      192.0.2.33/29
+                                                                                10.10.10.1/29
+ethernet1/13.388          298   2    ZONE_SDWAN       vr:vrf03                 388    192.0.2.65/27
+ethernet1/14              29    5    ZONE_INET        vr:vrf02                 0      192.0.2.97/28
+ae1                       64    2                     N/A                      0      N/A
+ae1.99                    267   2    ZONE_OTSC        vr:vrf03                 99     192.0.2.113/28
+ae5                       68    5                     vr:vrf02                 0      N/A
+ha1-a                     5     0                     ha                       0      198.51.100.1/30
+vlan                      1     1                     N/A                      0      N/A
+loopback                  3     1                     N/A                      0      N/A
+loopback.99               297   2    ZONE_CORP        vr:vrf03                 0      192.0.2.129/32
+tunnel                    4     1                     N/A                      0      N/A
+hsci                      8     0                     N/A                      0      198.51.100.5/30
+
+```
+
+**Help:** execute the command "show interface all"
+
+**Prompt:**
+- paloalto_panos>
+
+### show lacp aggregate-ethernet all
+
+**Output:**
+```
+**********************************************************************************
+AE group: ae1
+Members:                Bndl Rx state       Mux state  Sel state
+  ethernet1/19          yes  Current        Tx_Rx      Selected
+  ethernet1/20          yes  Current        Tx_Rx      Selected
+Status:           Enabled
+Mode:             Active
+Rate:             Slow
+Max-port:         8
+Fast-failover:    Disabled
+Pre-negotiation:  Enabled
+Local:            System Priority: 32768
+                  System MAC:      64:7c:e8:aa:bb:01
+                  Key:             64
+Partner:          System Priority: 65534
+                  System MAC:      0a:00:00:aa:bb:cc
+                  Key:             103
+Port State
+--------------------------------------------------------------------------------
+Interface                       Port
+                    Number Priority  Mode    Rate  Key      State
+--------------------------------------------------------------------------------
+ethernet1/19         34     32768    Active  Slow  64       0x3D
+Partner              3      1        Active  Slow  103      0x3D
+
+ethernet1/20         35     32768    Active  Slow  64       0x3D
+Partner              1003   1        Active  Slow  103      0x3D
+
+Port Counters
+--------------------------------------------------------------------------------
+Interface               LACPDUs         Marker      Marker Response       Error
+                    Sent     Recv     Sent Recv     Sent     Recv     Unknown  Illegal
+--------------------------------------------------------------------------------
+ethernet1/19         100      100      0    0        0        0        0        0
+ethernet1/20         100      100      0    0        0        0        0        0
+
+**********************************************************************************
+AE group: ae2
+Members:                Bndl Rx state       Mux state  Sel state
+  ethernet1/11          yes  Current        Tx_Rx      Selected
+Status:           Enabled
+Mode:             Active
+Rate:             Slow
+Max-port:         8
+Fast-failover:    Disabled
+Pre-negotiation:  Enabled
+Local:            System Priority: 32768
+                  System MAC:      64:7c:e8:aa:bb:01
+                  Key:             65
+Partner:          System Priority: 32768
+                  System MAC:      64:7c:e8:aa:bb:01
+                  Key:             67
+Port State
+--------------------------------------------------------------------------------
+Interface                       Port
+                    Number Priority  Mode    Rate  Key      State
+--------------------------------------------------------------------------------
+ethernet1/11         26     32768    Active  Slow  65       0x3D
+Partner              27     32768    Active  Slow  67       0x3D
+
+Port Counters
+--------------------------------------------------------------------------------
+Interface               LACPDUs         Marker      Marker Response       Error
+                    Sent     Recv     Sent Recv     Sent     Recv     Unknown  Illegal
+--------------------------------------------------------------------------------
+ethernet1/11         100      100      0    0        0        0        0        0
+
+```
+
+**Help:** execute the command "show lacp aggregate-ethernet all"
+
+**Prompt:**
+- paloalto_panos>
+

--- a/simnos/plugins/nos/platforms_yaml/alcatel_aos.yaml
+++ b/simnos/plugins/nos/platforms_yaml/alcatel_aos.yaml
@@ -28,3 +28,406 @@ commands:
     prompt:
     - "{base_prompt}>"
     - "{base_prompt}#"
+  show chassis:
+    output: "Chassis 1\n  Model Name:                    OS6350-P24,\n  Description:\
+      \                   Chassis,\n  Part Number:                   000000-00,\n\
+      \  Hardware Revision:             01,\n  Serial Number:                 AAA000000000,\n\
+      \  Manufacture Date:              JAN  1 2000,\n  Admin Status:            \
+      \      POWER ON,\n  Operational Status:            UP,\n  Number Of Resets:\
+      \              1\n  MAC Address:                   00:00:00:00:00:00,\n\nChassis\
+      \ 2\n  Model Name:                    OS6350-P24,\n  Description:          \
+      \         6350 24 PORT COPPER GE POE ,\n  Part Number:                   000000-00,\n\
+      \  Hardware Revision:             01,\n  Serial Number:                 AAA000000000,\n\
+      \  Manufacture Date:              JAN  1 2000,\n  Admin Status:            \
+      \      POWER ON,\n  Operational Status:            UP,\n  MAC Address:     \
+      \              00:00:00:00:00:00,\n\n"
+    help: execute the command "show chassis"
+    prompt: &id001
+      - '{base_prompt}>'
+      - '{base_prompt}#'
+    output_variants:
+      - "Local Chassis ID 1 (Master)\n  Model Name:                    OS6360-PH24,\n\
+        \  Module Type:                   0xa0a0000,\n  Description:             \
+        \      Chassis,\n  Part Number:                   000000-00,\n  Hardware Revision:\
+        \             01,\n  Serial Number:                 AAA000000000,\n  Manufacture\
+        \ Date:              Jan  1 2000,\n  Admin Status:                  POWER\
+        \ ON,\n  Operational Status:            UP,\n  Number Of Resets:         \
+        \     1,\n  MAC Address:                   00:00:00:00:00:00\n"
+  show interfaces alias:
+    output: " Chas/\n Slot/     Admin     Link        WTR      WTS       Alias\n Port\
+      \      Status   Status      (sec)    (msec)\n--------+----------+---------+----------+----------+-----------------------\n\
+      \ 1/1/1     enable     up      0          0          \"This is an example\"\n\
+      \ 2/1/10    enable     down    0          0          \"This_is_an_example\"\n\
+      \ 2/1/11    enable     down    0          0          \"This\"\n"
+    help: execute the command "show interfaces alias"
+    prompt: *id001
+  show interfaces ethernet:
+    output: "Slot/Port  1/1  :\n  Operational Status     : up, \"\"\n  Last Time Link\
+      \ Changed : MON JAN 08 20:38:47 ,\n  Number of Status Change: 2,\n  Type   \
+      \                : Ethernet,\n  SFP/SFP+/XFP           : Not Present,\n  MAC\
+      \ address            : aa:aa:aa:aa:aa:aa,\n  BandWidth (Megabits)   :     1000,\
+      \            Duplex           : Full,\n  Autonegotiation        :   1  [ 1000-F\
+      \ 100-F 100-H 10-F 10-H ],\n  Long Frame Size(Bytes) : 9216,\n  Rx         \
+      \     :\n  Bytes Received  :          28902644070, Unicast Frames :        \
+      \     62119123,\n  Broadcast Frames:               123797, M-cast Frames  :\
+      \               358499,\n  UnderSize Frames:                    0, OverSize\
+      \ Frames:                    0,\n  Lost Frames     :                    0, Error\
+      \ Frames   :                    0,\n  CRC Error Frames:                    0,\
+      \ Alignments Err :                    0,\n  Tx              :\n  Bytes Xmitted\
+      \   :         274375376582, Unicast Frames :             97599952,\n  Broadcast\
+      \ Frames:           1746630116, M-cast Frames  :             87217616,\n  UnderSize\
+      \ Frames:                    0, OverSize Frames:                    0,\n  Lost\
+      \ Frames     :                    0, Collided Frames:                    0,\n\
+      \  Error Frames    :                    0\nSlot/Port  1/2 :\n  Operational Status\
+      \     : down, \"Admin-Down\"\n  Last Time Link Changed : WED JAN 10 10:00:26\
+      \ ,\n  Number of Status Change: 2,\n  Type                   : Ethernet,\n \
+      \ SFP/SFP+/XFP           : GBIC_LX,\n  MAC address            : bb:bb:bb:bb:bb:bb,\n\
+      \  BandWidth (Megabits)   :     -  ,            Duplex           : -,\n  Autonegotiation\
+      \        :   1  [ 1000-F                       ],\n  Long Frame Size(Bytes)\
+      \ : 9216,\n  Rx              :\n  Bytes Received  :        1602614019301, Unicast\
+      \ Frames :           1423093884,\n  Broadcast Frames:            131096783,\
+      \ M-cast Frames  :              9298965,\n  UnderSize Frames:              \
+      \      0, OverSize Frames:                    0,\n  Lost Frames     :      \
+      \              0, Error Frames   :                    0,\n  CRC Error Frames:\
+      \                    0, Alignments Err :                    0,\n  Tx       \
+      \       :\n  Bytes Xmitted   :         313945899784, Unicast Frames :      \
+      \      702405038,\n  Broadcast Frames:                94040, M-cast Frames \
+      \ :              3193107,\n  UnderSize Frames:                    0, OverSize\
+      \ Frames:                    0,\n  Lost Frames     :                    0, Collided\
+      \ Frames:                    0,\n  Error Frames    :                    0\n"
+    help: execute the command "show interfaces ethernet"
+    prompt: *id001
+    output_variants:
+      - "Chassis/Slot/Port          : 1/1/30 \n Operational Status        : up,\n\
+        \ Port-Down/Violation Reason: None,\n Last Time Link Changed    : Sun Jan\
+        \ 08 01:14:25 2024,\n Number of Status Change   : 1,\n Type              \
+        \        : Ethernet,\n SFP/XFP                   : GBIC_LX,\n Interface Type\
+        \            : Fiber,\n EPP                       : Disabled,\n Link-Quality\
+        \              : N/A,\n MAC address               : aa:bb:cc:dd:ee:ff,\n BandWidth\
+        \ (Megabits)      :     1000,                  Duplex           : Full,\n\
+        \ Autonegotiation           :   1  [ 1000-F                       ],\n Long\
+        \ Frame Size(Bytes)    : 9216,\n Inter Frame Gap(Bytes)    : 12,\n loopback\
+        \ mode             : N/A,\n Rx              :\n Bytes Received  :        \
+        \      9419904, Unicast Frames :                    0,\n Broadcast Frames:\
+        \                    0, M-cast Frames  :                73593,\n UnderSize\
+        \ Frames:                    0, OverSize Frames:                    0,\n Lost\
+        \ Frames     :                    0, Error Frames   :                    0,\n\
+        \ CRC Error Frames:                    0, Alignments Err :               \
+        \     0,\n Tx              :\n Bytes Xmitted   :         155215209608, Unicast\
+        \ Frames :              3121178,\n Broadcast Frames:           1616888391,\
+        \ M-cast Frames  :             80210193,\n UnderSize Frames:             \
+        \       0, OverSize Frames:                    0,\n Lost Frames     :    \
+        \                0, Collided Frames:                    0,\n Error Frames\
+        \    :                    0, Collisions     :                    0,\n Late\
+        \ collisions :                    0, Exc-Collisions :                    0\n\
+        Chassis/Slot/Port          : 1/1/31 \n Operational Status        : up,\n Port-Down/Violation\
+        \ Reason: None,\n Last Time Link Changed    : Sun Jan 22 01:14:25 2024,\n\
+        \ Number of Status Change   : 1,\n Type                      : Ethernet,\n\
+        \ SFP/XFP                   : GBIC_LX,\n Interface Type            : Fiber,\n\
+        \ EPP                       : Disabled,\n Link-Quality              : N/A,\n\
+        \ MAC address               : ab:cd:ef:12:34:56,\n BandWidth (Megabits)  \
+        \    :     1000,                  Duplex           : Full,\n Autonegotiation\
+        \           :   0  [                            ],\n Long Frame Size(Bytes)\
+        \    : 9216,\n Inter Frame Gap(Bytes)    : 12,\n loopback mode           \
+        \  : N/A,\n Rx              :\n Bytes Received  :         542857246503, Unicast\
+        \ Frames :            631292769,\n Broadcast Frames:               366413,\
+        \ M-cast Frames  :               777995,\n UnderSize Frames:             \
+        \       0, OverSize Frames:                    0,\n Lost Frames     :    \
+        \                0, Error Frames   :                    0,\n CRC Error Frames:\
+        \                    0, Alignments Err :                    0,\n Tx      \
+        \        :\n Bytes Xmitted   :         361668198206, Unicast Frames :    \
+        \        488416804,\n Broadcast Frames:           1618263684, M-cast Frames\
+        \  :             79968048,\n UnderSize Frames:                    0, OverSize\
+        \ Frames:                    0,\n Lost Frames     :                    0,\
+        \ Collided Frames:                    0,\n Error Frames    :             \
+        \       0\n"
+  show interfaces port:
+    output: "Legends: WTR - Wait To Restore\n         #   - WTR Timer is Running &\
+      \ Port is in wait-to-restore state\n         *   - Permanent Shutdown\n\nSlot/\
+      \    Admin     Link    Violations  Recovery   Recovery      WTR            Alias\n\
+      Port     Status   Status                 Time       Max        (sec)\n------+----------+---------+----------+----------+----------+----------+-----------------------------------------\n\
+      \ *1/1    enable      up        none           300         10          0 \"\
+      Hello\"\n  1/2    enable      down      none           300         10      \
+      \    0 \"\"\n  1/11   enable      down      none           300         10  \
+      \     # 10 \"\"\n  1/17   disable     down      none           300         10\
+      \          0 \"\"\n  1/23   disable     down      none           300       \
+      \  10          0 \"\"\n  1/25   enable      up        none           300   \
+      \      10          0 \"\"\n  1/26   enable      down      none           300\
+      \         10          0 \"\"\n  1/28   enable      down      none          \
+      \   0          0          0 \"\"\n"
+    help: execute the command "show interfaces port"
+    prompt: *id001
+    output_variants:
+      - " Chas/\n Slot/     Admin     Link        WTR      WTS       Alias\n Port\
+        \      Status   Status      (sec)    (msec)\n--------+----------+---------+----------+----------+-----------------------\n\
+        \ 1/1/1     enable     up      0          0          \"This is a test\"\n\
+        \ 1/1/2     enable     up      0          0          \"This_is_a_test\"\n\
+        \ 1/1/3     enable     up      0          0          \"This\"\n 1/1/4    \
+        \ enable     up      0          0          \"\"\n"
+  show interfaces status:
+    output: "                       DETECTED           CONFIGURED\nSlot/ AutoNego\
+      \  Speed Duplex Hybrid  Speed   Duplex Hybrid  Trap\nPort           (Mbps) \
+      \        Type   (Mbps)         Mode   LinkUpDown\n-----+--------+------+------+------+--------+------+------+------\n\
+      \ 1/1   Enable   1000   Full    NA      Auto   Auto    NA      -  \n 1/2   Enable\
+      \    -      -      -       Auto   Auto    NA      -  \n 1/3   Enable    -  \
+      \    -      -       Auto   Auto    NA      -  \n 1/4   Enable    -      -  \
+      \    -       Auto   Auto    NA      -  \n 1/5   Enable    -      -      -  \
+      \     Auto   Auto    NA      -  \n 1/6   Enable    -      -      -       Auto\
+      \   Auto    NA      -  \n 1/7   Enable    -      -      -       Auto   Auto\
+      \    NA      -  \n 1/8   Enable    -      -      -       Auto   Auto    NA \
+      \     -  \n 1/9   Enable    -      -      -       Auto   Auto    NA      - \
+      \ \n 1/10  Enable    -      -      -       Auto   Auto    NA      -  \n 1/11\
+      \  Enable    -      -      -       Auto   Auto    NA      -  \n 1/12  Enable\
+      \    -      -      -       Auto   Auto    NA      -  \n 1/13  Enable    -  \
+      \    -      -       Auto   Auto    NA      -  \n 1/14  Enable    -      -  \
+      \    -       Auto   Auto    NA      -  \n 1/15  Enable    -      -      -  \
+      \     Auto   Auto    NA      -  \n 1/16  Enable    -      -      -       Auto\
+      \   Auto    NA      -  \n 1/17  Enable    -      -      -       Auto   Auto\
+      \    NA      -  \n 1/18  Enable    -      -      -       Auto   Auto    NA \
+      \     -  \n 1/19  Enable    -      -      -       Auto   Auto    NA      - \
+      \ \n 1/20  Enable    -      -      -       Auto   Auto    NA      -  \n 1/21\
+      \  Enable    -      -      -       Auto   Auto    NA      -  \n 1/22  Enable\
+      \    -      -      -       Auto   Auto    NA      -  \n 1/23  Enable    -  \
+      \    -      -       Auto   Auto    NA      -  \n 1/24  Enable    -      -  \
+      \    -       Auto   Auto    NA      -  \n 1/25  Enable   1000   Full    NA \
+      \      1000  Full    NA      -  \n 1/26  Enable    -      -      -        1000\
+      \  Full    NA      -  \n\nFF - ForcedFiber PF - PreferredFiber  F - Fiber\n\
+      FC - ForcedCopper PC - PreferredCopper C - Copper\n"
+    help: execute the command "show interfaces status"
+    prompt: *id001
+    output_variants:
+      - " Chas/                DETECTED-VALUES              CONFIGURED-VALUES    \n\
+        \ Slot/   Admin  Auto  Speed   Duplex  Pause  FEC   Speed   Duplex  Pause\
+        \  FEC   Link\n Port    Status Nego  (Mbps)                 Det   (Mbps) \
+        \                Cfg   Trap  EEE\n--------+------+----+--------+------+-------+----+--------+------+-------+-----+-----+---\n\
+        \ 1/1/1      en    en    1000   Full     -     DIS  10000    Full     -  \
+        \  AUTO  en   dis\n 1/1/2      en   dis     -      -       -    -     10000\
+        \    Full     -    AUTO  en   dis\n 1/1/3      en    en    1000   Full   \
+        \  -     DIS  10000    Full     -    AUTO  en   dis\n 1/1/4      en   dis\
+        \     -      -       -    -     10000    Full     -    AUTO  en   dis\n 1/1/5\
+        \      en   dis     -      -       -    -     10000    Full     -    AUTO\
+        \  en   dis\n 1/1/6      en   dis     -      -       -    -     10000    Full\
+        \     -    AUTO  en   dis\n 1/1/7      en   dis     -      -       -    -\
+        \     10000    Full     -    AUTO  en   dis\n 1/1/8      en   dis     -  \
+        \    -       -    -     10000    Full     -    AUTO  en   dis\n 1/1/9    \
+        \  en   dis     -      -       -    -     20000    Full     -    AUTO  en\
+        \   dis\n 1/1/10    dis   dis     -      -       -    -     20000    Full\
+        \     -    AUTO  en   dis\n"
+  show linkagg alias:
+    output: "\n                         Admin        Oper     Att/Sel  \nNumber  Aggregate\
+      \  Size  state        state      Ports      Name \n-------+----------+----+------------+-------+---------+--------------\n\
+      \   2     Dynamic      2    ENABLED    UP      2  2     LINK_LACP_CORE\n  31\
+      \     Dynamic      8    ENABLED    DOWN    0  0     Created by Auto-Fabric on\
+      \ Mon Oct 6 00:00:00 2000\n  32     Dynamic      8    ENABLED    DOWN    0 \
+      \ 0     Created by Auto-Fabric on Mon Oct 01 00:00:00 2000\n"
+    help: execute the command "show linkagg alias"
+    prompt: *id001
+  show linkagg port:
+    output: "\nSlot/Port Aggregate SNMP Id   Status   Agg  Oper Link Prim\n---------+---------+-------+----------+----+----+----+----\n\
+      \   1/1    Dynamic     1000  ATTACHED     1  UP   UP   YES\n   1/2    Dynamic\
+      \     1001  ATTACHED     1  UP   UP   NO \n   1/3    Dynamic     1002  ATTACHED\
+      \     2  UP   UP   YES\n   1/4    Dynamic     1003  ATTACHED     2  UP   UP\
+      \   NO \n"
+    help: execute the command "show linkagg port"
+    prompt: *id001
+    output_variants:
+      - "\nChassis/Slot/Port  Aggregate   SNMP Id   Status    Agg  Oper   Link Prim\n\
+        -------------------+----------+--------+----------+----+-----+-----+----\n\
+        \         1/1/20     Dynamic      1000   ATTACHED      2  UP   UP    NO \n\
+        \         1/1/16     Dynamic      1002   CONFIGURED NONE  DOWN DOWN  UNK\n\
+        \         1/1/21     Dynamic      1001   ATTACHED      2  UP   UP    YES\n"
+  show lldp remote-system:
+    output: "Remote LLDP Agents on Local Slot/Port 1/1:\n\n    Chassis aa:aa:aa:aa:aa:aa,\
+      \ Port bb:bb:bb:bb:bb:bb:\n      Remote ID                   = 1,\n      Chassis\
+      \ Subtype             = 1 (MAC Address),\n      Port Subtype               \
+      \ = 1 (MAC address),\n      Port Description            = Alcatel-Lucent Enterprise\
+      \ OAW-AP1201H eth0-4094,\n      System Name                 = AP,\n      System\
+      \ Description          = Alcatel-Lucent Enterprise OAW-AP1201H 1.0.0.10,\n \
+      \     Capabilities Supported      = Bridge WLAN AP Router Station Only,\n  \
+      \    Capabilities Enabled        = Bridge WLAN AP Router,\n      Management\
+      \ IP Address       = 1.1.1.1,\n      MED Device Type             = Network Connectivity,\n\
+      \      MED Capabilities            = Capabilities | Power via MDI-PD(33),\n\
+      \      MED Extension TLVs Present  = Network Policy| Inventory,\n      MED Power\
+      \ Type              = PD Device,\n      MED Power Source            = PSE and\
+      \ Local,\n      MED Power Priority          = Low,\n      MED Power Value  \
+      \           = 25.4 W\n\nRemote LLDP Agents on Local Slot/Port 1/2:\n\n    Chassis\
+      \ aa:aa:aa:aa:aa:aa, Port bb:bb:bb:bb:bb:bb:\n      Remote ID              \
+      \     = 1,\n      Chassis Subtype             = 1 (MAC Address),\n      Port\
+      \ Subtype                = 1 (MAC address),\n      Port Description        \
+      \    = Alcatel-Lucent Enterprise OAW-AP1321 eth1,\n      System Name       \
+      \          = AP,\n      System Description          = Alcatel-Lucent Enterprise\
+      \ OAW-AP1321 1.0.0.10,\n      Capabilities Supported      = Bridge WLAN AP Router\
+      \ Station Only,\n      Capabilities Enabled        = Bridge WLAN AP Router,\n\
+      \      Management IP Address       = 1.1.1.1,\n      MED Device Type       \
+      \      = Network Connectivity,\n      MED Capabilities            = Capabilities\
+      \ | Power via MDI-PD(33),\n      MED Extension TLVs Present  = Network Policy|\
+      \ Inventory,\n      MED Power Type              = PD Device,\n      MED Power\
+      \ Source            = PSE and Local,\n      MED Power Priority          = Low,\n\
+      \      MED Power Value             = 25.4 W,\n      Remote port MAC/PHY AutoNeg\
+      \ = Supported Enabled Capability 0x8336,\n      Mau Type                   \
+      \ = 1000BaseTFD - Four-pair Category 5 UTP full duplex mode\n\nRemote LLDP Agents\
+      \ on Local Slot/Port 1/3:\n\n    Chassis aa:aa:aa:aa:aa:aa, Port bb:bb:bb:bb:bb:bb:\n\
+      \      Remote ID                   = 1,\n      Chassis Subtype             =\
+      \ 1 (MAC Address),\n      Port Subtype                = 1 (MAC address),\n \
+      \     Port Description            = Alcatel-Lucent Enterprise OAW-AP1361 eth0,\n\
+      \      System Name                 = AP,\n      System Description         \
+      \ = Alcatel-Lucent Enterprise OAW-AP1361 1.0.0.10,\n      Capabilities Supported\
+      \      = Bridge WLAN AP Router Station Only,\n      Capabilities Enabled   \
+      \     = Bridge WLAN AP Router,\n      Management IP Address       = 1.1.1.1,\n\
+      \      MED Device Type             = Network Connectivity,\n      MED Capabilities\
+      \            = Capabilities | Power via MDI-PD(33),\n      MED Extension TLVs\
+      \ Present  = Network Policy| Inventory,\n      Remote port MAC/PHY AutoNeg =\
+      \ Supported Enabled Capability 0x8337,\n      Mau Type                    =\
+      \ 1000BaseTFD - Four-pair Category 5 UTP full duplex mode\n\nRemote LLDP Agents\
+      \ on Local Slot/Port 1/4:\n\n    Chassis aa:aa:aa:aa:aa:aa, Port 1001:\n   \
+      \   Remote ID                   = 123,\n      Chassis Subtype             =\
+      \ 1 (MAC Address),\n      Port Subtype                = 1 (Locally assigned),\n\
+      \      Port Description            = Alcatel-Lucent OS6860 GNI 1/1/1,\n    \
+      \  System Name                 = SW,\n      System Description          = (null),\n\
+      \      Capabilities Supported      = Bridge Router,\n      Capabilities Enabled\
+      \        = Bridge Router,\n      Management IP Address       = 1.1.1.1\n\nRemote\
+      \ LLDP Agents on Local Slot/Port 1/24:\n\n    Chassis aa:aa:aa:aa:aa:aa, Port\
+      \ GigabitEthernet0/0/47:\n      Remote ID                   = 223,\n      Chassis\
+      \ Subtype             = 4 (MAC Address),\n      Port Subtype               \
+      \ = 5 (Interface name),\n      Port Description            = UPLINK,\n     \
+      \ System Name                 = super_mega_switch,\n      System Description\
+      \          = S5700-52P-PWR-LI-AC\nHuawei Versatile Routing Platform Software\n\
+      VRP (R) software, Version 1.110 (S5700 A000A000A00AAA000)\nCopyright (C) 2000-2001\
+      \ HUAWEI TECH Co., Ltd.,\n      Capabilities Supported      = Bridge Router,\n\
+      \      Capabilities Enabled        = Bridge Router,\n      Management IP Address\
+      \       = 1.1.1.1\n      Remote port default vlan    = 2000,\n      Vlan ID\
+      \                     = 1,\n      Vlan Name                   = VLAN 0001,\n\
+      \      Protocol vlan Id            = 0 (Flags = 0),\n      Remote port MAC/PHY\
+      \ AutoNeg = Supported Enabled Capability 0xa03e,\n      Mau Type           \
+      \         = 1000BaseTFD - Four-pair Category 5 UTP full duplex mode\n"
+    help: execute the command "show lldp remote-system"
+    prompt: *id001
+    output_variants:
+      - "Remote LLDP nearest-bridge Agents on Local Port 1/1/1:\n\n    Chassis aa:aa:aa:aa:aa:aa,\
+        \ Port 1025:\n      Remote ID                   = 1,\n      Chassis Subtype\
+        \             = 2 (MAC Address),\n      Port Subtype                = 3 (Locally\
+        \ assigned),\n      Port Description            = Alcatel-Lucent Enterprise\
+        \ 1/1,\n      System Name                 = SW,\n      System Description\
+        \          = (null),\n      Capabilities Supported      = none supported,\n\
+        \      Capabilities Enabled        = none enabled,\n      Management IP Address\
+        \       = 1.1.1.1,\n      Remote port default vlan    = 1\n\nRemote LLDP nearest-bridge\
+        \ Agents on Local Port 1/1/2:\n\n    Chassis aa:aa:aa:aa:aa:aa, Port 1025:\n\
+        \      Remote ID                   = 1,\n      Chassis Subtype           \
+        \  = 2 (MAC Address),\n      Port Subtype                = 3 (Locally assigned),\n\
+        \      Port Description            = Alcatel-Lucent OS6360 GNI 1/1/1,\n  \
+        \    System Name                 = SW,\n      System Description         \
+        \ = (null),\n      Capabilities Supported      = Bridge Router,\n      Capabilities\
+        \ Enabled        = Bridge Router,\n      Management IP Address       = 1.1.1.1\n\
+        \nRemote LLDP nearest-bridge Agents on Local Port 1/1/3:\n\n    Chassis aa:aa:aa:aa:aa:aa,\
+        \ Port Vlan_1_things:\n      Remote ID                   = 1,\n      Chassis\
+        \ Subtype             = 2 (MAC Address),\n      Port Subtype             \
+        \   = 3 (Interface name),\n      Port Description            = (null),\n \
+        \     System Name                 = SomeSystem_that_has_FW,\n      System\
+        \ Description          = Mikrotik RouterOS 1.1 (stable) Jan/1/2000 01:01:01\
+        \ RB1100AHx4,\n      Capabilities Supported      = Bridge Router,\n      Capabilities\
+        \ Enabled        = Router,\n      Management IP Address       = 1.1.1.1\n\n\
+        \n    Chassis bb:bb:bb:bb:bb:bb, Port Vlan_2_more_things:\n      Remote ID\
+        \                   = 1,\n      Chassis Subtype             = 2 (MAC Address),\n\
+        \      Port Subtype                = 3 (Interface name),\n      Port Description\
+        \            = (null),\n      System Name                 = SomeSystem_that_has_FW,\n\
+        \      System Description          = Mikrotik RouterOS 1.1 (stable) Jan/1/2000\
+        \ 01:01:01 RB1100AHx4,\n      Capabilities Supported      = Bridge Router,\n\
+        \      Capabilities Enabled        = Router,\n      Management IP Address\
+        \       = 1.1.1.1\n\n\n    Chassis cc:cc:cc:cc:cc:cc, Port sfp-sfpplus1:\n\
+        \      Remote ID                   = 1,\n      Chassis Subtype           \
+        \  = 2 (MAC Address),\n      Port Subtype                = 3 (Interface name),\n\
+        \      Port Description            = (null),\n      System Name          \
+        \       = SomeSystem_that_has_FW,\n      System Description          = Mikrotik\
+        \ RouterOS 1.1 (stable) Jan/1/2000 01:01:01 RB1100AHx4,\n      Capabilities\
+        \ Supported      = Bridge Router,\n      Capabilities Enabled        = Router\n"
+  show mac-address-table:
+    output: "Legend: Mac Address: * = address not valid\n\n   Vlan      Mac Address\
+      \          Type       Protocol    Operation    Interface \n  ------+-------------------+--------------+-----------+------------+-----------\n\
+      \   * 1    aa:aa:aa:aa:aa:aa      permanent         ---      bridging      1/1\
+      \  \n     2    bb:bb:bb:bb:bb:bb        learned         ---      bridging  \
+      \    1/1  \n     3    cc:cc:cc:cc:cc:cc        learned         ---      bridging\
+      \      1/1  \n     4    dd:dd:dd:dd:dd:dd        learned         ---      bridging\
+      \      1/1\n * 999    ee:ee:ee:ee:ee:ee      permanent           0      bridging\
+      \      1/11\n\nTotal number of Valid MAC addresses above = 4\n"
+    help: execute the command "show mac-address-table"
+    prompt: *id001
+    output_variants:
+      - "Legend: Mac Address: * = address not valid,\n\n        Mac Address: & = duplicate\
+        \ static address,\n\n   Domain    Vlan/SrvcId[ISId/vnId]     Mac Address \
+        \          Type          Operation          Interface\n------------+----------------------+-------------------+------------------+-------------+-------------------------\n\
+        \      VLAN                        1   aa:aa:aa:aa:aa:aa            dynamic\
+        \     bridging                     1/1/1 \n      VLAN                    \
+        \    1   bb:bb:bb:bb:bb:bb            dynamic     bridging               \
+        \      1/1/1 \n      VLAN                        1   cc:cc:cc:cc:cc:cc   \
+        \         dynamic     bridging                    1/1/10 \n      VLAN    \
+        \                    1   dd:dd:dd:dd:dd:dd            dynamic     bridging\
+        \                     1/1/1 \n\n Total number of Valid MAC addresses above\
+        \ = 4\n"
+      - "Legend: Mac Address: * = address not valid,\n        Mac Address: & = duplicate\
+        \ static address,\n        ID = ISID/Vnid/vplsid\n\n    Domain    Vlan/SrvcId[:ID]\
+        \           Mac Address           Type          Operation          Interface\n\
+        ------------+----------------------+-------------------+------------------+-------------+-------------------------\n\
+        \      VLAN                        1   aa:aa:aa:aa:aa:aa            dynamic\
+        \     bridging                     1/1/1 \n      VLAN                    \
+        \    1   bb:bb:bb:bb:bb:bb            dynamic     bridging               \
+        \      1/1/1 \n      VLAN                        1   cc:cc:cc:cc:cc:cc   \
+        \         dynamic     bridging                    1/1/10 \n      VLAN    \
+        \                    1   dd:dd:dd:dd:dd:dd            dynamic     bridging\
+        \                     1/1/1 \n\n Total number of Valid MAC addresses above\
+        \ = 4\n"
+  show port-security:
+    output: "\nLegend: Mac Address: * = Duplicate Static\n        Mac Address: # =\
+      \ Pseudo Static\n\n\nPort:  1/11\n Operation Mode   :                ENABLED,\n\
+      \ Max MAC bridged  :                      1,\n Trap Threshold   :          \
+      \     DISABLED,\n Max MAC filtered :                      5,\n Violation   \
+      \     :               RESTRICT,\n Violating MAC    :                   NULL\n\
+      \n MAC Address        VLAN   TYPE\n-------------------+------+------------\n\
+      \ aa:aa:aa:aa:aa:aa    10   STATIC\n\n \nLegend: Mac Address: * = Duplicate\
+      \ Static\n        Mac Address: # = Pseudo Static\n\n\nPort:  1/12\n Operation\
+      \ Mode   :                ENABLED,\n Max MAC bridged  :                    \
+      \  1,\n Trap Threshold   :               DISABLED,\n Max MAC filtered :    \
+      \                  5,\n Violation        :               RESTRICT,\n Violating\
+      \ MAC    :                   NULL\n\n MAC Address        VLAN   TYPE\n-------------------+------+------------\n\
+      \ aa:aa:aa:aa:aa:bb    10   STATIC\n"
+    help: execute the command "show port-security"
+    prompt: *id001
+    output_variants:
+      - "Legend: Mac Address: * = address not valid,\n\n        Mac Address: & = duplicate\
+        \ static address,\n\n\nPort:  1/1/1 \n  Admin-State      :               DISABLED,\n\
+        \  Operation Mode   :               DISABLED,\n  Max MAC bridged  :      \
+        \                1,\n  Trap Threshold   :               DISABLED,\n  Violation\
+        \        :               RESTRICT,\n  Max MAC filtered :                 \
+        \     5,\n  Violating MAC    :                   NULL,\n  Pkt-Relay      \
+        \  :               DISABLED\n\n            MAC             VLAN       MAC\
+        \ TYPE          OPERATION    \n-------------------------+--------+-----------------+-----------------\n"
+      - 'No Port Security is configured in the system.
+
+
+        '
+  show system:
+    output: "System:\n  Description:  Alcatel-Lucent Enterprise OS6350-P24 6.7.1.001.R01\
+      \ GA, January 01, 2000.,\n  Object ID:    0.0.0.0.0.0.0000.000.0.0.0.0.00.0.0,\n\
+      \  Up Time:      22 days 2 hours 20 minutes and 20 seconds,\n  Contact:    \
+      \  Alcatel-Lucent Enterprise, https://www.al-enterprise.com,\n  Name:      \
+      \   SWA_0001,\n  Location:     Espoo - Finland,\n  Services:     2,\n  Date\
+      \ & Time:  MON JAN 01 2001  00:00:00 (CET)\n\nFlash Space:\n    Primary CMM:\n\
+      \      Available (bytes):  39243776,\n      Comments         :  None\n"
+    help: execute the command "show system"
+    prompt: *id001
+    output_variants:
+      - "System:\n  Description:  Alcatel-Lucent Enterprise OS6360-PH24 8.0.00.R01\
+        \ GA, January 01, 2000.,\n  Object ID:    0.0.0.0.0.0.0000.000.0.0.0.0.00.0.0,\n\
+        \  Up Time:      22 days 22 hours 22 minutes and 22 seconds,\n  Contact: \
+        \     Alcatel-Lucent Enterprise, https://www.al-enterprise.com,\n  Name: \
+        \        SWA_0001,\n  Location:     Espoo - Finland,\n  Services:     2,\n\
+        \  Date & Time:  MON DEC 24 2025 01:02:03 (CET)\nFlash Space:\n    Primary\
+        \ CMM:\n      Available (bytes):  501198848,\n      Comments         :  None\n"
+  show vlan port:
+    output: "  vlan       port         type         status\n--------+------------+------------+--------------\n\
+      \  1         1/1/23       default    inactive\n  1         1/1/25       qtagged\
+      \    forwarding\n"
+    help: execute the command "show vlan port"
+    prompt: *id001
+    output_variants:
+      - " vlan   port     type      status\n------+-------+---------+-------------\n\
+        \    1    1/25   default     inactive\n    1    1/26   qtagged   forwarding\n"

--- a/simnos/plugins/nos/platforms_yaml/alcatel_aos.yaml
+++ b/simnos/plugins/nos/platforms_yaml/alcatel_aos.yaml
@@ -43,16 +43,16 @@ commands:
       \              00:00:00:00:00:00,\n\n"
     help: execute the command "show chassis"
     prompt: &id001
-      - '{base_prompt}>'
-      - '{base_prompt}#'
+    - '{base_prompt}>'
+    - '{base_prompt}#'
     output_variants:
-      - "Local Chassis ID 1 (Master)\n  Model Name:                    OS6360-PH24,\n\
-        \  Module Type:                   0xa0a0000,\n  Description:             \
-        \      Chassis,\n  Part Number:                   000000-00,\n  Hardware Revision:\
-        \             01,\n  Serial Number:                 AAA000000000,\n  Manufacture\
-        \ Date:              Jan  1 2000,\n  Admin Status:                  POWER\
-        \ ON,\n  Operational Status:            UP,\n  Number Of Resets:         \
-        \     1,\n  MAC Address:                   00:00:00:00:00:00\n"
+    - "Local Chassis ID 1 (Master)\n  Model Name:                    OS6360-PH24,\n\
+      \  Module Type:                   0xa0a0000,\n  Description:               \
+      \    Chassis,\n  Part Number:                   000000-00,\n  Hardware Revision:\
+      \             01,\n  Serial Number:                 AAA000000000,\n  Manufacture\
+      \ Date:              Jan  1 2000,\n  Admin Status:                  POWER ON,\n\
+      \  Operational Status:            UP,\n  Number Of Resets:              1,\n\
+      \  MAC Address:                   00:00:00:00:00:00\n"
   show interfaces alias:
     output: " Chas/\n Slot/     Admin     Link        WTR      WTS       Alias\n Port\
       \      Status   Status      (sec)    (msec)\n--------+----------+---------+----------+----------+-----------------------\n\
@@ -98,49 +98,47 @@ commands:
     help: execute the command "show interfaces ethernet"
     prompt: *id001
     output_variants:
-      - "Chassis/Slot/Port          : 1/1/30 \n Operational Status        : up,\n\
-        \ Port-Down/Violation Reason: None,\n Last Time Link Changed    : Sun Jan\
-        \ 08 01:14:25 2024,\n Number of Status Change   : 1,\n Type              \
-        \        : Ethernet,\n SFP/XFP                   : GBIC_LX,\n Interface Type\
-        \            : Fiber,\n EPP                       : Disabled,\n Link-Quality\
-        \              : N/A,\n MAC address               : aa:bb:cc:dd:ee:ff,\n BandWidth\
-        \ (Megabits)      :     1000,                  Duplex           : Full,\n\
-        \ Autonegotiation           :   1  [ 1000-F                       ],\n Long\
-        \ Frame Size(Bytes)    : 9216,\n Inter Frame Gap(Bytes)    : 12,\n loopback\
-        \ mode             : N/A,\n Rx              :\n Bytes Received  :        \
-        \      9419904, Unicast Frames :                    0,\n Broadcast Frames:\
-        \                    0, M-cast Frames  :                73593,\n UnderSize\
-        \ Frames:                    0, OverSize Frames:                    0,\n Lost\
-        \ Frames     :                    0, Error Frames   :                    0,\n\
-        \ CRC Error Frames:                    0, Alignments Err :               \
-        \     0,\n Tx              :\n Bytes Xmitted   :         155215209608, Unicast\
-        \ Frames :              3121178,\n Broadcast Frames:           1616888391,\
-        \ M-cast Frames  :             80210193,\n UnderSize Frames:             \
-        \       0, OverSize Frames:                    0,\n Lost Frames     :    \
-        \                0, Collided Frames:                    0,\n Error Frames\
-        \    :                    0, Collisions     :                    0,\n Late\
-        \ collisions :                    0, Exc-Collisions :                    0\n\
-        Chassis/Slot/Port          : 1/1/31 \n Operational Status        : up,\n Port-Down/Violation\
-        \ Reason: None,\n Last Time Link Changed    : Sun Jan 22 01:14:25 2024,\n\
-        \ Number of Status Change   : 1,\n Type                      : Ethernet,\n\
-        \ SFP/XFP                   : GBIC_LX,\n Interface Type            : Fiber,\n\
-        \ EPP                       : Disabled,\n Link-Quality              : N/A,\n\
-        \ MAC address               : ab:cd:ef:12:34:56,\n BandWidth (Megabits)  \
-        \    :     1000,                  Duplex           : Full,\n Autonegotiation\
-        \           :   0  [                            ],\n Long Frame Size(Bytes)\
-        \    : 9216,\n Inter Frame Gap(Bytes)    : 12,\n loopback mode           \
-        \  : N/A,\n Rx              :\n Bytes Received  :         542857246503, Unicast\
-        \ Frames :            631292769,\n Broadcast Frames:               366413,\
-        \ M-cast Frames  :               777995,\n UnderSize Frames:             \
-        \       0, OverSize Frames:                    0,\n Lost Frames     :    \
-        \                0, Error Frames   :                    0,\n CRC Error Frames:\
-        \                    0, Alignments Err :                    0,\n Tx      \
-        \        :\n Bytes Xmitted   :         361668198206, Unicast Frames :    \
-        \        488416804,\n Broadcast Frames:           1618263684, M-cast Frames\
-        \  :             79968048,\n UnderSize Frames:                    0, OverSize\
-        \ Frames:                    0,\n Lost Frames     :                    0,\
-        \ Collided Frames:                    0,\n Error Frames    :             \
-        \       0\n"
+    - "Chassis/Slot/Port          : 1/1/30 \n Operational Status        : up,\n Port-Down/Violation\
+      \ Reason: None,\n Last Time Link Changed    : Sun Jan 08 01:14:25 2024,\n Number\
+      \ of Status Change   : 1,\n Type                      : Ethernet,\n SFP/XFP\
+      \                   : GBIC_LX,\n Interface Type            : Fiber,\n EPP  \
+      \                     : Disabled,\n Link-Quality              : N/A,\n MAC address\
+      \               : aa:bb:cc:dd:ee:ff,\n BandWidth (Megabits)      :     1000,\
+      \                  Duplex           : Full,\n Autonegotiation           :  \
+      \ 1  [ 1000-F                       ],\n Long Frame Size(Bytes)    : 9216,\n\
+      \ Inter Frame Gap(Bytes)    : 12,\n loopback mode             : N/A,\n Rx  \
+      \            :\n Bytes Received  :              9419904, Unicast Frames :  \
+      \                  0,\n Broadcast Frames:                    0, M-cast Frames\
+      \  :                73593,\n UnderSize Frames:                    0, OverSize\
+      \ Frames:                    0,\n Lost Frames     :                    0, Error\
+      \ Frames   :                    0,\n CRC Error Frames:                    0,\
+      \ Alignments Err :                    0,\n Tx              :\n Bytes Xmitted\
+      \   :         155215209608, Unicast Frames :              3121178,\n Broadcast\
+      \ Frames:           1616888391, M-cast Frames  :             80210193,\n UnderSize\
+      \ Frames:                    0, OverSize Frames:                    0,\n Lost\
+      \ Frames     :                    0, Collided Frames:                    0,\n\
+      \ Error Frames    :                    0, Collisions     :                 \
+      \   0,\n Late collisions :                    0, Exc-Collisions :          \
+      \          0\nChassis/Slot/Port          : 1/1/31 \n Operational Status    \
+      \    : up,\n Port-Down/Violation Reason: None,\n Last Time Link Changed    :\
+      \ Sun Jan 22 01:14:25 2024,\n Number of Status Change   : 1,\n Type        \
+      \              : Ethernet,\n SFP/XFP                   : GBIC_LX,\n Interface\
+      \ Type            : Fiber,\n EPP                       : Disabled,\n Link-Quality\
+      \              : N/A,\n MAC address               : ab:cd:ef:12:34:56,\n BandWidth\
+      \ (Megabits)      :     1000,                  Duplex           : Full,\n Autonegotiation\
+      \           :   0  [                            ],\n Long Frame Size(Bytes)\
+      \    : 9216,\n Inter Frame Gap(Bytes)    : 12,\n loopback mode             :\
+      \ N/A,\n Rx              :\n Bytes Received  :         542857246503, Unicast\
+      \ Frames :            631292769,\n Broadcast Frames:               366413, M-cast\
+      \ Frames  :               777995,\n UnderSize Frames:                    0,\
+      \ OverSize Frames:                    0,\n Lost Frames     :               \
+      \     0, Error Frames   :                    0,\n CRC Error Frames:        \
+      \            0, Alignments Err :                    0,\n Tx              :\n\
+      \ Bytes Xmitted   :         361668198206, Unicast Frames :            488416804,\n\
+      \ Broadcast Frames:           1618263684, M-cast Frames  :             79968048,\n\
+      \ UnderSize Frames:                    0, OverSize Frames:                 \
+      \   0,\n Lost Frames     :                    0, Collided Frames:          \
+      \          0,\n Error Frames    :                    0\n"
   show interfaces port:
     output: "Legends: WTR - Wait To Restore\n         #   - WTR Timer is Running &\
       \ Port is in wait-to-restore state\n         *   - Permanent Shutdown\n\nSlot/\
@@ -158,12 +156,12 @@ commands:
     help: execute the command "show interfaces port"
     prompt: *id001
     output_variants:
-      - " Chas/\n Slot/     Admin     Link        WTR      WTS       Alias\n Port\
-        \      Status   Status      (sec)    (msec)\n--------+----------+---------+----------+----------+-----------------------\n\
-        \ 1/1/1     enable     up      0          0          \"This is a test\"\n\
-        \ 1/1/2     enable     up      0          0          \"This_is_a_test\"\n\
-        \ 1/1/3     enable     up      0          0          \"This\"\n 1/1/4    \
-        \ enable     up      0          0          \"\"\n"
+    - " Chas/\n Slot/     Admin     Link        WTR      WTS       Alias\n Port  \
+      \    Status   Status      (sec)    (msec)\n--------+----------+---------+----------+----------+-----------------------\n\
+      \ 1/1/1     enable     up      0          0          \"This is a test\"\n 1/1/2\
+      \     enable     up      0          0          \"This_is_a_test\"\n 1/1/3  \
+      \   enable     up      0          0          \"This\"\n 1/1/4     enable   \
+      \  up      0          0          \"\"\n"
   show interfaces status:
     output: "                       DETECTED           CONFIGURED\nSlot/ AutoNego\
       \  Speed Duplex Hybrid  Speed   Duplex Hybrid  Trap\nPort           (Mbps) \
@@ -196,23 +194,22 @@ commands:
     help: execute the command "show interfaces status"
     prompt: *id001
     output_variants:
-      - " Chas/                DETECTED-VALUES              CONFIGURED-VALUES    \n\
-        \ Slot/   Admin  Auto  Speed   Duplex  Pause  FEC   Speed   Duplex  Pause\
-        \  FEC   Link\n Port    Status Nego  (Mbps)                 Det   (Mbps) \
-        \                Cfg   Trap  EEE\n--------+------+----+--------+------+-------+----+--------+------+-------+-----+-----+---\n\
-        \ 1/1/1      en    en    1000   Full     -     DIS  10000    Full     -  \
-        \  AUTO  en   dis\n 1/1/2      en   dis     -      -       -    -     10000\
-        \    Full     -    AUTO  en   dis\n 1/1/3      en    en    1000   Full   \
-        \  -     DIS  10000    Full     -    AUTO  en   dis\n 1/1/4      en   dis\
-        \     -      -       -    -     10000    Full     -    AUTO  en   dis\n 1/1/5\
-        \      en   dis     -      -       -    -     10000    Full     -    AUTO\
-        \  en   dis\n 1/1/6      en   dis     -      -       -    -     10000    Full\
-        \     -    AUTO  en   dis\n 1/1/7      en   dis     -      -       -    -\
-        \     10000    Full     -    AUTO  en   dis\n 1/1/8      en   dis     -  \
-        \    -       -    -     10000    Full     -    AUTO  en   dis\n 1/1/9    \
-        \  en   dis     -      -       -    -     20000    Full     -    AUTO  en\
-        \   dis\n 1/1/10    dis   dis     -      -       -    -     20000    Full\
-        \     -    AUTO  en   dis\n"
+    - " Chas/                DETECTED-VALUES              CONFIGURED-VALUES    \n\
+      \ Slot/   Admin  Auto  Speed   Duplex  Pause  FEC   Speed   Duplex  Pause  FEC\
+      \   Link\n Port    Status Nego  (Mbps)                 Det   (Mbps)        \
+      \         Cfg   Trap  EEE\n--------+------+----+--------+------+-------+----+--------+------+-------+-----+-----+---\n\
+      \ 1/1/1      en    en    1000   Full     -     DIS  10000    Full     -    AUTO\
+      \  en   dis\n 1/1/2      en   dis     -      -       -    -     10000    Full\
+      \     -    AUTO  en   dis\n 1/1/3      en    en    1000   Full     -     DIS\
+      \  10000    Full     -    AUTO  en   dis\n 1/1/4      en   dis     -      -\
+      \       -    -     10000    Full     -    AUTO  en   dis\n 1/1/5      en   dis\
+      \     -      -       -    -     10000    Full     -    AUTO  en   dis\n 1/1/6\
+      \      en   dis     -      -       -    -     10000    Full     -    AUTO  en\
+      \   dis\n 1/1/7      en   dis     -      -       -    -     10000    Full  \
+      \   -    AUTO  en   dis\n 1/1/8      en   dis     -      -       -    -    \
+      \ 10000    Full     -    AUTO  en   dis\n 1/1/9      en   dis     -      - \
+      \      -    -     20000    Full     -    AUTO  en   dis\n 1/1/10    dis   dis\
+      \     -      -       -    -     20000    Full     -    AUTO  en   dis\n"
   show linkagg alias:
     output: "\n                         Admin        Oper     Att/Sel  \nNumber  Aggregate\
       \  Size  state        state      Ports      Name \n-------+----------+----+------------+-------+---------+--------------\n\
@@ -231,11 +228,11 @@ commands:
     help: execute the command "show linkagg port"
     prompt: *id001
     output_variants:
-      - "\nChassis/Slot/Port  Aggregate   SNMP Id   Status    Agg  Oper   Link Prim\n\
-        -------------------+----------+--------+----------+----+-----+-----+----\n\
-        \         1/1/20     Dynamic      1000   ATTACHED      2  UP   UP    NO \n\
-        \         1/1/16     Dynamic      1002   CONFIGURED NONE  DOWN DOWN  UNK\n\
-        \         1/1/21     Dynamic      1001   ATTACHED      2  UP   UP    YES\n"
+    - "\nChassis/Slot/Port  Aggregate   SNMP Id   Status    Agg  Oper   Link Prim\n\
+      -------------------+----------+--------+----------+----+-----+-----+----\n \
+      \        1/1/20     Dynamic      1000   ATTACHED      2  UP   UP    NO \n  \
+      \       1/1/16     Dynamic      1002   CONFIGURED NONE  DOWN DOWN  UNK\n   \
+      \      1/1/21     Dynamic      1001   ATTACHED      2  UP   UP    YES\n"
   show lldp remote-system:
     output: "Remote LLDP Agents on Local Slot/Port 1/1:\n\n    Chassis aa:aa:aa:aa:aa:aa,\
       \ Port bb:bb:bb:bb:bb:bb:\n      Remote ID                   = 1,\n      Chassis\
@@ -303,43 +300,43 @@ commands:
     help: execute the command "show lldp remote-system"
     prompt: *id001
     output_variants:
-      - "Remote LLDP nearest-bridge Agents on Local Port 1/1/1:\n\n    Chassis aa:aa:aa:aa:aa:aa,\
-        \ Port 1025:\n      Remote ID                   = 1,\n      Chassis Subtype\
-        \             = 2 (MAC Address),\n      Port Subtype                = 3 (Locally\
-        \ assigned),\n      Port Description            = Alcatel-Lucent Enterprise\
-        \ 1/1,\n      System Name                 = SW,\n      System Description\
-        \          = (null),\n      Capabilities Supported      = none supported,\n\
-        \      Capabilities Enabled        = none enabled,\n      Management IP Address\
-        \       = 1.1.1.1,\n      Remote port default vlan    = 1\n\nRemote LLDP nearest-bridge\
-        \ Agents on Local Port 1/1/2:\n\n    Chassis aa:aa:aa:aa:aa:aa, Port 1025:\n\
-        \      Remote ID                   = 1,\n      Chassis Subtype           \
-        \  = 2 (MAC Address),\n      Port Subtype                = 3 (Locally assigned),\n\
-        \      Port Description            = Alcatel-Lucent OS6360 GNI 1/1/1,\n  \
-        \    System Name                 = SW,\n      System Description         \
-        \ = (null),\n      Capabilities Supported      = Bridge Router,\n      Capabilities\
-        \ Enabled        = Bridge Router,\n      Management IP Address       = 1.1.1.1\n\
-        \nRemote LLDP nearest-bridge Agents on Local Port 1/1/3:\n\n    Chassis aa:aa:aa:aa:aa:aa,\
-        \ Port Vlan_1_things:\n      Remote ID                   = 1,\n      Chassis\
-        \ Subtype             = 2 (MAC Address),\n      Port Subtype             \
-        \   = 3 (Interface name),\n      Port Description            = (null),\n \
-        \     System Name                 = SomeSystem_that_has_FW,\n      System\
-        \ Description          = Mikrotik RouterOS 1.1 (stable) Jan/1/2000 01:01:01\
-        \ RB1100AHx4,\n      Capabilities Supported      = Bridge Router,\n      Capabilities\
-        \ Enabled        = Router,\n      Management IP Address       = 1.1.1.1\n\n\
-        \n    Chassis bb:bb:bb:bb:bb:bb, Port Vlan_2_more_things:\n      Remote ID\
-        \                   = 1,\n      Chassis Subtype             = 2 (MAC Address),\n\
-        \      Port Subtype                = 3 (Interface name),\n      Port Description\
-        \            = (null),\n      System Name                 = SomeSystem_that_has_FW,\n\
-        \      System Description          = Mikrotik RouterOS 1.1 (stable) Jan/1/2000\
-        \ 01:01:01 RB1100AHx4,\n      Capabilities Supported      = Bridge Router,\n\
-        \      Capabilities Enabled        = Router,\n      Management IP Address\
-        \       = 1.1.1.1\n\n\n    Chassis cc:cc:cc:cc:cc:cc, Port sfp-sfpplus1:\n\
-        \      Remote ID                   = 1,\n      Chassis Subtype           \
-        \  = 2 (MAC Address),\n      Port Subtype                = 3 (Interface name),\n\
-        \      Port Description            = (null),\n      System Name          \
-        \       = SomeSystem_that_has_FW,\n      System Description          = Mikrotik\
-        \ RouterOS 1.1 (stable) Jan/1/2000 01:01:01 RB1100AHx4,\n      Capabilities\
-        \ Supported      = Bridge Router,\n      Capabilities Enabled        = Router\n"
+    - "Remote LLDP nearest-bridge Agents on Local Port 1/1/1:\n\n    Chassis aa:aa:aa:aa:aa:aa,\
+      \ Port 1025:\n      Remote ID                   = 1,\n      Chassis Subtype\
+      \             = 2 (MAC Address),\n      Port Subtype                = 3 (Locally\
+      \ assigned),\n      Port Description            = Alcatel-Lucent Enterprise\
+      \ 1/1,\n      System Name                 = SW,\n      System Description  \
+      \        = (null),\n      Capabilities Supported      = none supported,\n  \
+      \    Capabilities Enabled        = none enabled,\n      Management IP Address\
+      \       = 1.1.1.1,\n      Remote port default vlan    = 1\n\nRemote LLDP nearest-bridge\
+      \ Agents on Local Port 1/1/2:\n\n    Chassis aa:aa:aa:aa:aa:aa, Port 1025:\n\
+      \      Remote ID                   = 1,\n      Chassis Subtype             =\
+      \ 2 (MAC Address),\n      Port Subtype                = 3 (Locally assigned),\n\
+      \      Port Description            = Alcatel-Lucent OS6360 GNI 1/1/1,\n    \
+      \  System Name                 = SW,\n      System Description          = (null),\n\
+      \      Capabilities Supported      = Bridge Router,\n      Capabilities Enabled\
+      \        = Bridge Router,\n      Management IP Address       = 1.1.1.1\n\nRemote\
+      \ LLDP nearest-bridge Agents on Local Port 1/1/3:\n\n    Chassis aa:aa:aa:aa:aa:aa,\
+      \ Port Vlan_1_things:\n      Remote ID                   = 1,\n      Chassis\
+      \ Subtype             = 2 (MAC Address),\n      Port Subtype               \
+      \ = 3 (Interface name),\n      Port Description            = (null),\n     \
+      \ System Name                 = SomeSystem_that_has_FW,\n      System Description\
+      \          = Mikrotik RouterOS 1.1 (stable) Jan/1/2000 01:01:01 RB1100AHx4,\n\
+      \      Capabilities Supported      = Bridge Router,\n      Capabilities Enabled\
+      \        = Router,\n      Management IP Address       = 1.1.1.1\n\n\n    Chassis\
+      \ bb:bb:bb:bb:bb:bb, Port Vlan_2_more_things:\n      Remote ID             \
+      \      = 1,\n      Chassis Subtype             = 2 (MAC Address),\n      Port\
+      \ Subtype                = 3 (Interface name),\n      Port Description     \
+      \       = (null),\n      System Name                 = SomeSystem_that_has_FW,\n\
+      \      System Description          = Mikrotik RouterOS 1.1 (stable) Jan/1/2000\
+      \ 01:01:01 RB1100AHx4,\n      Capabilities Supported      = Bridge Router,\n\
+      \      Capabilities Enabled        = Router,\n      Management IP Address  \
+      \     = 1.1.1.1\n\n\n    Chassis cc:cc:cc:cc:cc:cc, Port sfp-sfpplus1:\n   \
+      \   Remote ID                   = 1,\n      Chassis Subtype             = 2\
+      \ (MAC Address),\n      Port Subtype                = 3 (Interface name),\n\
+      \      Port Description            = (null),\n      System Name            \
+      \     = SomeSystem_that_has_FW,\n      System Description          = Mikrotik\
+      \ RouterOS 1.1 (stable) Jan/1/2000 01:01:01 RB1100AHx4,\n      Capabilities\
+      \ Supported      = Bridge Router,\n      Capabilities Enabled        = Router\n"
   show mac-address-table:
     output: "Legend: Mac Address: * = address not valid\n\n   Vlan      Mac Address\
       \          Type       Protocol    Operation    Interface \n  ------+-------------------+--------------+-----------+------------+-----------\n\
@@ -352,29 +349,27 @@ commands:
     help: execute the command "show mac-address-table"
     prompt: *id001
     output_variants:
-      - "Legend: Mac Address: * = address not valid,\n\n        Mac Address: & = duplicate\
-        \ static address,\n\n   Domain    Vlan/SrvcId[ISId/vnId]     Mac Address \
-        \          Type          Operation          Interface\n------------+----------------------+-------------------+------------------+-------------+-------------------------\n\
-        \      VLAN                        1   aa:aa:aa:aa:aa:aa            dynamic\
-        \     bridging                     1/1/1 \n      VLAN                    \
-        \    1   bb:bb:bb:bb:bb:bb            dynamic     bridging               \
-        \      1/1/1 \n      VLAN                        1   cc:cc:cc:cc:cc:cc   \
-        \         dynamic     bridging                    1/1/10 \n      VLAN    \
-        \                    1   dd:dd:dd:dd:dd:dd            dynamic     bridging\
-        \                     1/1/1 \n\n Total number of Valid MAC addresses above\
-        \ = 4\n"
-      - "Legend: Mac Address: * = address not valid,\n        Mac Address: & = duplicate\
-        \ static address,\n        ID = ISID/Vnid/vplsid\n\n    Domain    Vlan/SrvcId[:ID]\
-        \           Mac Address           Type          Operation          Interface\n\
-        ------------+----------------------+-------------------+------------------+-------------+-------------------------\n\
-        \      VLAN                        1   aa:aa:aa:aa:aa:aa            dynamic\
-        \     bridging                     1/1/1 \n      VLAN                    \
-        \    1   bb:bb:bb:bb:bb:bb            dynamic     bridging               \
-        \      1/1/1 \n      VLAN                        1   cc:cc:cc:cc:cc:cc   \
-        \         dynamic     bridging                    1/1/10 \n      VLAN    \
-        \                    1   dd:dd:dd:dd:dd:dd            dynamic     bridging\
-        \                     1/1/1 \n\n Total number of Valid MAC addresses above\
-        \ = 4\n"
+    - "Legend: Mac Address: * = address not valid,\n\n        Mac Address: & = duplicate\
+      \ static address,\n\n   Domain    Vlan/SrvcId[ISId/vnId]     Mac Address   \
+      \        Type          Operation          Interface\n------------+----------------------+-------------------+------------------+-------------+-------------------------\n\
+      \      VLAN                        1   aa:aa:aa:aa:aa:aa            dynamic\
+      \     bridging                     1/1/1 \n      VLAN                      \
+      \  1   bb:bb:bb:bb:bb:bb            dynamic     bridging                   \
+      \  1/1/1 \n      VLAN                        1   cc:cc:cc:cc:cc:cc         \
+      \   dynamic     bridging                    1/1/10 \n      VLAN            \
+      \            1   dd:dd:dd:dd:dd:dd            dynamic     bridging         \
+      \            1/1/1 \n\n Total number of Valid MAC addresses above = 4\n"
+    - "Legend: Mac Address: * = address not valid,\n        Mac Address: & = duplicate\
+      \ static address,\n        ID = ISID/Vnid/vplsid\n\n    Domain    Vlan/SrvcId[:ID]\
+      \           Mac Address           Type          Operation          Interface\n\
+      ------------+----------------------+-------------------+------------------+-------------+-------------------------\n\
+      \      VLAN                        1   aa:aa:aa:aa:aa:aa            dynamic\
+      \     bridging                     1/1/1 \n      VLAN                      \
+      \  1   bb:bb:bb:bb:bb:bb            dynamic     bridging                   \
+      \  1/1/1 \n      VLAN                        1   cc:cc:cc:cc:cc:cc         \
+      \   dynamic     bridging                    1/1/10 \n      VLAN            \
+      \            1   dd:dd:dd:dd:dd:dd            dynamic     bridging         \
+      \            1/1/1 \n\n Total number of Valid MAC addresses above = 4\n"
   show port-security:
     output: "\nLegend: Mac Address: * = Duplicate Static\n        Mac Address: # =\
       \ Pseudo Static\n\n\nPort:  1/11\n Operation Mode   :                ENABLED,\n\
@@ -392,18 +387,18 @@ commands:
     help: execute the command "show port-security"
     prompt: *id001
     output_variants:
-      - "Legend: Mac Address: * = address not valid,\n\n        Mac Address: & = duplicate\
-        \ static address,\n\n\nPort:  1/1/1 \n  Admin-State      :               DISABLED,\n\
-        \  Operation Mode   :               DISABLED,\n  Max MAC bridged  :      \
-        \                1,\n  Trap Threshold   :               DISABLED,\n  Violation\
-        \        :               RESTRICT,\n  Max MAC filtered :                 \
-        \     5,\n  Violating MAC    :                   NULL,\n  Pkt-Relay      \
-        \  :               DISABLED\n\n            MAC             VLAN       MAC\
-        \ TYPE          OPERATION    \n-------------------------+--------+-----------------+-----------------\n"
-      - 'No Port Security is configured in the system.
+    - "Legend: Mac Address: * = address not valid,\n\n        Mac Address: & = duplicate\
+      \ static address,\n\n\nPort:  1/1/1 \n  Admin-State      :               DISABLED,\n\
+      \  Operation Mode   :               DISABLED,\n  Max MAC bridged  :        \
+      \              1,\n  Trap Threshold   :               DISABLED,\n  Violation\
+      \        :               RESTRICT,\n  Max MAC filtered :                   \
+      \   5,\n  Violating MAC    :                   NULL,\n  Pkt-Relay        : \
+      \              DISABLED\n\n            MAC             VLAN       MAC TYPE \
+      \         OPERATION    \n-------------------------+--------+-----------------+-----------------\n"
+    - 'No Port Security is configured in the system.
 
 
-        '
+      '
   show system:
     output: "System:\n  Description:  Alcatel-Lucent Enterprise OS6350-P24 6.7.1.001.R01\
       \ GA, January 01, 2000.,\n  Object ID:    0.0.0.0.0.0.0000.000.0.0.0.0.00.0.0,\n\
@@ -415,13 +410,13 @@ commands:
     help: execute the command "show system"
     prompt: *id001
     output_variants:
-      - "System:\n  Description:  Alcatel-Lucent Enterprise OS6360-PH24 8.0.00.R01\
-        \ GA, January 01, 2000.,\n  Object ID:    0.0.0.0.0.0.0000.000.0.0.0.0.00.0.0,\n\
-        \  Up Time:      22 days 22 hours 22 minutes and 22 seconds,\n  Contact: \
-        \     Alcatel-Lucent Enterprise, https://www.al-enterprise.com,\n  Name: \
-        \        SWA_0001,\n  Location:     Espoo - Finland,\n  Services:     2,\n\
-        \  Date & Time:  MON DEC 24 2025 01:02:03 (CET)\nFlash Space:\n    Primary\
-        \ CMM:\n      Available (bytes):  501198848,\n      Comments         :  None\n"
+    - "System:\n  Description:  Alcatel-Lucent Enterprise OS6360-PH24 8.0.00.R01 GA,\
+      \ January 01, 2000.,\n  Object ID:    0.0.0.0.0.0.0000.000.0.0.0.0.00.0.0,\n\
+      \  Up Time:      22 days 22 hours 22 minutes and 22 seconds,\n  Contact:   \
+      \   Alcatel-Lucent Enterprise, https://www.al-enterprise.com,\n  Name:     \
+      \    SWA_0001,\n  Location:     Espoo - Finland,\n  Services:     2,\n  Date\
+      \ & Time:  MON DEC 24 2025 01:02:03 (CET)\nFlash Space:\n    Primary CMM:\n\
+      \      Available (bytes):  501198848,\n      Comments         :  None\n"
   show vlan port:
     output: "  vlan       port         type         status\n--------+------------+------------+--------------\n\
       \  1         1/1/23       default    inactive\n  1         1/1/25       qtagged\
@@ -429,5 +424,5 @@ commands:
     help: execute the command "show vlan port"
     prompt: *id001
     output_variants:
-      - " vlan   port     type      status\n------+-------+---------+-------------\n\
-        \    1    1/25   default     inactive\n    1    1/26   qtagged   forwarding\n"
+    - " vlan   port     type      status\n------+-------+---------+-------------\n\
+      \    1    1/25   default     inactive\n    1    1/26   qtagged   forwarding\n"

--- a/simnos/plugins/nos/platforms_yaml/alcatel_sros.yaml
+++ b/simnos/plugins/nos/platforms_yaml/alcatel_sros.yaml
@@ -674,102 +674,100 @@ commands:
       '
     help: execute the command "ping"
     prompt: &id001
-      - '{base_prompt}>'
-      - '{base_prompt}#'
+    - '{base_prompt}>'
+    - '{base_prompt}#'
     output_variants:
-      - 'PING 10.30.99.22 56 data bytes
+    - 'PING 10.30.99.22 56 data bytes
 
-        Request timed out. icmp_seq=1.
+      Request timed out. icmp_seq=1.
 
-        Request timed out. icmp_seq=2.
+      Request timed out. icmp_seq=2.
 
-        Request timed out. icmp_seq=3.
+      Request timed out. icmp_seq=3.
 
-        Request timed out. icmp_seq=4.
+      Request timed out. icmp_seq=4.
 
-        Request timed out. icmp_seq=5.
-
-
-        ---- 201.30.99.22 PING Statistics ----
-
-        5 packets transmitted, 5 packets bounced, 0 packets received, 100% packet
-        loss
-
-        '
-      - 'PING 10.39.119.105 56 data bytes
-
-        Request timed out. icmp_seq=1.
-
-        Request timed out. icmp_seq=2.
-
-        Request timed out. icmp_seq=3.
-
-        Request timed out. icmp_seq=4.
-
-        Request timed out. icmp_seq=5.
+      Request timed out. icmp_seq=5.
 
 
-        ---- 10.39.119.105 PING Statistics ----
+      ---- 201.30.99.22 PING Statistics ----
 
-        5 packets transmitted, 0 packets received, 100% packet loss
+      5 packets transmitted, 5 packets bounced, 0 packets received, 100% packet loss
 
-        '
-      - 'PING 10.42.255.74 56 data bytes
+      '
+    - 'PING 10.39.119.105 56 data bytes
 
-        !!!!!
+      Request timed out. icmp_seq=1.
 
-        ---- 10.42.255.74 PING Statistics ----
+      Request timed out. icmp_seq=2.
 
-        5 packets transmitted, 5 packets received, 0.00% packet loss
+      Request timed out. icmp_seq=3.
 
-        round-trip min = 2.36ms, avg = 2.39ms, max = 2.42ms, stddev = 0.025ms
+      Request timed out. icmp_seq=4.
 
-        '
-      - 'PING 10.30.99.22 56 data bytes
-
-
-        ---- 10.30.99.22 PING Statistics ----
-
-        5 packets transmitted, 5 packets bounced, 0 packets received, 100% packet
-        loss
-
-        '
-      - 'PING 10.53.16.134 56 data bytes
-
-        ...!!.!.
-
-        ---- 189.53.16.134 PING Statistics ----
-
-        5 packets transmitted, 0 packets received, 3 duplicates
-
-        '
-      - 'PING 10.39.119.105 56 data bytes
-
-        .....
-
-        ---- 10.39.119.105 PING Statistics ----
-
-        5 packets transmitted, 0 packets received, 100% packet loss
-
-        '
-      - 'PING 10.52.198.114 56 data bytes
-
-        Send failed. Source IP address is not local to the system
-
-        Send failed. Source IP address is not local to the system
-
-        Send failed. Source IP address is not local to the system
-
-        Send failed. Source IP address is not local to the system
-
-        Send failed. Source IP address is not local to the system
+      Request timed out. icmp_seq=5.
 
 
-        ---- 10.52.198.114 PING Statistics ----
+      ---- 10.39.119.105 PING Statistics ----
 
-        5 packets transmitted, 0 packets received, 100% packet loss
+      5 packets transmitted, 0 packets received, 100% packet loss
 
-        '
+      '
+    - 'PING 10.42.255.74 56 data bytes
+
+      !!!!!
+
+      ---- 10.42.255.74 PING Statistics ----
+
+      5 packets transmitted, 5 packets received, 0.00% packet loss
+
+      round-trip min = 2.36ms, avg = 2.39ms, max = 2.42ms, stddev = 0.025ms
+
+      '
+    - 'PING 10.30.99.22 56 data bytes
+
+
+      ---- 10.30.99.22 PING Statistics ----
+
+      5 packets transmitted, 5 packets bounced, 0 packets received, 100% packet loss
+
+      '
+    - 'PING 10.53.16.134 56 data bytes
+
+      ...!!.!.
+
+      ---- 189.53.16.134 PING Statistics ----
+
+      5 packets transmitted, 0 packets received, 3 duplicates
+
+      '
+    - 'PING 10.39.119.105 56 data bytes
+
+      .....
+
+      ---- 10.39.119.105 PING Statistics ----
+
+      5 packets transmitted, 0 packets received, 100% packet loss
+
+      '
+    - 'PING 10.52.198.114 56 data bytes
+
+      Send failed. Source IP address is not local to the system
+
+      Send failed. Source IP address is not local to the system
+
+      Send failed. Source IP address is not local to the system
+
+      Send failed. Source IP address is not local to the system
+
+      Send failed. Source IP address is not local to the system
+
+
+      ---- 10.52.198.114 PING Statistics ----
+
+      5 packets transmitted, 0 packets received, 100% packet loss
+
+      '
   show lag port:
     output: "\n===============================================================================\n\
       Lag Port States\nLACP Status: e - Enabled, d - Disabled\n===============================================================================\n\
@@ -807,69 +805,67 @@ commands:
     help: execute the command "show lag port"
     prompt: *id001
     output_variants:
-      - "\n===============================================================================\n\
-        Lag Port States\nLACP Status: e - Enabled, d - Disabled\n===============================================================================\n\
-        Name\nId     Port-id         Adm   Act/     Opr   Primary Sub-group     Forced\
-        \ Prio\n                             Stdby\n-------------------------------------------------------------------------------\n\
-        lag-1\n1(e)   1/1/1           down  active   down  yes     1             -\
-        \      32768\nlag-2\n2(e)   1/1/2           up    active   up    yes     1\
-        \             -      32768\nlag-3\n3(d)   1/1/3           up    active   up\
-        \    yes     1             -      32768\nlag-4\n4(d)   1/1/4           up\
-        \    active   up    yes     1             -      32768\nlag-5\n5(d)   1/1/5\
-        \           up    active   up    yes     1             -      32768\nlag-6\n\
-        6(d)   1/1/6           up    active   up    yes     1             -      32768\n\
-        lag-7\n7(d)   1/1/7           up    active   up    yes     1             -\
-        \      32768\nlag-8\n8(d)   1/1/8           up    active   up    yes     1\
-        \             -      32768\nlag-9\n9(d)   1/1/9           up    active   up\
-        \    yes     1             -      32768\nlag-10\n10(d)  1/1/10          up\
-        \    active   up    yes     1             -      32768\nlag-11\n11(e)  1/1/11\
-        \          up    active   up    yes     1             -      32768\nlag-12\n\
-        12(d)  1/1/12          up    active   up    yes     1             -      32768\n\
-        lag-13\n13(d)  1/1/13          up    active   up    yes     1            \
-        \ -      32768\nlag-14\n14(d)  1/1/14          up    active   up    yes  \
-        \   1             -      32768\nlag-15\n15(e)  1/1/15          up    active\
-        \   up    yes     1             -      32768\nlag-16\n16(e)  1/1/16      \
-        \    up    active   up    yes     1             -      32768\nlag-17\n17(d)\
-        \  1/1/17          up    active   up    yes     1             -      32768\n\
-        lag-18\n18(d)  1/1/18          up    active   up    yes     1            \
-        \ -      32768\nlag-19\n19(d)  1/1/19          up    active   up    yes  \
-        \   1             -      32768\nlag-20\n20(e)  1/1/20          up    active\
-        \   up    yes     1             -      32768\nlag-21\n21(e)  1/1/21      \
-        \    up    active   up    yes     1             -      32768\nlag-22\n22(d)\
-        \  1/1/22          up    active   up    yes     1             -      32768\n\
-        lag-23\n23(d)  1/1/23          up    active   up    yes     1            \
-        \ -      32768\nlag-24\n24(e)  1/1/24          up    active   up    yes  \
-        \   1             -      32768\nlag-25\n25(d)  1/1/25          up    active\
-        \   up    yes     1             -      32768\nlag-26\n26(d)  1/1/26      \
-        \    up    active   up    yes     1             -      32768\nlag-27\n27(e)\
-        \  1/1/27          up    active   up    yes     1             -      32768\n\
-        lag-28\n28(d)  1/1/28          up    active   up    yes     1            \
-        \ -      32768\nlag-29\n29(d)  1/1/29          up    active   up    yes  \
-        \   1             -      32768\nlag-30\n30(d)  1/1/30          up    active\
-        \   up    yes     1             -      32768\nlag-31\n31(e)  1/1/31      \
-        \    up    active   up    yes     1             -      32768\nlag-32\n32(d)\
-        \  1/1/32          up    active   up    yes     1             -      32768\n\
-        lag-33\n33(e)  1/1/33          up    active   up    yes     1            \
-        \ -      32768\nlag-34\n34(d)  1/1/34          up    active   up    yes  \
-        \   1             -      32768\nlag-35\n35(d)  1/1/35          up    active\
-        \   up    yes     1             -      32768\nlag-36\n36(d)  1/1/36      \
-        \    up    active   up    yes     1             -      32768\nlag-37\n37(d)\
-        \  1/1/37          up    active   up    yes     1             -      32768\n\
-        lag-38\n38(d)  1/1/38          up    active   up    yes     1            \
-        \ -      32768\nlag-39\n39(d)  1/1/39          up    active   up    yes  \
-        \   1             -      32768\nlag-40\n40(d)  1/1/40          up    active\
-        \   up    yes     1             -      32768\nlag-41\n41(d)  1/1/41      \
-        \    up    active   up    yes     1             -      32768\nlag-42\n42(d)\
-        \  1/1/42          up    active   up    yes     1             -      32768\n\
-        lag-49\n49(e)  1/1/c49/1       up    active   up    yes     1            \
-        \ -      32768\nlag-51\n51(e)  1/1/c51/1       up    active   up    yes  \
-        \   1             -      32768\nlag-52\n52(e)  1/1/c52/1       up    active\
-        \   up    yes     1             -      32768\nlag-64\n64(e)  1/1/45      \
-        \    up    active   up    yes     1             -      32768\n       1/1/46\
-        \          up    active   up            1             -      32768\n     \
-        \  1/1/47          up    active   up            1             -      32768\n\
-        \       1/1/48          up    active   up            1             -     \
-        \ 32768\n===============================================================================\n"
+    - "\n===============================================================================\n\
+      Lag Port States\nLACP Status: e - Enabled, d - Disabled\n===============================================================================\n\
+      Name\nId     Port-id         Adm   Act/     Opr   Primary Sub-group     Forced\
+      \ Prio\n                             Stdby\n-------------------------------------------------------------------------------\n\
+      lag-1\n1(e)   1/1/1           down  active   down  yes     1             - \
+      \     32768\nlag-2\n2(e)   1/1/2           up    active   up    yes     1  \
+      \           -      32768\nlag-3\n3(d)   1/1/3           up    active   up  \
+      \  yes     1             -      32768\nlag-4\n4(d)   1/1/4           up    active\
+      \   up    yes     1             -      32768\nlag-5\n5(d)   1/1/5          \
+      \ up    active   up    yes     1             -      32768\nlag-6\n6(d)   1/1/6\
+      \           up    active   up    yes     1             -      32768\nlag-7\n\
+      7(d)   1/1/7           up    active   up    yes     1             -      32768\n\
+      lag-8\n8(d)   1/1/8           up    active   up    yes     1             - \
+      \     32768\nlag-9\n9(d)   1/1/9           up    active   up    yes     1  \
+      \           -      32768\nlag-10\n10(d)  1/1/10          up    active   up \
+      \   yes     1             -      32768\nlag-11\n11(e)  1/1/11          up  \
+      \  active   up    yes     1             -      32768\nlag-12\n12(d)  1/1/12\
+      \          up    active   up    yes     1             -      32768\nlag-13\n\
+      13(d)  1/1/13          up    active   up    yes     1             -      32768\n\
+      lag-14\n14(d)  1/1/14          up    active   up    yes     1             -\
+      \      32768\nlag-15\n15(e)  1/1/15          up    active   up    yes     1\
+      \             -      32768\nlag-16\n16(e)  1/1/16          up    active   up\
+      \    yes     1             -      32768\nlag-17\n17(d)  1/1/17          up \
+      \   active   up    yes     1             -      32768\nlag-18\n18(d)  1/1/18\
+      \          up    active   up    yes     1             -      32768\nlag-19\n\
+      19(d)  1/1/19          up    active   up    yes     1             -      32768\n\
+      lag-20\n20(e)  1/1/20          up    active   up    yes     1             -\
+      \      32768\nlag-21\n21(e)  1/1/21          up    active   up    yes     1\
+      \             -      32768\nlag-22\n22(d)  1/1/22          up    active   up\
+      \    yes     1             -      32768\nlag-23\n23(d)  1/1/23          up \
+      \   active   up    yes     1             -      32768\nlag-24\n24(e)  1/1/24\
+      \          up    active   up    yes     1             -      32768\nlag-25\n\
+      25(d)  1/1/25          up    active   up    yes     1             -      32768\n\
+      lag-26\n26(d)  1/1/26          up    active   up    yes     1             -\
+      \      32768\nlag-27\n27(e)  1/1/27          up    active   up    yes     1\
+      \             -      32768\nlag-28\n28(d)  1/1/28          up    active   up\
+      \    yes     1             -      32768\nlag-29\n29(d)  1/1/29          up \
+      \   active   up    yes     1             -      32768\nlag-30\n30(d)  1/1/30\
+      \          up    active   up    yes     1             -      32768\nlag-31\n\
+      31(e)  1/1/31          up    active   up    yes     1             -      32768\n\
+      lag-32\n32(d)  1/1/32          up    active   up    yes     1             -\
+      \      32768\nlag-33\n33(e)  1/1/33          up    active   up    yes     1\
+      \             -      32768\nlag-34\n34(d)  1/1/34          up    active   up\
+      \    yes     1             -      32768\nlag-35\n35(d)  1/1/35          up \
+      \   active   up    yes     1             -      32768\nlag-36\n36(d)  1/1/36\
+      \          up    active   up    yes     1             -      32768\nlag-37\n\
+      37(d)  1/1/37          up    active   up    yes     1             -      32768\n\
+      lag-38\n38(d)  1/1/38          up    active   up    yes     1             -\
+      \      32768\nlag-39\n39(d)  1/1/39          up    active   up    yes     1\
+      \             -      32768\nlag-40\n40(d)  1/1/40          up    active   up\
+      \    yes     1             -      32768\nlag-41\n41(d)  1/1/41          up \
+      \   active   up    yes     1             -      32768\nlag-42\n42(d)  1/1/42\
+      \          up    active   up    yes     1             -      32768\nlag-49\n\
+      49(e)  1/1/c49/1       up    active   up    yes     1             -      32768\n\
+      lag-51\n51(e)  1/1/c51/1       up    active   up    yes     1             -\
+      \      32768\nlag-52\n52(e)  1/1/c52/1       up    active   up    yes     1\
+      \             -      32768\nlag-64\n64(e)  1/1/45          up    active   up\
+      \    yes     1             -      32768\n       1/1/46          up    active\
+      \   up            1             -      32768\n       1/1/47          up    active\
+      \   up            1             -      32768\n       1/1/48          up    active\
+      \   up            1             -      32768\n===============================================================================\n"
   show port description:
     output: '===============================================================================
 
@@ -1054,15 +1050,15 @@ commands:
     help: execute the command "show service service-using"
     prompt: *id001
     output_variants:
-      - "===============================================================================\n\
-        Services \n===============================================================================\n\
-        ServiceId    Type      Adm  Opr  CustomerId Service Name\n-------------------------------------------------------------------------------\n\
-        1000         VPRN      Up   Up   1000       DELTA_CLIENT:581\n1046       \
-        \  VPRN      Up   Up   128978     LIQ:8293\n1048         IES       Up   Up\
-        \   123714     BALD_JEAN\n1049         IES       Up   Down 121593     BOLD_PORT02\n\
-        1052         IES       Up   Down 129882     SPACE1 AC\n1054         IES  \
-        \     Up   Down 130273     SPACE1 COM SPACE2\n1061         IES       Up  \
-        \ Down 11402      B0LD_MR_IUB_UNION\n1095         IES       Up   Down 117029\
-        \     BUILD_VALR_1146ABC292\n-------------------------------------------------------------------------------\n\
-        Matching Services : 8\n-------------------------------------------------------------------------------\n\
-        ===============================================================================\n"
+    - "===============================================================================\n\
+      Services \n===============================================================================\n\
+      ServiceId    Type      Adm  Opr  CustomerId Service Name\n-------------------------------------------------------------------------------\n\
+      1000         VPRN      Up   Up   1000       DELTA_CLIENT:581\n1046         VPRN\
+      \      Up   Up   128978     LIQ:8293\n1048         IES       Up   Up   123714\
+      \     BALD_JEAN\n1049         IES       Up   Down 121593     BOLD_PORT02\n1052\
+      \         IES       Up   Down 129882     SPACE1 AC\n1054         IES       Up\
+      \   Down 130273     SPACE1 COM SPACE2\n1061         IES       Up   Down 11402\
+      \      B0LD_MR_IUB_UNION\n1095         IES       Up   Down 117029     BUILD_VALR_1146ABC292\n\
+      -------------------------------------------------------------------------------\n\
+      Matching Services : 8\n-------------------------------------------------------------------------------\n\
+      ===============================================================================\n"

--- a/simnos/plugins/nos/platforms_yaml/alcatel_sros.yaml
+++ b/simnos/plugins/nos/platforms_yaml/alcatel_sros.yaml
@@ -651,3 +651,418 @@ commands:
     prompt:
     - "{base_prompt}>"
     - "{base_prompt}#"
+  ping:
+    output: 'PING 10.252.117.158 56 data bytes
+
+      64 bytes from 10.252.117.158: icmp_seq=1 ttl=255 time=1.93ms.
+
+      64 bytes from 10.252.117.158: icmp_seq=2 ttl=255 time=1.89ms.
+
+      64 bytes from 10.252.117.158: icmp_seq=3 ttl=255 time=1.80ms.
+
+      64 bytes from 10.252.117.158: icmp_seq=4 ttl=255 time=1.84ms.
+
+      64 bytes from 10.252.117.158: icmp_seq=5 ttl=255 time=1.70ms.
+
+
+      ---- 10.252.117.158 PING Statistics ----
+
+      5 packets transmitted, 5 packets received, 0.00% packet loss
+
+      round-trip min = 1.70ms, avg = 1.83ms, max = 1.93ms, stddev = 0.079ms
+
+      '
+    help: execute the command "ping"
+    prompt: &id001
+      - '{base_prompt}>'
+      - '{base_prompt}#'
+    output_variants:
+      - 'PING 10.30.99.22 56 data bytes
+
+        Request timed out. icmp_seq=1.
+
+        Request timed out. icmp_seq=2.
+
+        Request timed out. icmp_seq=3.
+
+        Request timed out. icmp_seq=4.
+
+        Request timed out. icmp_seq=5.
+
+
+        ---- 201.30.99.22 PING Statistics ----
+
+        5 packets transmitted, 5 packets bounced, 0 packets received, 100% packet
+        loss
+
+        '
+      - 'PING 10.39.119.105 56 data bytes
+
+        Request timed out. icmp_seq=1.
+
+        Request timed out. icmp_seq=2.
+
+        Request timed out. icmp_seq=3.
+
+        Request timed out. icmp_seq=4.
+
+        Request timed out. icmp_seq=5.
+
+
+        ---- 10.39.119.105 PING Statistics ----
+
+        5 packets transmitted, 0 packets received, 100% packet loss
+
+        '
+      - 'PING 10.42.255.74 56 data bytes
+
+        !!!!!
+
+        ---- 10.42.255.74 PING Statistics ----
+
+        5 packets transmitted, 5 packets received, 0.00% packet loss
+
+        round-trip min = 2.36ms, avg = 2.39ms, max = 2.42ms, stddev = 0.025ms
+
+        '
+      - 'PING 10.30.99.22 56 data bytes
+
+
+        ---- 10.30.99.22 PING Statistics ----
+
+        5 packets transmitted, 5 packets bounced, 0 packets received, 100% packet
+        loss
+
+        '
+      - 'PING 10.53.16.134 56 data bytes
+
+        ...!!.!.
+
+        ---- 189.53.16.134 PING Statistics ----
+
+        5 packets transmitted, 0 packets received, 3 duplicates
+
+        '
+      - 'PING 10.39.119.105 56 data bytes
+
+        .....
+
+        ---- 10.39.119.105 PING Statistics ----
+
+        5 packets transmitted, 0 packets received, 100% packet loss
+
+        '
+      - 'PING 10.52.198.114 56 data bytes
+
+        Send failed. Source IP address is not local to the system
+
+        Send failed. Source IP address is not local to the system
+
+        Send failed. Source IP address is not local to the system
+
+        Send failed. Source IP address is not local to the system
+
+        Send failed. Source IP address is not local to the system
+
+
+        ---- 10.52.198.114 PING Statistics ----
+
+        5 packets transmitted, 0 packets received, 100% packet loss
+
+        '
+  show lag port:
+    output: "\n===============================================================================\n\
+      Lag Port States\nLACP Status: e - Enabled, d - Disabled\n===============================================================================\n\
+      Lag-id Port-id        Adm   Act/     Opr   Primary Sub-group      Forced Prio\n\
+      \                            Stdby\n-------------------------------------------------------------------------------\n\
+      5(d)   1/1/15         up    active   down  yes     1              -      32768\n\
+      \       1/1/16         up    active   down          2              -      32768\n\
+      10(e)  1/1/1          down  active   down  yes     1              -      32768\n\
+      11(d)  1/1/2          up    active   down  yes     1              -      32768\n\
+      12(d)  1/1/3          up    active   down  yes     1              -      32768\n\
+      13(d)  1/1/4          up    active   down  yes     1              -      32768\n\
+      14(d)  1/1/5          up    active   down  yes     1              -      32768\n\
+      15(d)  1/1/6          up    active   down  yes     1              -      32768\n\
+      16(d)  1/1/7          up    active   down  yes     1              -      32768\n\
+      17(d)  1/1/8          up    active   down  yes     1              -      32768\n\
+      18(d)  1/1/9          up    active   down  yes     1              -      32768\n\
+      19(e)  1/1/10         up    active   down  yes     1              -      32768\n\
+      20(d)  1/1/12         up    active   down  yes     1              -      32768\n\
+      51(d)  1/1/13         up    active   down  yes     1              -      32768\n\
+      \       1/1/14         up    active   down          1              -      32768\n\
+      52(d)  1/1/18         up    active   down  yes     1              -      32768\n\
+      53(d)  1/1/19         up    active   down  yes     1              -      32768\n\
+      54(d)  1/1/20         down  active   down  yes     1              -      32768\n\
+      115(e) 3/2/2          up    active   up    yes     2              -      32768\n\
+      \       7/2/3          up    standby  down          1              -      32768\n\
+      116(e) esat-1/1/6     up    active   up    yes     1              -      32768\n\
+      \       esat-2/1/6     up    standby  down          2              -      32768\n\
+      120(e) 2/1/13         up    active   up    yes     1              -      32768\n\
+      \       3/1/4          up    standby  down          2              -      32768\n\
+      121(e) 3/2/6          up    standby  down  yes     1              -      32768\n\
+      \       8/1/5          up    active   up            2              -      32768\n\
+      122(e) A/6            up    standby  down  yes     1              -      32768\n\
+      \       B/5            up    active   up            2              -      32768\n\
+      ===============================================================================\n"
+    help: execute the command "show lag port"
+    prompt: *id001
+    output_variants:
+      - "\n===============================================================================\n\
+        Lag Port States\nLACP Status: e - Enabled, d - Disabled\n===============================================================================\n\
+        Name\nId     Port-id         Adm   Act/     Opr   Primary Sub-group     Forced\
+        \ Prio\n                             Stdby\n-------------------------------------------------------------------------------\n\
+        lag-1\n1(e)   1/1/1           down  active   down  yes     1             -\
+        \      32768\nlag-2\n2(e)   1/1/2           up    active   up    yes     1\
+        \             -      32768\nlag-3\n3(d)   1/1/3           up    active   up\
+        \    yes     1             -      32768\nlag-4\n4(d)   1/1/4           up\
+        \    active   up    yes     1             -      32768\nlag-5\n5(d)   1/1/5\
+        \           up    active   up    yes     1             -      32768\nlag-6\n\
+        6(d)   1/1/6           up    active   up    yes     1             -      32768\n\
+        lag-7\n7(d)   1/1/7           up    active   up    yes     1             -\
+        \      32768\nlag-8\n8(d)   1/1/8           up    active   up    yes     1\
+        \             -      32768\nlag-9\n9(d)   1/1/9           up    active   up\
+        \    yes     1             -      32768\nlag-10\n10(d)  1/1/10          up\
+        \    active   up    yes     1             -      32768\nlag-11\n11(e)  1/1/11\
+        \          up    active   up    yes     1             -      32768\nlag-12\n\
+        12(d)  1/1/12          up    active   up    yes     1             -      32768\n\
+        lag-13\n13(d)  1/1/13          up    active   up    yes     1            \
+        \ -      32768\nlag-14\n14(d)  1/1/14          up    active   up    yes  \
+        \   1             -      32768\nlag-15\n15(e)  1/1/15          up    active\
+        \   up    yes     1             -      32768\nlag-16\n16(e)  1/1/16      \
+        \    up    active   up    yes     1             -      32768\nlag-17\n17(d)\
+        \  1/1/17          up    active   up    yes     1             -      32768\n\
+        lag-18\n18(d)  1/1/18          up    active   up    yes     1            \
+        \ -      32768\nlag-19\n19(d)  1/1/19          up    active   up    yes  \
+        \   1             -      32768\nlag-20\n20(e)  1/1/20          up    active\
+        \   up    yes     1             -      32768\nlag-21\n21(e)  1/1/21      \
+        \    up    active   up    yes     1             -      32768\nlag-22\n22(d)\
+        \  1/1/22          up    active   up    yes     1             -      32768\n\
+        lag-23\n23(d)  1/1/23          up    active   up    yes     1            \
+        \ -      32768\nlag-24\n24(e)  1/1/24          up    active   up    yes  \
+        \   1             -      32768\nlag-25\n25(d)  1/1/25          up    active\
+        \   up    yes     1             -      32768\nlag-26\n26(d)  1/1/26      \
+        \    up    active   up    yes     1             -      32768\nlag-27\n27(e)\
+        \  1/1/27          up    active   up    yes     1             -      32768\n\
+        lag-28\n28(d)  1/1/28          up    active   up    yes     1            \
+        \ -      32768\nlag-29\n29(d)  1/1/29          up    active   up    yes  \
+        \   1             -      32768\nlag-30\n30(d)  1/1/30          up    active\
+        \   up    yes     1             -      32768\nlag-31\n31(e)  1/1/31      \
+        \    up    active   up    yes     1             -      32768\nlag-32\n32(d)\
+        \  1/1/32          up    active   up    yes     1             -      32768\n\
+        lag-33\n33(e)  1/1/33          up    active   up    yes     1            \
+        \ -      32768\nlag-34\n34(d)  1/1/34          up    active   up    yes  \
+        \   1             -      32768\nlag-35\n35(d)  1/1/35          up    active\
+        \   up    yes     1             -      32768\nlag-36\n36(d)  1/1/36      \
+        \    up    active   up    yes     1             -      32768\nlag-37\n37(d)\
+        \  1/1/37          up    active   up    yes     1             -      32768\n\
+        lag-38\n38(d)  1/1/38          up    active   up    yes     1            \
+        \ -      32768\nlag-39\n39(d)  1/1/39          up    active   up    yes  \
+        \   1             -      32768\nlag-40\n40(d)  1/1/40          up    active\
+        \   up    yes     1             -      32768\nlag-41\n41(d)  1/1/41      \
+        \    up    active   up    yes     1             -      32768\nlag-42\n42(d)\
+        \  1/1/42          up    active   up    yes     1             -      32768\n\
+        lag-49\n49(e)  1/1/c49/1       up    active   up    yes     1            \
+        \ -      32768\nlag-51\n51(e)  1/1/c51/1       up    active   up    yes  \
+        \   1             -      32768\nlag-52\n52(e)  1/1/c52/1       up    active\
+        \   up    yes     1             -      32768\nlag-64\n64(e)  1/1/45      \
+        \    up    active   up    yes     1             -      32768\n       1/1/46\
+        \          up    active   up            1             -      32768\n     \
+        \  1/1/47          up    active   up            1             -      32768\n\
+        \       1/1/48          up    active   up            1             -     \
+        \ 32768\n===============================================================================\n"
+  show port description:
+    output: '===============================================================================
+
+      Port Descriptions on Slot 1
+
+      ===============================================================================
+
+      Port Id        Description
+
+      -------------------------------------------------------------------------------
+
+      1/1/1          some_gig1_test
+
+      1/1/2          some2_gig1_test
+
+      1/1/3          some3_gig1_test
+
+      1/1/4          some4_gig1_test
+
+      1/1/5          some5_gig1_test
+
+      1/1/6          10/100/Gig Ethernet SFP
+
+      1/1/7          10/100/Gig Ethernet SFP
+
+      1/1/8          10/100/Gig Ethernet SFP
+
+      1/1/9          10/100/Gig Ethernet SFP
+
+      1/1/10         10/100/Gig Ethernet SFP
+
+      1/1/11         10/100/Gig Ethernet SFP
+
+      1/1/12         TEST_AGG_TOGGLE
+
+      1/1/13         TNET_RAN_TEST1
+
+      1/1/14         TNET_RAN_TEST2
+
+      1/1/15         test 1
+
+      1/1/16         test 2
+
+      1/1/17         TEST_3
+
+      1/1/18         TNET_RAN_TEST3
+
+      1/1/19         TNET_RAN_TEST4
+
+      1/1/20         TNET_RAN_TEST5
+
+      1/5/1          10-Gig Ethernet
+
+      1/5/2          10-Gig Ethernet
+
+
+      ===============================================================================
+
+      Port Descriptions on Slot A
+
+      ===============================================================================
+
+      Port Id        Description
+
+      -------------------------------------------------------------------------------
+
+      A/1            10/100 Ethernet TX
+
+      ===============================================================================
+
+
+      ===============================================================================
+
+      Port Descriptions on Satellite esat-3
+
+      ===============================================================================
+
+      Port Id        Description
+
+      -------------------------------------------------------------------------------
+
+      esat-3/1/21    TNET_RAN_TEST9999
+
+      ===============================================================================
+
+
+      '
+    help: execute the command "show port description"
+    prompt: *id001
+  show service id 0 sap:
+    output: "===============================================================================\n\
+      SAP(Summary), Service 24731\n===============================================================================\n\
+      PortId                          SvcId      Ing.  Ing.    Egr.  Egr.   Adm  Opr\n\
+      \                                           QoS   Fltr    QoS   Fltr\n-------------------------------------------------------------------------------\n\
+      lag-54:950                      24731      1     none    1     none   Up   Down\n\
+      -------------------------------------------------------------------------------\n\
+      Number of SAPs : 1\n-------------------------------------------------------------------------------\n\
+      ===============================================================================\n"
+    help: execute the command "show service id 0 sap"
+    prompt: *id001
+  show service id interface:
+    output: "\n==============================================================================\n\
+      Interface Table\n==============================================================================\n\
+      Interface-Name                   Adm       Opr(v4/v6)  Type    Port/SapId\n\
+      \   IP-Address                                                  PfxState\n------------------------------------------------------------------------------\n\
+      Gigaesat-1/1/5:7                 Up        Up/Up       IES     esat-1/1/5:7.0\n\
+      \   10.42.255.73/30                                            n/a\n   fe80:a8:2:90::8d5/126\
+      \                                       PREFERRED\n   fe80::22e0:9cff:fe20:d401/64\
+      \                                PREFERRED\n------------------------------------------------------------------------------\n\
+      Interfaces : 1\n==============================================================================\n"
+    help: execute the command "show service id interface"
+    prompt: *id001
+  show service service-name-using:
+    output: '===============================================================================
+
+      Services By Name
+
+      ===============================================================================
+
+      Service Name                                                 Type   Service
+      Id
+
+      -------------------------------------------------------------------------------
+
+      ROYAL_CUSTOMER:3581                                           Vprn         1200
+
+      LLC:3293                                                      Vprn         1246
+
+      OLD_UNIVERSE AC                                               Ies          1042
+
+      OLD_M PUB UNION                                               Ies          1041
+
+      TLS_TCE-AC                                                    Ies          1170
+
+      ABC_MPLS:6666                                                 Vprn         1171
+
+      _tmnx_InternalVplsService                                     intV*  2147487649
+
+      _tmnx_InternalSatVpls                                         Vpls   2148667979
+
+      _tmnx_InternalSatVprn                                         Vprn   2141237980
+
+      -------------------------------------------------------------------------------
+
+      Matching Services : 9
+
+      ===============================================================================
+
+      '
+    help: execute the command "show service service-name-using"
+    prompt: *id001
+  show service service-using:
+    output: '
+
+      ===============================================================================
+
+      Services [vpls]  Customer 4020
+
+      ===============================================================================
+
+      ServiceId    Type      Adm  Opr  CustomerId Service Name
+
+      -------------------------------------------------------------------------------
+
+      24728        VPLS      Up   Down 4020       testservice1
+
+      24729        VPLS      Up   Up   4020       test-service2
+
+      24730        VPLS      Up   Down 4020       testservice3
+
+      24731        VPLS      Up   Down 4020       testservice5
+
+      -------------------------------------------------------------------------------
+
+      Matching Services : 4
+
+      -------------------------------------------------------------------------------
+
+      ===============================================================================
+
+      '
+    help: execute the command "show service service-using"
+    prompt: *id001
+    output_variants:
+      - "===============================================================================\n\
+        Services \n===============================================================================\n\
+        ServiceId    Type      Adm  Opr  CustomerId Service Name\n-------------------------------------------------------------------------------\n\
+        1000         VPRN      Up   Up   1000       DELTA_CLIENT:581\n1046       \
+        \  VPRN      Up   Up   128978     LIQ:8293\n1048         IES       Up   Up\
+        \   123714     BALD_JEAN\n1049         IES       Up   Down 121593     BOLD_PORT02\n\
+        1052         IES       Up   Down 129882     SPACE1 AC\n1054         IES  \
+        \     Up   Down 130273     SPACE1 COM SPACE2\n1061         IES       Up  \
+        \ Down 11402      B0LD_MR_IUB_UNION\n1095         IES       Up   Down 117029\
+        \     BUILD_VALR_1146ABC292\n-------------------------------------------------------------------------------\n\
+        Matching Services : 8\n-------------------------------------------------------------------------------\n\
+        ===============================================================================\n"

--- a/simnos/plugins/nos/platforms_yaml/aruba_aoscx.yaml
+++ b/simnos/plugins/nos/platforms_yaml/aruba_aoscx.yaml
@@ -502,3 +502,101 @@ commands:
     prompt:
     - '{base_prompt}>'
     - '{base_prompt}#'
+  show vrf:
+    output: "VRF Configuration:\n------------------\nVRF Name   : default\n      \
+      \  Interfaces             Status\n        -----------------------------\n  \
+      \      1/1/9                    down\n        1/1/10                   down\n\
+      \        1/1/11                   down\n        1/1/12                   down\n\
+      \        1/1/15                   down\n        1/1/20                   down\n\
+      \        1/1/21                   down\n        1/1/22                   down\n\
+      \        1/1/23                   down\n        1/1/24                   down\n\
+      \        1/1/37                   down\n        1/1/38                   down\n\
+      \        1/1/39                   down\n        1/1/40                   down\n\
+      \        1/1/41                   down\n        1/1/42                   down\n\
+      \        1/1/43                   down\n        1/1/44                   down\n\
+      \        1/1/45                   down\n        1/1/46                   down\n\
+      \        1/1/47                   down\n        1/1/52                   down\n\
+      \        1/1/54                   down\n        1/1/55                   down\n\
+      \        1/1/56                   down\n\nVRF Name   : VRF_GREEN\n        Interfaces\
+      \             Status\n        -----------------------------\n        loopback117\
+      \              up\n        vlan704                  up\n        vlan917    \
+      \              up\n\nVRF Name   : VRF_BLUE\n        Interfaces             Status\n\
+      \        -----------------------------\n        loopback102              up\n\
+      \        vlan7                    up\n        vlan9                    up\n\
+      \        vlan903                  up\n\nVRF Name   : CCTV\n        Interfaces\
+      \             Status\n        -----------------------------\n        loopback103\
+      \              up\n        vlan904                  up\n\nVRF Name   : CLIENT\n\
+      \        Interfaces             Status\n        -----------------------------\n\
+      \        loopback109              up\n        vlan10                   up\n\
+      \        vlan910                  up\n\nVRF Name   : DMZ\n        Interfaces\
+      \             Status\n        -----------------------------\n        loopback129\
+      \              up\n        vlan1300                 up\n        vlan1302   \
+      \              up\n        vlan1325                 up\n\nVRF Name   : VRF_INT_A\n\
+      \        Interfaces             Status\n        -----------------------------\n\
+      \        loopback126              up\n        vlan502                  up\n\
+      \        vlan924                  up\n        vlan926                  up\n\n\
+      VRF Name   : INTERNET_DMZ\n        Interfaces             Status\n        -----------------------------\n\
+      \        loopback127              up\n        vlan707                  up\n\
+      \        vlan927                  up\n        vlan2540                 up\n\n\
+      VRF Name   : INTERNET_ISP\n        Interfaces             Status\n        -----------------------------\n\
+      \        vlan714                  up\n        vlan715                  up\n\
+      \        vlan716                  up\n        vlan717                  up\n\n\
+      VRF Name   : VRF_INT_B\n        Interfaces             Status\n        -----------------------------\n\
+      \        loopback125              up\n        vlan501                  up\n\
+      \        vlan923                  up\n        vlan925                  up\n\n\
+      VRF Name   : VRF_MAGENTA\n        Interfaces             Status\n        -----------------------------\n\
+      \        1/1/48                   up\n\nVRF Name   : VRF_YELLOW\n        Interfaces\
+      \             Status\n        -----------------------------\n        loopback121\
+      \              up\n        vlan830                  up\n        vlan831    \
+      \              up\n        vlan876                  up\n        vlan922    \
+      \              up\n\nVRF Name   : MEDICAL\n        Interfaces             Status\n\
+      \        -----------------------------\n        loopback108              up\n\
+      \        vlan31                   up\n        vlan909                  up\n\n\
+      VRF Name   : MGMT\n        Interfaces             Status\n        -----------------------------\n\
+      \        loopback110              up\n        vlan2                    up\n\
+      \        vlan5                    up\n        vlan60                   up\n\
+      \        vlan61                   up\n        vlan62                   up\n\
+      \        vlan63                   up\n        vlan64                   up\n\
+      \        vlan65                   up\n        vlan66                   up\n\
+      \        vlan67                   up\n        vlan911                  up\n\n\
+      VRF Name   : MULTIMEDIA\n        Interfaces             Status\n        -----------------------------\n\
+      \        loopback100              up\n        vlan901                  up\n\n\
+      VRF Name   : PCI\n        Interfaces             Status\n        -----------------------------\n\
+      \        loopback104              up\n        vlan12                   up\n\
+      \        vlan905                  up\n\nVRF Name   : POS\n        Interfaces\
+      \             Status\n        -----------------------------\n        loopback107\
+      \              up\n        vlan30                   up\n        vlan40     \
+      \              up\n        vlan140                  up\n        vlan908    \
+      \              up\n\nVRF Name   : SD-WAN\n        Interfaces             Status\n\
+      \        -----------------------------\n        loopback111              up\n\
+      \        vlan102                  up\n        vlan801                  up\n\
+      \        vlan912                  up\n\nVRF Name   : VRF_RED\n        Interfaces\
+      \             Status\n        -----------------------------\n        loopback101\
+      \              up\n        vlan11                   up\n        vlan902    \
+      \              up\n\nVRF Name   : SERVICE\n        Interfaces             Status\n\
+      \        -----------------------------\n        loopback130              up\n\
+      \        vlan1600                 up\n        vlan1660                 up\n\
+      \        vlan1661                 up\n        vlan1665                 up\n\
+      \        vlan1670                 up\n\nVRF Name   : VRF_ORANGE\n        Interfaces\
+      \             Status\n        -----------------------------\n        loopback113\
+      \              up\n        vlan914                  up\n\nVRF Name   : VRF_PURPLE\n\
+      \        Interfaces             Status\n        -----------------------------\n\
+      \nVRF Name   : TELEPHONY\n        Interfaces             Status\n        -----------------------------\n\
+      \nVRF Name   : VRF_CYAN\n        Interfaces             Status\n        -----------------------------\n\
+      \        loopback105              up\n        vlan385                  up\n\
+      \        vlan906                  up\n\nVRF Name   : VENDOR\n        Interfaces\
+      \             Status\n        -----------------------------\n        loopback106\
+      \              up\n        vlan20                   up\n        vlan907    \
+      \              up\n        vlan2070                 up\n\nVRF Name   : VOIP\n\
+      \        Interfaces             Status\n        -----------------------------\n\
+      \        loopback128              up\n        vlan55                   up\n\
+      \        vlan75                   up\n        vlan305                  up\n\
+      \        vlan310                  up\n        vlan928                  up\n"
+    help: execute the command "show vrf"
+    prompt:
+      - '{base_prompt}>'
+      - '{base_prompt}#'
+    output_variants:
+      - "VRF Configuration:\n------------------\nVRF Name   : default\n        Interfaces\
+        \             Status\n        -----------------------------\n        vlan1\
+        \                    up\n        vlan61                   up\n"

--- a/simnos/plugins/nos/platforms_yaml/aruba_aoscx.yaml
+++ b/simnos/plugins/nos/platforms_yaml/aruba_aoscx.yaml
@@ -594,9 +594,9 @@ commands:
       \        vlan310                  up\n        vlan928                  up\n"
     help: execute the command "show vrf"
     prompt:
-      - '{base_prompt}>'
-      - '{base_prompt}#'
+    - '{base_prompt}>'
+    - '{base_prompt}#'
     output_variants:
-      - "VRF Configuration:\n------------------\nVRF Name   : default\n        Interfaces\
-        \             Status\n        -----------------------------\n        vlan1\
-        \                    up\n        vlan61                   up\n"
+    - "VRF Configuration:\n------------------\nVRF Name   : default\n        Interfaces\
+      \             Status\n        -----------------------------\n        vlan1 \
+      \                   up\n        vlan61                   up\n"

--- a/simnos/plugins/nos/platforms_yaml/aruba_aoscx.yaml
+++ b/simnos/plugins/nos/platforms_yaml/aruba_aoscx.yaml
@@ -496,12 +496,6 @@ commands:
       \       : 11%\n\tVSF Link 1               : Up, connected to peer member 1, link 1\n\tVSF Link 2\n"
     help: execute the command "show vsf detail"
     prompt: *id001
-  _default_:
-    output: '% Invalid input detected'
-    help: default output for unknown commands
-    prompt:
-    - '{base_prompt}>'
-    - '{base_prompt}#'
   show vrf:
     output: "VRF Configuration:\n------------------\nVRF Name   : default\n      \
       \  Interfaces             Status\n        -----------------------------\n  \
@@ -600,3 +594,9 @@ commands:
     - "VRF Configuration:\n------------------\nVRF Name   : default\n        Interfaces\
       \             Status\n        -----------------------------\n        vlan1 \
       \                   up\n        vlan61                   up\n"
+  _default_:
+    output: '% Invalid input detected'
+    help: default output for unknown commands
+    prompt:
+    - '{base_prompt}>'
+    - '{base_prompt}#'

--- a/simnos/plugins/nos/platforms_yaml/aruba_os.yaml
+++ b/simnos/plugins/nos/platforms_yaml/aruba_os.yaml
@@ -180,8 +180,8 @@ commands:
       Hostname is WLC-AMC72-LAB01'
     help: execute the command "show hostname"
     prompt: &id001
-      - '{base_prompt}>'
-      - '{base_prompt}#'
+    - '{base_prompt}>'
+    - '{base_prompt}#'
   show inventory:
     output: "\nSupervisor Card slot            : 0\nSystem Serial#               \
       \   : CV123ABC2 (Date:08/25/18)\nCPU Card Serial#                : ABC123XYZ\

--- a/simnos/plugins/nos/platforms_yaml/aruba_os.yaml
+++ b/simnos/plugins/nos/platforms_yaml/aruba_os.yaml
@@ -174,3 +174,101 @@ commands:
     prompt:
     - "{base_prompt}>"
     - "{base_prompt}#"
+  show hostname:
+    output: '
+
+      Hostname is WLC-AMC72-LAB01'
+    help: execute the command "show hostname"
+    prompt: &id001
+      - '{base_prompt}>'
+      - '{base_prompt}#'
+  show inventory:
+    output: "\nSupervisor Card slot            : 0\nSystem Serial#               \
+      \   : CV123ABC2 (Date:08/25/18)\nCPU Card Serial#                : ABC123XYZ\
+      \ (Date:08/25/18)\nCPU Card Assembly#              : 2010151H\nCPU Card Revision\
+      \               : (Rev:11.00)\nInterface Card Serial#          : AI3ABC12379\
+      \ (Date:08/25/18)\nInterface Card Assembly#        : 2010085E\nInterface Card\
+      \ Revision         : (Rev:04.00)\nSC Model#                       : Aruba7210-US\n\
+      HW MAC Addr                     : 00:1a:1e:05:27:60 to 00:1a:1e:05:27:67\nCPLD\
+      \ Version                    : (Rev: 3.0)\nPower Supply 0                  :\
+      \ Present               : No\nPower Supply 1                  : Present    \
+      \           : Yes\n                                : 12V OK                :\
+      \ Yes\n                                : Fan OK                : Yes\n     \
+      \                           : Aruba Model No        : 2510057\n            \
+      \                    : Vendor & Model No     : QCS DCJ3501-01P\n           \
+      \                     : Serial No             : QC1234506L\n               \
+      \                 : MFG Date              : 7/2/18\n                       \
+      \         : Output 1 Config       : 12V 350W\n                             \
+      \   : Input Min             : 90V AC\n                                : Input\
+      \ Max             : 264V AC\nMain Board Temperatures         :             \
+      \     \n                                : U24 - Local Temp      25 C (shadow\
+      \ of XLP heatsink)\n                                : Q1  - Remote 1 Temp  \
+      \ 27 C (shadow of VRM, VDD_CPU)\n                                : Q2  - Remote\
+      \ 2 Temp   26 C (shadow of VRM, VDD_SOC)\n                                :\
+      \ U44 - Local Temp      20 C (shadow of DPI connector)\n                   \
+      \             : U29  - Remote 1 Temp  24 C (XLP die temperature)\n         \
+      \                       : Q36  - Remote 2 Temp  21 C (shadow of 98X1422)\n \
+      \                               : J2  - DDR A Temp      18 C (DDR3 A temp)\n\
+      \                                : J4  - DDR B Temp      22 C (DDR3 B temp)\n\
+      \                                : J1  - DDR C Temp      19 C (DDR3 C temp)\n\
+      \                                : J3  - DDR D Temp      20 C (DDR3 D temp)\n\
+      \                                : Port 0 Temp           23 C (1G PHY temp)\n\
+      \                                : Port 1 Temp           23 C (1G PHY temp)\n\
+      Interface Board Temperatures    :\n                                : U21 - Local\
+      \ Temp      23 C (shadow of port 1 RJ45)\n                                :\
+      \ Q4 - Remote 1 Temp    22 C (shadow of 88E1543)\n                         \
+      \       : Q3 - Remote 2 Temp    25 C (shadow of 88X2140)\nFan  0           \
+      \               : 9070 rpm (5.831 V),Speed Low\nFan  1                     \
+      \     : 9112 rpm (5.921 V),Speed Low\nFan  2                          : 8916\
+      \ rpm (5.809 V),Speed Low\nFan  3                          : 9049 rpm (5.876\
+      \ V),Speed Low\nMain Board Voltages             :\nispPAC_POWR1014A_A      \
+      \        :\n                                : 1V2                  1.20V sense\
+      \ 1.208 V\n                                : VDD SOC              0.943V sense\
+      \ 0.928 V\n                                : VCC IOBD 1V5         1.50V sense\
+      \ 1.538 V\n                                : DDR3BD_VTT           0.75V sense\
+      \ 0.760 V\n                                : VCC 1A               1.00V sense\
+      \ 1.026 V\n                                : IV8_DIGITAL          1.80V sense\
+      \ 1.852 V\n                                : 3V3_MAIN             3.30V sense\
+      \ 3.348 V\n                                : VCC1                 1.00V sense\
+      \ 1.024 V\n                                : VCC25                2.50V sense\
+      \ 2.538 V\n                                : 3V3 SB               3.30V sense\
+      \ 3.366 V\nispPAC_POWR1014A_B              :\n                             \
+      \   : VDD                  0.837V sense 0.850 V\n                          \
+      \      : VCC IOAC 1V5         1.50V sense 1.546 V\n                        \
+      \        : DDR3AC_VTT           0.75V sense 0.760 V\n                      \
+      \          : VDD_SRAM             1.00V sense 1.048 V\n                    \
+      \            : VCC1B                1.00V sense 1.030 V\n                  \
+      \              : 1V8_ANALOG           1.80V sense 1.842 V\n                \
+      \                : 1V8                  1.80V sense 1.848 V\n              \
+      \                  : VDDIO12_XAUI         1.20V sense 1.212 V\n            \
+      \                    : 5V                   5.00V sense 5.016 V\nInterface Board\
+      \ Voltages        :\nispPAC_POWR6AT6                 :\n                   \
+      \             : VCC33                3.30V sense 3.342 V\n                 \
+      \               : VCC 18               1.80V sense 1.840 V\n               \
+      \                 : VCC1                 1.00V sense 1.024 V\n             \
+      \                   : VCC12                1.20V sense 1.220 V\n           \
+      \                     : VCC12-DVDD           1.20V sense 1.214 V\n         \
+      \                       : VCC9                 0.90V sense 0.932 V"
+    help: execute the command "show inventory"
+    prompt: *id001
+  show version:
+    output: "\nImage stamp:    /ws/swbuildm/rel_venice_qaoff/code/build/lvm(swbuildm_rel_venice_qaoff_rel_venice)\n\
+      \                Mar 26 2018 23:16:08\n                WC.16.05.0007\n     \
+      \           570\nBoot Image:     Primary\n\nBoot ROM Version:    WC.16.01.0005\n\
+      Active Boot ROM:     Primary\n"
+    help: execute the command "show version"
+    prompt: *id001
+  show vlan:
+    output: " Status and Counters - VLAN Information\n\n  Maximum VLANs to support\
+      \ : 128\n  Primary VLAN : DEFAULT_VLAN\n  Management VLAN :\n\n  VLAN ID Name\
+      \                             | Status     Voice Jumbo\n  ------- --------------------------------\
+      \ + ---------- ----- -----\n  1       DEFAULT_VLAN                     | Port-based\
+      \ No    No\n  102     Printers                         | Port-based No    No\n\
+      \  103     Workstations                     | Port-based No    No\n  104   \
+      \  Management                       | Port-based No    No\n  105     AP_Management\
+      \                    | Port-based No    No\n  106     WiFi_ot              \
+      \            | Port-based No    No\n  107     WiFi_main                    \
+      \    | Port-based No    No\n  108     WiFi_guest                       | Port-based\
+      \ No    No\n"
+    help: execute the command "show vlan"
+    prompt: *id001

--- a/simnos/plugins/nos/platforms_yaml/ciena_saos.yaml
+++ b/simnos/plugins/nos/platforms_yaml/ciena_saos.yaml
@@ -208,3 +208,206 @@ commands:
     prompt:
     - "{base_prompt}>"
     - "{base_prompt}#"
+  lldp show neighbors:
+    output: '+--------------------------------------------------------------------------------------------------------------+
+
+      |                                                LLDP Neighbors                                                |
+
+      +--------------------------------------------------------------------------------------------------------------+
+
+      | Remote Addr: 10.8.91.1                                                                                       |
+
+      | Remote Addr: 10.8.128.39                                                                                     |
+
+      | Remote Addr: fe80::9e7a:3ff:fed1:cd1                                                                         |
+
+      | Remote Addr: fe80::9e7a:3ff:fed1:cdf                                                                         |
+
+      | System Name: LAB_00009-SDS39-100                                                                             |
+
+      | System Desc: Ciena 3916 Service Delivery Switch                                                              |
+
+      +-------------+------------------------------------------------------------------------------------------------+
+
+      |Local        |                                              Remote                                            |
+
+      +-------------+--------------------------------+---------------------------------------------------------------+
+
+      |Port         |Port                            |Info                                                           |
+
+      +-------------+--------------------------------+---------------------------------------------------------------+
+
+      |5            |6                               |  Chassis Id: 9C7A03A10D60                                     |
+
+      |             |                                |   Mgmt Addr: 10.8.91.2                                        |
+
+      |             |                                |              10.8.128.40                                      |
+
+      |             |                                |              fe80::9e7a:3ff:fed1:d61                          |
+
+      |             |                                |              fe80::9e7a:3ff:fed1:d6f                          |
+
+      |             |                                | System Name: LAB_SDS39-200                                    |
+
+      |             |                                | System Desc: Ciena 3916 Service
+      Delivery Switch               |
+
+      |             |                                | SyncE Suppt: Not Supported                                    |
+
+      |             |                                | SyncE Confg: Not Configured                                   |
+
+      +-------------+--------------------------------+---------------------------------------------------------------+
+
+      |6            |3                               |  Chassis Id: 9C7A03B86040                                     |
+
+      |             |                                |   Mgmt Addr: 10.8.90.250                                      |
+
+      |             |                                |              10.8.130.1                                       |
+
+      |             |                                |              fe80::9e7a:3ff:fec8:6040                         |
+
+      |             |                                |              fe80::9e7a:3ff:fec8:6041                         |
+
+      |             |                                | System Name: LAB_SAS51-100                                    |
+
+      |             |                                | System Desc: Ciena 5142 Service
+      Aggregation Switch            |
+
+      |             |                                | SyncE Suppt: Input and Output                                 |
+
+      |             |                                | SyncE Confg: Not Configured                                   |
+
+      +-------------+--------------------------------+---------------------------------------------------------------+
+
+      '
+    help: execute the command "lldp show neighbors"
+    prompt: &id001
+      - '{base_prompt}>'
+      - '{base_prompt}#'
+  port show ethernet-config:
+    output: '+------------------------ PORT ETHERNET CONFIGURATION -------------------------+
+
+      |        |         |       |      |     |    |    |     |      |    Mirror     |
+
+      | Port   | Port    | Admin |      |     |    | FC | Auto| MTU  |    Status     |
+
+      | Name   | Type    | Status| Speed| Dplx| FC | Adv| Neg | Size |State| Eg |
+      Ig |
+
+      +--------+---------+-------+------+-----+----+----+-----+------+-----+----+----+
+
+      | 1      | 10/100/G| Dis   | Auto | ??  |off |off | On  | 9100 | Off | 0  |
+      0  |
+
+      | 2      | 10/100/G| Ena   | Auto | ??  |off |off | On  | 9100 | Off | 0  |
+      0  |
+
+      | 3      | 100/G   | Ena   | 100  | ??  |off |off | Off | 9100 | Off | 0  |
+      0  |
+
+      | 4      | 100/G   | Ena   | 1000 | ??  |off |off | On  | 9100 | Off | 0  |
+      0  |
+
+      | 5      | Gig     | Ena   | 1000 | Full|off |off | Off | 9216 | Off | 0  |
+      0  |
+
+      | 6      | Gig     | Ena   | 1000 | Full|off |off | Off | 9216 | Off | 0  |
+      0  |
+
+      +--------+---------+-------+------+-----+----+----+-----+------+-----+----+----+
+
+      '
+    help: execute the command "port show ethernet-config"
+    prompt: *id001
+  port show network-config:
+    output: '+----------------------------- PORT NETWORK CONFIGURATION ------------------------------+
+
+      |         |     | Accpt  |Untag  |VLAN   |VS     |Egress |VS     |Ingress| VPLS  |Eth
+      VC|
+
+      | Port    |     | Frame  |Ingress|Ingress|Ingress|Untag  |Egress |CoS    | Port  |Ether-|
+
+      | Name    |PVID | Type   |Vid    |Filter |Filter |VLAN   |Filter |Policy | Type  |Type  |
+
+      +---------+-----+--------+-------+-------+-------+-------+-------+-------+-------+------+
+
+      | 1       | 1   | All    | 0     | Ena   | Dis   | 1     | Dis   | leave | Subsc
+      | 8100 |
+
+      | 2       | 1   | All    | 0     | Ena   | Dis   | 1     | Dis   | leave | Subsc
+      | 8100 |
+
+      | 3       | 1   | All    | 0     | Ena   | Dis   | 1     | Dis   | leave | Subsc
+      | 8100 |
+
+      | 4       | 1   | All    | 0     | Ena   | Ena   | 1     | Dis   | leave | Subsc
+      | 8100 |
+
+      | 5       | 1   | All    | 0     | Ena   | Ena   | 1     | Dis   | leave | Ntwrk
+      | 8100 |
+
+      | 6       | 1   | All    | 0     | Ena   | Dis   | 1     | Dis   | leave | Ntwrk
+      | 8100 |
+
+      +---------+-----+--------+-------+-------+-------+-------+-------+-------+-------+------+
+
+      '
+    help: execute the command "port show network-config"
+    prompt: *id001
+  port show status:
+    output: '+---------------------------- PORT OPERATIONAL STATUS ----------------------------+
+
+      |    |                               |    |Link State|    |   |Speed/ |MTU  |Flow
+      |
+
+      | ## | Description                   |Link|Duration  |XCVR|STP|Duplex |Size
+      |Ctrl |
+
+      +----+-------------------------------+----+----------+----+---+-------+-----+-----+
+
+      |1   |ACL_3360610_71CHA              |Down|  0h 0m 0s|    |Dis|       | 9100|     |
+
+      |2   |UNI-Port2                      |Down|  0h 0m 0s|    |Dis|       | 9100|     |
+
+      |3   |UNI-Port3                      |Down|  0h 0m 0s|    |Dis|       | 9100|     |
+
+      |4   |NNI-Ringport                   |Down|  0h 0m 0s|    |Dis|       | 9100|     |
+
+      |5   |NNI-Ringport                   | Up |268d 1h12m|Ena |FWD|1000/FD| 9216|off  |
+
+      |6   |NNI-Ringport                   | Up |268d 1h14m|Ena |FWD|1000/FD| 9216|off  |
+
+      +----+-------------------------------+----+----------+----+---+-------+-----+-----+
+
+      '
+    help: execute the command "port show status"
+    prompt: *id001
+  port xcvr show:
+    output: '+----+-----+-----+---------Transceiver-Status------------+-----+----------------+----+
+
+      |    |Admin| Oper|                                       |Ciena|Ether Medium
+      &  |Diag|
+
+      |Port|State|State|      Vendor Name & Part Number        | Rev |Connector Type  |Data|
+
+      +----+-----+-----+---------------------------------------+-----+----------------+----+
+
+      |1   |Empty|     |                                       |     |                |    |
+
+      |2   |Empty|     |                                       |     |                |    |
+
+      |3   |Empty|     |                                       |     |                |    |
+
+      |4   |Empty|     |                                       |     |                |    |
+
+      |5   |Ena  |Ena  |CIENA-LMT XCVR-A40Y31 Rev0003          |A    |1000BASE-LX/LC  |Yes
+      |
+
+      |6   |Ena  |Ena  |CIENA-LMT XCVR-A40Y31 Rev0003          |A    |1000BASE-LX/LC  |Yes
+      |
+
+      +----+-----+-----+---------------------------------------+-----+----------------+----+
+
+      '
+    help: execute the command "port xcvr show"
+    prompt: *id001

--- a/simnos/plugins/nos/platforms_yaml/ciena_saos.yaml
+++ b/simnos/plugins/nos/platforms_yaml/ciena_saos.yaml
@@ -282,8 +282,8 @@ commands:
       '
     help: execute the command "lldp show neighbors"
     prompt: &id001
-      - '{base_prompt}>'
-      - '{base_prompt}#'
+    - '{base_prompt}>'
+    - '{base_prompt}#'
   port show ethernet-config:
     output: '+------------------------ PORT ETHERNET CONFIGURATION -------------------------+
 

--- a/simnos/plugins/nos/platforms_yaml/extreme_exos.yaml
+++ b/simnos/plugins/nos/platforms_yaml/extreme_exos.yaml
@@ -369,8 +369,8 @@ commands:
       \ 1  Locked: 0  Locked with Timeout: 0\nFDB Aging time: 300\n"
     help: execute the command "show fdb"
     prompt: &id001
-      - '{base_prompt}>'
-      - '{base_prompt}#'
+    - '{base_prompt}>'
+    - '{base_prompt}#'
   show iparp:
     output: "VR            Destination      Mac                Age  Static  VLAN \
       \         VID   Port\nVR-Default    10.128.32.4      00:d0:59:17:74:83   20\
@@ -386,41 +386,41 @@ commands:
     help: execute the command "show iparp"
     prompt: *id001
     output_variants:
-      - 'VR            Destination      Mac                Age  Static  VLAN          VID  Port
+    - 'VR            Destination      Mac                Age  Static  VLAN          VID  Port
 
-        VR-Default    10.10.10.6       00:04:96:1f:a5:71    8      NO  bluered       4092  1
+      VR-Default    10.10.10.6       00:04:96:1f:a5:71    8      NO  bluered       4092  1
 
-        VR-Default    10.128.32.1      (00:01:30:ba:6a:a0)  0      NO  Default       4095
+      VR-Default    10.128.32.1      (00:01:30:ba:6a:a0)  0      NO  Default       4095
 
-        Dynamic Entries  :           1             Static Entries            :          0
+      Dynamic Entries  :           1             Static Entries            :          0
 
-        Pending Entries  :           0
+      Pending Entries  :           0
 
-        In Request       :         111             In Response               :          3
+      In Request       :         111             In Response               :          3
 
-        Out Request      :         110             Out Response              :        111
+      Out Request      :         110             Out Response              :        111
 
-        Failed Requests  :           0
+      Failed Requests  :           0
 
-        Proxy Answered   :           0
+      Proxy Answered   :           0
 
-        Rx Error         :           0             Dup IP Addr               :         0.0.0.0
+      Rx Error         :           0             Dup IP Addr               :         0.0.0.0
 
-        Rejected Count   :                         Rejected IP               :
+      Rejected Count   :                         Rejected IP               :
 
-        Rejected Port    :                         Rejected I/F              :
+      Rejected Port    :                         Rejected I/F              :
 
-        Max ARP entries  :        4096             Max ARP pending entries   :        256
+      Max ARP entries  :        4096             Max ARP pending entries   :        256
 
-        ARP address check:    Enabled              ARP refresh               :    Enabled
+      ARP address check:    Enabled              ARP refresh               :    Enabled
 
-        Timeout          :    Configured:  10 minutes    Current:  30 minutes
+      Timeout          :    Configured:  10 minutes    Current:  30 minutes
 
-        Distributed mode :    Configured:  On            Current:  Off
+      Distributed mode :    Configured:  On            Current:  Off
 
-        Max ARP entries  :    Configured:  259000 (Distributed mode was turned "on"
-        after boot)
+      Max ARP entries  :    Configured:  259000 (Distributed mode was turned "on"
+      after boot)
 
-        ARP Sender-Mac Learning   :   Disabled
+      ARP Sender-Mac Learning   :   Disabled
 
-        '
+      '

--- a/simnos/plugins/nos/platforms_yaml/extreme_exos.yaml
+++ b/simnos/plugins/nos/platforms_yaml/extreme_exos.yaml
@@ -349,3 +349,78 @@ commands:
     prompt:
     - "{base_prompt}>"
     - "{base_prompt}#"
+  show fdb:
+    output: "MAC                                      VLAN Name( Tag)  Age  Flags\
+      \          Port / Virtual Port List\n------------------------------------------------------------------------------------------------------\n\
+      00:0c:29:4b:34:cf                             v101(0101) 0041  d m D       \
+      \   1:2\n00:0c:29:4b:34:cf                             v100(0100) 0041  d m\
+      \ P          1:2\n00:0c:29:d2:2d:48                             v102(0102) 0045\
+      \  d miM          1:3, 1:45\n00:0c:29:d2:2d:48                             v100(0100)\
+      \ 0045  d m P          1:3\n00:0c:29:f1:f2:f5                             v100(0100)\
+      \ 0045  d miM          1:51:1, 1:45\n00:0c:29:f1:f2:f5                     \
+      \        v102(0102) 0045  d m P          1:1\n00:0c:29:f1:f2:f5            \
+      \                 v101(0101) 0000  d m P          1:1\n\nFlags : d - Dynamic,\
+      \ s - Static, p - Permanent, n - NetLogin, m - MAC, i - IP,\n        x - IPX,\
+      \ l - lockdown MAC, L - lockdown-timeout MAC, M- Mirror, B - Egress Blackhole,\n\
+      \        b - Ingress Blackhole, v - MAC-Based VLAN, P - Private VLAN, T - VLAN\
+      \ translation,\n        D - drop packet, h - Hardware Aging (Age=0), o - IEEE\
+      \ 802.1ah Backbone MAC,\n        S - Software Controlled Deletion, r - MSRP,\n\
+      \        X - VXLAN, E - EVPN\n\nTotal: 3 Static: 0  Perm: 0  Dyn: 3  Dropped:\
+      \ 1  Locked: 0  Locked with Timeout: 0\nFDB Aging time: 300\n"
+    help: execute the command "show fdb"
+    prompt: &id001
+      - '{base_prompt}>'
+      - '{base_prompt}#'
+  show iparp:
+    output: "VR            Destination      Mac                Age  Static  VLAN \
+      \         VID   Port\nVR-Default    10.128.32.4      00:d0:59:17:74:83   20\
+      \      NO  bluered       4092  1:25\nVR-Default    10.128.32.8      00:01:30:ba:6a:a0\
+      \    7      NO  Default       4095\n\nDynamic Entries  :           4       \
+      \      Static Entries            :          0\nPending Entries  :          \
+      \ 0\n\nARP address check:    Enabled              ARP refresh              \
+      \ :    Enabled\nTimeout          :          20 minutes     ARP Sender-Mac Learning\
+      \   :   Disabled\nLocktime         :        1000 milliseconds\nRetransmit Time\
+      \  :        1000 milliseconds\nReachable Time   :      900000 milliseconds (Auto)\n\
+      Fast Convergence :         Off \n\nARP Global Settings\nMax Entries        \
+      \ :    12288 \nMax Pending Entries :      256 \nMax Proxy Entries   :      256\n"
+    help: execute the command "show iparp"
+    prompt: *id001
+    output_variants:
+      - 'VR            Destination      Mac                Age  Static  VLAN          VID  Port
+
+        VR-Default    10.10.10.6       00:04:96:1f:a5:71    8      NO  bluered       4092  1
+
+        VR-Default    10.128.32.1      (00:01:30:ba:6a:a0)  0      NO  Default       4095
+
+        Dynamic Entries  :           1             Static Entries            :          0
+
+        Pending Entries  :           0
+
+        In Request       :         111             In Response               :          3
+
+        Out Request      :         110             Out Response              :        111
+
+        Failed Requests  :           0
+
+        Proxy Answered   :           0
+
+        Rx Error         :           0             Dup IP Addr               :         0.0.0.0
+
+        Rejected Count   :                         Rejected IP               :
+
+        Rejected Port    :                         Rejected I/F              :
+
+        Max ARP entries  :        4096             Max ARP pending entries   :        256
+
+        ARP address check:    Enabled              ARP refresh               :    Enabled
+
+        Timeout          :    Configured:  10 minutes    Current:  30 minutes
+
+        Distributed mode :    Configured:  On            Current:  Off
+
+        Max ARP entries  :    Configured:  259000 (Distributed mode was turned "on"
+        after boot)
+
+        ARP Sender-Mac Learning   :   Disabled
+
+        '

--- a/simnos/plugins/nos/platforms_yaml/hp_procurve.yaml
+++ b/simnos/plugins/nos/platforms_yaml/hp_procurve.yaml
@@ -514,3 +514,70 @@ commands:
     prompt:
     - "{base_prompt}>"
     - "{base_prompt}#"
+  show version:
+    output: 'Aruba Operating System Software.
+
+      ArubaOS (MODEL: 310), Version 01.01.0.1 SSR
+
+      Website: http://www.arubanetworks.com
+
+      (c) Copyright 2001 Hewlett Packard Enterprise Development LP.
+
+      Compiled on 2001-01-01 at 01:01:01 UTC (build 00001) by jenkins
+
+      FIPS Mode :disabled
+
+
+      AP uptime is 01 hours 01 minutes 01 seconds
+
+      Reboot Time and Cause: AP rebooted caused by cold HW reset(power loss)
+
+      '
+    help: execute the command "show version"
+    prompt: &id001
+      - '{base_prompt}>'
+      - '{base_prompt}#'
+  show vsf detail:
+    output: "VSF Domain ID    : 1\n MAC Address      : 94f128-aabbcc\n VSF Topology\
+      \     : Chain\n VSF Status       : Active\n Uptime           : 134d 1h 55m\n\
+      \ VSF MAD          : None\n VSF Port Speed   : 10G\n Software Version : WC.16.11.0021\n\
+      \nName             : SWITCH-1\nContact          : Network Team (email@address.com)\n\
+      Location         : Datacenter Generic\n\n\nMember ID        : 1\nMAC Address\
+      \      : 94f128-aabbcd\nType             : JL256A\nModel            : Aruba\
+      \ JL256A 2930F-48G-PoE+-4SFP+ Switch\nPriority         : 255\nStatus       \
+      \    : Commander\nROM Version      : WC.16.01.0010\nSerial Number    : SN0000001A\n\
+      Uptime           : 134d 1h 55m\nCPU Utilization  : 10%\nMemory - Total   : 333,513,216\
+      \ bytes\nFree             : 212,192,464 bytes\nVSF Links -\n#1 : Active, Peer\
+      \ member 2\n#2 : Inactive\n\n\n\nMember ID        : 2\nMAC Address      : 94f128-aabbce\n\
+      Type             : JL256A\nModel            : Aruba JL256A 2930F-48G-PoE+-4SFP+\
+      \ Switch\nPriority         : 128\nStatus           : Standby\nROM Version  \
+      \    : WC.16.01.0010\nSerial Number    : SN0000002A\nUptime           : 134d\
+      \ 1h 55m\nCPU Utilization  : 4%\nMemory - Total   : 333,513,216 bytes\nFree\
+      \             : 227,871,324 bytes\nVSF Links -\n#1 : Active, Peer member 1\n\
+      #2 : Inactive\n"
+    help: execute the command "show vsf detail"
+    prompt: *id001
+    output_variants:
+      - "VSF Domain ID    : 5\n MAC Address      : 548028-aabbd0\n VSF Topology  \
+        \   : Ring\n VSF Status       : Active\n Uptime           : 454d 7h 42m\n\
+        \ VSF MAD          : None\n VSF Port Speed   : 1G\n Software Version : WC.16.10.0014\n\
+        \nName             : SWITCH-2\nContact          :\nLocation         :\n\n\n\
+        Member ID        : 1\nMAC Address      : 548028-aabbd1\nType             :\
+        \ JL255A\nModel            : Aruba JL255A 2930F-24G-PoE+-4SFP+ Switch\nPriority\
+        \         : 255\nStatus           : Commander\nROM Version      : WC.16.01.0008\n\
+        Serial Number    : SN0000003A\nUptime           : 454d 7h 42m\nCPU Utilization\
+        \  : 0%\nMemory - Total   : 338,285,056 bytes\nFree             : 216,976,472\
+        \ bytes\nVSF Links -\n#1 : Active, Peer member 3\n#2 : Active, Peer member\
+        \ 2\n\n\n\nMember ID        : 2\nMAC Address      : 548028-aabbd2\nType  \
+        \           : JL255A\nModel            : Aruba JL255A 2930F-24G-PoE+-4SFP+\
+        \ Switch\nPriority         : 128\nStatus           : Standby\nROM Version\
+        \      : WC.16.01.0008\nSerial Number    : SN0000004A\nUptime           :\
+        \ 454d 7h 42m\nCPU Utilization  : 0%\nMemory - Total   : 338,285,056 bytes\n\
+        Free             : 233,891,828 bytes\nVSF Links -\n#1 : Active, Peer member\
+        \ 3\n#2 : Active, Peer member 1\n\n\n\nMember ID        : 3\nMAC Address \
+        \     : 548028-aabbd3\nType             : JL255A\nModel            : Aruba\
+        \ JL255A 2930F-24G-PoE+-4SFP+ Switch\nPriority         : 128\nStatus     \
+        \      : Member\nROM Version      : WC.16.01.0008\nSerial Number    : SN0000005A\n\
+        Uptime           : 454d 7h 42m\nCPU Utilization  : 0%\nMemory - Total   :\
+        \ 338,285,056 bytes\nFree             : 247,712,468 bytes\nVSF Links -\n#1\
+        \ : Active, Peer member 1\n#2 : Active, Peer member 2\n"

--- a/simnos/plugins/nos/platforms_yaml/hp_procurve.yaml
+++ b/simnos/plugins/nos/platforms_yaml/hp_procurve.yaml
@@ -535,8 +535,8 @@ commands:
       '
     help: execute the command "show version"
     prompt: &id001
-      - '{base_prompt}>'
-      - '{base_prompt}#'
+    - '{base_prompt}>'
+    - '{base_prompt}#'
   show vsf detail:
     output: "VSF Domain ID    : 1\n MAC Address      : 94f128-aabbcc\n VSF Topology\
       \     : Chain\n VSF Status       : Active\n Uptime           : 134d 1h 55m\n\
@@ -558,26 +558,25 @@ commands:
     help: execute the command "show vsf detail"
     prompt: *id001
     output_variants:
-      - "VSF Domain ID    : 5\n MAC Address      : 548028-aabbd0\n VSF Topology  \
-        \   : Ring\n VSF Status       : Active\n Uptime           : 454d 7h 42m\n\
-        \ VSF MAD          : None\n VSF Port Speed   : 1G\n Software Version : WC.16.10.0014\n\
-        \nName             : SWITCH-2\nContact          :\nLocation         :\n\n\n\
-        Member ID        : 1\nMAC Address      : 548028-aabbd1\nType             :\
-        \ JL255A\nModel            : Aruba JL255A 2930F-24G-PoE+-4SFP+ Switch\nPriority\
-        \         : 255\nStatus           : Commander\nROM Version      : WC.16.01.0008\n\
-        Serial Number    : SN0000003A\nUptime           : 454d 7h 42m\nCPU Utilization\
-        \  : 0%\nMemory - Total   : 338,285,056 bytes\nFree             : 216,976,472\
-        \ bytes\nVSF Links -\n#1 : Active, Peer member 3\n#2 : Active, Peer member\
-        \ 2\n\n\n\nMember ID        : 2\nMAC Address      : 548028-aabbd2\nType  \
-        \           : JL255A\nModel            : Aruba JL255A 2930F-24G-PoE+-4SFP+\
-        \ Switch\nPriority         : 128\nStatus           : Standby\nROM Version\
-        \      : WC.16.01.0008\nSerial Number    : SN0000004A\nUptime           :\
-        \ 454d 7h 42m\nCPU Utilization  : 0%\nMemory - Total   : 338,285,056 bytes\n\
-        Free             : 233,891,828 bytes\nVSF Links -\n#1 : Active, Peer member\
-        \ 3\n#2 : Active, Peer member 1\n\n\n\nMember ID        : 3\nMAC Address \
-        \     : 548028-aabbd3\nType             : JL255A\nModel            : Aruba\
-        \ JL255A 2930F-24G-PoE+-4SFP+ Switch\nPriority         : 128\nStatus     \
-        \      : Member\nROM Version      : WC.16.01.0008\nSerial Number    : SN0000005A\n\
-        Uptime           : 454d 7h 42m\nCPU Utilization  : 0%\nMemory - Total   :\
-        \ 338,285,056 bytes\nFree             : 247,712,468 bytes\nVSF Links -\n#1\
-        \ : Active, Peer member 1\n#2 : Active, Peer member 2\n"
+    - "VSF Domain ID    : 5\n MAC Address      : 548028-aabbd0\n VSF Topology    \
+      \ : Ring\n VSF Status       : Active\n Uptime           : 454d 7h 42m\n VSF\
+      \ MAD          : None\n VSF Port Speed   : 1G\n Software Version : WC.16.10.0014\n\
+      \nName             : SWITCH-2\nContact          :\nLocation         :\n\n\n\
+      Member ID        : 1\nMAC Address      : 548028-aabbd1\nType             : JL255A\n\
+      Model            : Aruba JL255A 2930F-24G-PoE+-4SFP+ Switch\nPriority      \
+      \   : 255\nStatus           : Commander\nROM Version      : WC.16.01.0008\n\
+      Serial Number    : SN0000003A\nUptime           : 454d 7h 42m\nCPU Utilization\
+      \  : 0%\nMemory - Total   : 338,285,056 bytes\nFree             : 216,976,472\
+      \ bytes\nVSF Links -\n#1 : Active, Peer member 3\n#2 : Active, Peer member 2\n\
+      \n\n\nMember ID        : 2\nMAC Address      : 548028-aabbd2\nType         \
+      \    : JL255A\nModel            : Aruba JL255A 2930F-24G-PoE+-4SFP+ Switch\n\
+      Priority         : 128\nStatus           : Standby\nROM Version      : WC.16.01.0008\n\
+      Serial Number    : SN0000004A\nUptime           : 454d 7h 42m\nCPU Utilization\
+      \  : 0%\nMemory - Total   : 338,285,056 bytes\nFree             : 233,891,828\
+      \ bytes\nVSF Links -\n#1 : Active, Peer member 3\n#2 : Active, Peer member 1\n\
+      \n\n\nMember ID        : 3\nMAC Address      : 548028-aabbd3\nType         \
+      \    : JL255A\nModel            : Aruba JL255A 2930F-24G-PoE+-4SFP+ Switch\n\
+      Priority         : 128\nStatus           : Member\nROM Version      : WC.16.01.0008\n\
+      Serial Number    : SN0000005A\nUptime           : 454d 7h 42m\nCPU Utilization\
+      \  : 0%\nMemory - Total   : 338,285,056 bytes\nFree             : 247,712,468\
+      \ bytes\nVSF Links -\n#1 : Active, Peer member 1\n#2 : Active, Peer member 2\n"

--- a/simnos/plugins/nos/platforms_yaml/linux.yaml
+++ b/simnos/plugins/nos/platforms_yaml/linux.yaml
@@ -113,37 +113,36 @@ commands:
       \ 2M\n        SupportedSecondaryChannels: Coded\n"
     help: execute the command "bluetoothctl show"
     prompt: &id001
-      - '{base_prompt}$'
-      - '{base_prompt}#'
+    - '{base_prompt}$'
+    - '{base_prompt}#'
     output_variants:
-      - "Controller AA:AA:AA:AA:AA:AA (public)\n        Manufacturer: 0x005d (93)\n\
-        \        Version: 0x0a (10)\n        Name: ntc-AA-AAAA\n        Alias: ntc-AA-AAAA\n\
-        \        Class: 0x007c0104 (8126724)\n        Powered: yes\n        Discoverable:\
-        \ yes\n        DiscoverableTimeout: 0x000000b4 (180)\n        Pairable: yes\n\
-        \        UUID: Message Notification Se.. (00001133-0000-1000-8000-00805f9b34fb)\n\
-        \        UUID: A/V Remote Control        (0000110e-0000-1000-8000-00805f9b34fb)\n\
-        \        UUID: OBEX Object Push          (00001105-0000-1000-8000-00805f9b34fb)\n\
-        \        UUID: Message Access Server     (00001132-0000-1000-8000-00805f9b34fb)\n\
-        \        UUID: PnP Information           (00001200-0000-1000-8000-00805f9b34fb)\n\
-        \        UUID: IrMC Sync                 (00001104-0000-1000-8000-00805f9b34fb)\n\
-        \        UUID: Vendor specific           (00005005-0000-1000-8000-0002ee000001)\n\
-        \        UUID: A/V Remote Control Target (0000110c-0000-1000-8000-00805f9b34fb)\n\
-        \        UUID: Generic Attribute Profile (00001801-0000-1000-8000-00805f9b34fb)\n\
-        \        UUID: Phonebook Access Server   (0000112f-0000-1000-8000-00805f9b34fb)\n\
-        \        UUID: Audio Sink                (0000110b-0000-1000-8000-00805f9b34fb)\n\
-        \        UUID: Device Information        (0000180a-0000-1000-8000-00805f9b34fb)\n\
-        \        UUID: Generic Access Profile    (00001800-0000-1000-8000-00805f9b34fb)\n\
-        \        UUID: Handsfree Audio Gateway   (0000111f-0000-1000-8000-00805f9b34fb)\n\
-        \        UUID: Audio Source              (0000110a-0000-1000-8000-00805f9b34fb)\n\
-        \        UUID: OBEX File Transfer        (00001106-0000-1000-8000-00805f9b34fb)\n\
-        \        UUID: Handsfree                 (0000111e-0000-1000-8000-00805f9b34fb)\n\
-        \        Modalias: usb:v1D6Bp0246d0548\n        Discovering: yes\n       \
-        \ Roles: central\n        Roles: peripheral\nAdvertising Features:\n     \
-        \   ActiveInstances: 0x00 (0)\n        SupportedInstances: 0x04 (4)\n    \
-        \    SupportedIncludes: tx-power\n        SupportedIncludes: appearance\n\
-        \        SupportedIncludes: local-name\n        SupportedSecondaryChannels:\
-        \ 1M\n        SupportedSecondaryChannels: 2M\n        SupportedSecondaryChannels:\
-        \ Coded"
+    - "Controller AA:AA:AA:AA:AA:AA (public)\n        Manufacturer: 0x005d (93)\n\
+      \        Version: 0x0a (10)\n        Name: ntc-AA-AAAA\n        Alias: ntc-AA-AAAA\n\
+      \        Class: 0x007c0104 (8126724)\n        Powered: yes\n        Discoverable:\
+      \ yes\n        DiscoverableTimeout: 0x000000b4 (180)\n        Pairable: yes\n\
+      \        UUID: Message Notification Se.. (00001133-0000-1000-8000-00805f9b34fb)\n\
+      \        UUID: A/V Remote Control        (0000110e-0000-1000-8000-00805f9b34fb)\n\
+      \        UUID: OBEX Object Push          (00001105-0000-1000-8000-00805f9b34fb)\n\
+      \        UUID: Message Access Server     (00001132-0000-1000-8000-00805f9b34fb)\n\
+      \        UUID: PnP Information           (00001200-0000-1000-8000-00805f9b34fb)\n\
+      \        UUID: IrMC Sync                 (00001104-0000-1000-8000-00805f9b34fb)\n\
+      \        UUID: Vendor specific           (00005005-0000-1000-8000-0002ee000001)\n\
+      \        UUID: A/V Remote Control Target (0000110c-0000-1000-8000-00805f9b34fb)\n\
+      \        UUID: Generic Attribute Profile (00001801-0000-1000-8000-00805f9b34fb)\n\
+      \        UUID: Phonebook Access Server   (0000112f-0000-1000-8000-00805f9b34fb)\n\
+      \        UUID: Audio Sink                (0000110b-0000-1000-8000-00805f9b34fb)\n\
+      \        UUID: Device Information        (0000180a-0000-1000-8000-00805f9b34fb)\n\
+      \        UUID: Generic Access Profile    (00001800-0000-1000-8000-00805f9b34fb)\n\
+      \        UUID: Handsfree Audio Gateway   (0000111f-0000-1000-8000-00805f9b34fb)\n\
+      \        UUID: Audio Source              (0000110a-0000-1000-8000-00805f9b34fb)\n\
+      \        UUID: OBEX File Transfer        (00001106-0000-1000-8000-00805f9b34fb)\n\
+      \        UUID: Handsfree                 (0000111e-0000-1000-8000-00805f9b34fb)\n\
+      \        Modalias: usb:v1D6Bp0246d0548\n        Discovering: yes\n        Roles:\
+      \ central\n        Roles: peripheral\nAdvertising Features:\n        ActiveInstances:\
+      \ 0x00 (0)\n        SupportedInstances: 0x04 (4)\n        SupportedIncludes:\
+      \ tx-power\n        SupportedIncludes: appearance\n        SupportedIncludes:\
+      \ local-name\n        SupportedSecondaryChannels: 1M\n        SupportedSecondaryChannels:\
+      \ 2M\n        SupportedSecondaryChannels: Coded"
   dmidecode -t bios:
     output: "# dmidecode 1.12\nSMBIOS 1.1 present.\n\nHandle 0x0000, DMI type 0, 24\
       \ bytes\nBIOS Information\n\tVendor: Dell\n\tVersion: O11   \n\tRelease Date:\
@@ -283,12 +282,12 @@ commands:
     help: execute the command "iwconfig"
     prompt: *id001
     output_variants:
-      - "lo        no wireless extensions.\n\neth0      no wireless extensions.\n\n\
-        wlan0     IEEE 802.11  ESSID:off/any  \n          Mode:Managed  Access Point:\
-        \ Not-Associated   \n          Retry short limit:7   RTS thr:off   Fragment\
-        \ thr:off\n          Power Management:on\n          \nwlan1     IEEE 802.11\
-        \  Mode:Monitor  Frequency:5.805 GHz  Tx-Power=13 dBm   \n          Retry\
-        \ short limit:7   RTS thr:off   Fragment thr:off\n          Power Management:off"
+    - "lo        no wireless extensions.\n\neth0      no wireless extensions.\n\n\
+      wlan0     IEEE 802.11  ESSID:off/any  \n          Mode:Managed  Access Point:\
+      \ Not-Associated   \n          Retry short limit:7   RTS thr:off   Fragment\
+      \ thr:off\n          Power Management:on\n          \nwlan1     IEEE 802.11\
+      \  Mode:Monitor  Frequency:5.805 GHz  Tx-Power=13 dBm   \n          Retry short\
+      \ limit:7   RTS thr:off   Fragment thr:off\n          Power Management:off"
   iwlist wlan0 scanning:
     output: "wlan1     Scan completed :\n          Cell 01 - Address: AA:AA:AA:AA:AA:AA\n\
       \                    ESSID:\"\"\n                    Protocol:IEEE 802.11bgn\n\
@@ -336,286 +335,276 @@ commands:
     help: execute the command "iwlist wlan0 scanning"
     prompt: *id001
     output_variants:
-      - "wlx6245b4e66e1a  Scan completed :\n          Cell 01 - Address: AA:AA:AA:AA:AA:AA\n\
-        \                    Channel:1\n                    Frequency:2.412 GHz (Channel\
-        \ 1)\n                    Quality=23/70  Signal level=-87 dBm  \n        \
-        \            Encryption key:on\n                    ESSID:\"MOVISTAR_9880\"\
-        \n                    Bit Rates:1 Mb/s; 2 Mb/s; 5.5 Mb/s; 11 Mb/s; 9 Mb/s\n\
-        \                              18 Mb/s; 36 Mb/s; 54 Mb/s\n               \
-        \     Bit Rates:6 Mb/s; 12 Mb/s; 24 Mb/s; 48 Mb/s\n                    Mode:Master\n\
-        \                    Extra:tsf=0000005ca9827456\n                    Extra:\
-        \ Last beacon: 69ms ago\n                    IE: Unknown: 000D4D4F5649535441525F39383830\n\
-        \                    IE: Unknown: 010882848B961224486C\n                 \
-        \   IE: Unknown: 030101\n                    IE: Unknown: 2A0100\n       \
-        \             IE: Unknown: 32040C183060\n                    IE: Unknown:\
-        \ 2D1AAC0117FFFF000000000000000000000000000000000000000000\n             \
-        \       IE: Unknown: 3D1601000700000000000000000000000000000000000000\n  \
-        \                  IE: IEEE 802.11i/WPA2 Version 1\n                     \
-        \   Group Cipher : CCMP\n                        Pairwise Ciphers (1) : CCMP\n\
-        \                        Authentication Suites (1) : PSK\n               \
-        \     IE: Unknown: 7F080100080000000000\n                    IE: Unknown:\
-        \ DD180050F2020101000003A4000027A4000042435E0062322F00\n                 \
-        \   IE: Unknown: 23021300\n                    IE: Unknown: 4605F3C0010004\n\
-        \                    IE: Unknown: 7F080000000100000000\n                 \
-        \   IE: Unknown: 0706455320010D10\n                    IE: Unknown: DD8A0050F204104A0001101044000102103B00010310470010BC329E001DD811B28601CCEDDCB29880102100094D6974726153746172102300154D697472615374617220576972656C657373204150102400065254353339321042000831323334353637381054000800060050F20400011011000C4750542D32373431474E414310080002008C103C000101\n\
-        \                    IE: Unknown: DD07000C4300000000\n          Cell 02 -\
-        \ Address: AA:AA:AA:AA:AA:AA\n                    Channel:2\n            \
-        \        Frequency:2.417 GHz (Channel 2)\n                    Quality=27/70\
-        \  Signal level=-83 dBm  \n                    Encryption key:on\n       \
-        \             ESSID:\"WIFI_INVITADOS\"\n                    Bit Rates:1 Mb/s;\
-        \ 2 Mb/s; 5.5 Mb/s; 11 Mb/s; 18 Mb/s\n                              24 Mb/s;\
-        \ 36 Mb/s; 54 Mb/s\n                    Bit Rates:6 Mb/s; 9 Mb/s; 12 Mb/s;\
-        \ 48 Mb/s\n                    Mode:Master\n                    Extra:tsf=00000000a371bb16\n\
-        \                    Extra: Last beacon: 53ms ago\n                    IE:\
-        \ Unknown: 000E574946495F494E56495441444F53\n                    IE: Unknown:\
-        \ 010882848B962430486C\n                    IE: Unknown: 030102\n        \
-        \            IE: Unknown: 2A0100\n                    IE: Unknown: 2F0100\n\
-        \                    IE: IEEE 802.11i/WPA2 Version 1\n                   \
-        \     Group Cipher : CCMP\n                        Pairwise Ciphers (1) :\
-        \ CCMP\n                        Authentication Suites (1) : PSK\n        \
-        \            IE: Unknown: 32040C121860\n                    IE: Unknown: 2D1AAC181BFFFF000000000000000000000000000000000000000000\n\
-        \                    IE: Unknown: 3D1602000000000000000000000000000000000000000000\n\
-        \                    IE: Unknown: 7F080000000000000040\n                 \
-        \   IE: Unknown: DD1000E0FC80000000230000000000000000\n                  \
-        \  IE: Unknown: DD090010180200000C0000\n                    IE: WPA Version\
-        \ 1\n                        Group Cipher : CCMP\n                       \
-        \ Pairwise Ciphers (1) : CCMP\n                        Authentication Suites\
-        \ (1) : PSK\n                    IE: Unknown: DD180050F2020101800003A4000027A4000042435E0062322F00\n\
-        \          Cell 03 - Address: AA:AA:AA:AA:AA:AA\n                    Channel:3\n\
-        \                    Frequency:2.422 GHz (Channel 3)\n                   \
-        \ Quality=58/70  Signal level=-52 dBm  \n                    Encryption key:on\n\
-        \                    ESSID:\"qwdnqwod\"\n                    Bit Rates:1 Mb/s;\
-        \ 2 Mb/s; 5.5 Mb/s; 11 Mb/s; 9 Mb/s\n                              18 Mb/s;\
-        \ 36 Mb/s; 54 Mb/s\n                    Bit Rates:6 Mb/s; 12 Mb/s; 24 Mb/s;\
-        \ 48 Mb/s\n                    Mode:Master\n                    Extra:tsf=0000004dff6e359e\n\
-        \                    Extra: Last beacon: 7187ms ago\n                    IE:\
-        \ Unknown: 0004575F3130\n                    IE: Unknown: 010802040B161224486C\n\
-        \                    IE: Unknown: 030103\n                    IE: Unknown:\
-        \ 2A0104\n                    IE: Unknown: 32040C183060\n                \
-        \    IE: IEEE 802.11i/WPA2 Version 1\n                        Group Cipher\
-        \ : CCMP\n                        Pairwise Ciphers (1) : CCMP\n          \
-        \              Authentication Suites (1) : PSK\n                    IE: Unknown:\
-        \ 2D1AEF1913FFFF000001000000000000000000000000001804870900\n             \
-        \       IE: Unknown: 3D1603050600000000000000000000000000000000000000\n  \
-        \                  IE: Unknown: 4A0E14000A002C01C800140005001900\n       \
-        \             IE: Unknown: 7F080100088000000000\n                    IE: Unknown:\
-        \ 0B0502000E127A\n                    IE: Unknown: 6B09000008000000000000\n\
-        \                    IE: Unknown: 6C027F00\n                    IE: Unknown:\
-        \ DD180050F2020101800003A4000027A4000042435E0062322F00\n                 \
-        \   IE: Unknown: 46050200010000\n                    IE: Unknown: 330A53010203040506070809\n\
-        \                    IE: Unknown: 200100\n                    IE: Unknown:\
-        \ 23020E00\n                    IE: Unknown: 0706465204010914\n          \
-        \          IE: Unknown: BF0C9279C933FAFF6801FAFF6821\n                   \
-        \ IE: Unknown: C005000300FCFF\n                    IE: Unknown: DD07000C430B000000\n\
-        \                    IE: Unknown: DD21000CE708000000BF0CB101C0332AFF92042AFF9204C0050000002AFFC303010202\n\
-        \                    IE: Unknown: DD0A000CE701000000010101\n             \
-        \       IE: Unknown: DD31F832E401010102010003148FEFB4475CECF8E59D66C942A0C3C0DD4438383707045AED3B981204ECEC0000130101150100\n\
-        \                    IE: Unknown: F0020000\n          Cell 04 - Address: AA:AA:AA:AA:AA:AA\n\
-        \                    Channel:1\n                    Frequency:2.412 GHz (Channel\
-        \ 1)\n                    Quality=26/70  Signal level=-84 dBm  \n        \
-        \            Encryption key:on\n                    ESSID:\"qwdoinqwdoqwn\"\
-        \n                    Bit Rates:1 Mb/s; 2 Mb/s; 5.5 Mb/s; 11 Mb/s; 18 Mb/s\n\
-        \                              24 Mb/s; 36 Mb/s; 54 Mb/s\n               \
-        \     Bit Rates:6 Mb/s; 9 Mb/s; 12 Mb/s; 48 Mb/s\n                    Mode:Master\n\
-        \                    Extra:tsf=00000028ed34ed13\n                    Extra:\
-        \ Last beacon: 1792ms ago\n                    IE: Unknown: 000C766F6461666F6E6536353732\n\
-        \                    IE: Unknown: 010882848B962430486C\n                 \
-        \   IE: Unknown: 030101\n                    IE: Unknown: 0706444520010D14\n\
-        \                    IE: Unknown: 200100\n                    IE: Unknown:\
-        \ 23021000\n                    IE: Unknown: 2A0100\n                    IE:\
-        \ Unknown: 32040C121860\n                    IE: IEEE 802.11i/WPA2 Version\
-        \ 1\n                        Group Cipher : TKIP\n                       \
-        \ Pairwise Ciphers (2) : CCMP TKIP\n                        Authentication\
-        \ Suites (1) : PSK\n                    IE: Unknown: 0B050000410000\n    \
-        \                IE: Unknown: 46057208010000\n                    IE: Unknown:\
-        \ 2D1ABC091BFFFF000000000000000000000000000000000000000000\n             \
-        \       IE: Unknown: 3D1601080000000000000000000000000000000000000000\n  \
-        \                  IE: Unknown: 7F080400080000000040\n                   \
-        \ IE: Unknown: DD860050F204104A0001101044000102103B00010310470010F81E0F40661DC8946500EB584A1693981021000842726F6164636F6D1023000842726F6164636F6D1024000631323334353610420007303030303030311054000800060050F20400011011000D546563686E69636F6C6F724150100800022008103C0001031049000600372A000120\n\
-        \                    IE: Unknown: DD090010180200000C0000\n               \
-        \     IE: WPA Version 1\n                        Group Cipher : TKIP\n   \
-        \                     Pairwise Ciphers (2) : CCMP TKIP\n                 \
-        \       Authentication Suites (1) : PSK\n                    IE: Unknown:\
-        \ DD180050F2020101880003A4000027A4000042435E0062322F00\n          Cell 05\
-        \ - Address: AA:AA:AA:AA:AA:AA\n                    Channel:1\n          \
-        \          Frequency:2.412 GHz (Channel 1)\n                    Quality=20/70\
-        \  Signal level=-90 dBm  \n                    Encryption key:on\n       \
-        \             ESSID:\"WDNIOWN\"\n                    Bit Rates:1 Mb/s; 2 Mb/s;\
-        \ 5.5 Mb/s; 11 Mb/s; 18 Mb/s\n                              24 Mb/s; 36 Mb/s;\
-        \ 54 Mb/s\n                    Bit Rates:6 Mb/s; 9 Mb/s; 12 Mb/s; 48 Mb/s\n\
-        \                    Mode:Master\n                    Extra:tsf=0000000dada2ddd0\n\
-        \                    Extra: Last beacon: 8923ms ago\n                    IE:\
-        \ Unknown: 0008576966696A617669\n                    IE: Unknown: 010882848B962430486C\n\
-        \                    IE: Unknown: 030101\n                    IE: Unknown:\
-        \ 050400010000\n                    IE: Unknown: 0706444520010D14\n      \
-        \              IE: Unknown: 200100\n                    IE: Unknown: 23020F00\n\
-        \                    IE: Unknown: 2A0104\n                    IE: Unknown:\
-        \ 32040C121860\n                    IE: IEEE 802.11i/WPA2 Version 1\n    \
-        \                    Group Cipher : TKIP\n                        Pairwise\
-        \ Ciphers (2) : CCMP TKIP\n                        Authentication Suites (1)\
-        \ : PSK\n                    IE: Unknown: 0B050600740000\n               \
-        \     IE: Unknown: 46057208010000\n                    IE: Unknown: 2D1AAD0917FFFFFF0000000000000000000000000000000000000000\n\
-        \                    IE: Unknown: 3D1601081500000000000000000000000000000000000000\n\
-        \                    IE: Unknown: 4A0E14000A002C01C800140005001900\n     \
-        \               IE: Unknown: 7F080500080000000040\n                    IE:\
-        \ Unknown: DD310050F204104A0001101044000102104700101E8FB990104475971B7B59198FB3BEC1103C0001031049000600372A000120\n\
-        \                    IE: Unknown: DD1E00904C0408BF0CB251820FEAFF0000EAFF0000C0050001000000C3020002\n\
-        \                    IE: Unknown: DD090010180206001C0000\n               \
-        \     IE: WPA Version 1\n                        Group Cipher : TKIP\n   \
-        \                     Pairwise Ciphers (2) : CCMP TKIP\n                 \
-        \       Authentication Suites (1) : PSK\n                    IE: Unknown:\
-        \ DD180050F2020101840003A4000027A4000042435E0062322F00\n\nwlan0  Scan completed\
-        \ :\n        Cell 01 - Address: AA:AA:AA:AA:AA:AA\n                    Channel:1\n\
-        \                    Frequency:2.412 GHz (Channel 1)\n                   \
-        \ Quality=19/70  Signal level=-91 dBm  \n                    Encryption key:on\n\
-        \                    ESSID:\"Wifi\"\n                    Bit Rates:1 Mb/s;\
-        \ 2 Mb/s; 5.5 Mb/s; 11 Mb/s; 18 Mb/s\n                            24 Mb/s;\
-        \ 36 Mb/s; 54 Mb/s\n                    Bit Rates:6 Mb/s; 9 Mb/s; 12 Mb/s;\
-        \ 48 Mb/s\n                    Mode:Master\n                    Extra:tsf=000000012bd8ea64\n\
-        \                    Extra: Last beacon: 35ms ago\n                    IE:\
-        \ Unknown: 0008576966696A617669\n                    IE: Unknown: 010882848B962430486C\n\
-        \                    IE: Unknown: 030101\n                    IE: Unknown:\
-        \ 0706444520010D14\n                    IE: Unknown: 200100\n            \
-        \        IE: Unknown: 23020F00\n                    IE: Unknown: 2A0104\n\
-        \                    IE: Unknown: 32040C121860\n                    IE: IEEE\
-        \ 802.11i/WPA2 Version 1\n                        Group Cipher : TKIP\n  \
-        \                      Pairwise Ciphers (2) : CCMP TKIP\n                \
-        \        Authentication Suites (1) : PSK\n                    IE: Unknown:\
-        \ 0B050600560000\n                    IE: Unknown: 46057208010000\n      \
-        \              IE: Unknown: 2D1AAD0917FFFFFF0000000000000000000000000000000000000000\n\
-        \                    IE: Unknown: 3D1601081500000000000000000000000000000000000000\n\
-        \                    IE: Unknown: 4A0E14000A002C01C800140005001900\n     \
-        \               IE: Unknown: 7F080500080000000040\n                    IE:\
-        \ Unknown: DD830050F204104A0001101044000102103B000103104700101E8FB990104475971B7B59198FB3BEC110210008536167656D636F6D10230008536167656D636F6D1024000631323334353610420007303030303030311054000800060050F20400011011000A536167656D636F6D4150100800022008103C0001031049000600372A000120\n\
-        \                    IE: Unknown: DD1E00904C0408BF0CB251820FEAFF0000EAFF0000C0050001000000C3020002\n\
-        \                    IE: Unknown: DD090010180206001C0000\n               \
-        \     IE: WPA Version 1\n                        Group Cipher : TKIP\n   \
-        \                     Pairwise Ciphers (2) : CCMP TKIP\n                 \
-        \       Authentication Suites (1) : PSK\n                    IE: Unknown:\
-        \ DD180050F2020101840003A4000027A4000042435E0062322F00\n        Cell 02 -\
-        \ Address: AA:AA:AA:AA:AA:AA\n                    Channel:1\n            \
-        \        Frequency:2.412 GHz (Channel 1)\n                    Quality=22/70\
-        \  Signal level=-88 dBm  \n                    Encryption key:on\n       \
-        \             ESSID:\"HECTOR\"\n                    Bit Rates:1 Mb/s; 2 Mb/s;\
-        \ 5.5 Mb/s; 11 Mb/s; 18 Mb/s\n                            24 Mb/s; 36 Mb/s;\
-        \ 54 Mb/s\n                    Bit Rates:6 Mb/s; 9 Mb/s; 12 Mb/s; 48 Mb/s\n\
-        \                    Mode:Master\n                    Extra:tsf=0000001e1f01376e\n\
-        \                    Extra: Last beacon: 7721ms ago\n                    IE:\
-        \ Unknown: 0006484543544F52\n                    IE: Unknown: 010882848B962430486C\n\
-        \                    IE: Unknown: 030101\n                    IE: Unknown:\
-        \ 050401030000\n                    IE: Unknown: 0706444520010D14\n      \
-        \              IE: Unknown: 200100\n                    IE: Unknown: 23021100\n\
-        \                    IE: Unknown: 2A0100\n                    IE: Unknown:\
-        \ 32040C121860\n                    IE: IEEE 802.11i/WPA2 Version 1\n    \
-        \                    Group Cipher : CCMP\n                        Pairwise\
-        \ Ciphers (1) : CCMP\n                        Authentication Suites (1) :\
-        \ PSK\n                    IE: Unknown: 0B050000590000\n                 \
-        \   IE: Unknown: 42020000\n                    IE: Unknown: 46050100000000\n\
-        \                    IE: Unknown: 2D1A2D0817FFFF000000000000000000000000000000000000000000\n\
-        \                    IE: Unknown: 3D1601081100000000000000000000000000000000000000\n\
-        \                    IE: Unknown: 7F080400080000000040\n                 \
-        \   IE: Unknown: DD350050F204104A000110104400010210470010D96C7EFC2F8938F1EFBD6E5148BFA812103C0001031049000A00372A00012005020284\n\
-        \                    IE: Unknown: DD090010180200101C0000\n               \
-        \     IE: Unknown: DD180050F2020101800003A4000027A4000042435E0062322F00\n\
-        \        Cell 03 - Address: AA:AA:AA:AA:AA:AA\n                    Channel:1\n\
-        \                    Frequency:2.412 GHz (Channel 1)\n                   \
-        \ Quality=25/70  Signal level=-85 dBm  \n                    Encryption key:on\n\
-        \                    ESSID:\"vodafone6572\"\n                    Bit Rates:1\
-        \ Mb/s; 2 Mb/s; 5.5 Mb/s; 11 Mb/s; 18 Mb/s\n                            24\
-        \ Mb/s; 36 Mb/s; 54 Mb/s\n                    Bit Rates:6 Mb/s; 9 Mb/s; 12\
-        \ Mb/s; 48 Mb/s\n                    Mode:Master\n                    Extra:tsf=0000003b1ff71990\n\
-        \                    Extra: Last beacon: 381ms ago\n                    IE:\
-        \ Unknown: 000C766F6461666F6E6536353732\n                    IE: Unknown:\
-        \ 010882848B962430486C\n                    IE: Unknown: 030101\n        \
-        \            IE: Unknown: 0706444520010D14\n                    IE: Unknown:\
-        \ 200100\n                    IE: Unknown: 23021000\n                    IE:\
-        \ Unknown: 2A0100\n                    IE: Unknown: 32040C121860\n       \
-        \             IE: IEEE 802.11i/WPA2 Version 1\n                        Group\
-        \ Cipher : TKIP\n                        Pairwise Ciphers (2) : CCMP TKIP\n\
-        \                        Authentication Suites (1) : PSK\n               \
-        \     IE: Unknown: 0B0501002B0000\n                    IE: Unknown: 46057208010000\n\
-        \                    IE: Unknown: 2D1ABC091BFFFF000000000000000000000000000000000000000000\n\
-        \                    IE: Unknown: 3D1601080400000000000000000000000000000000000000\n\
-        \                    IE: Unknown: 7F080400080000000040\n                 \
-        \   IE: Unknown: DD860050F204104A0001101044000102103B00010310470010F81E0F40661DC8946500EB584A1693981021000842726F6164636F6D1023000842726F6164636F6D1024000631323334353610420007303030303030311054000800060050F20400011011000D546563686E69636F6C6F724150100800022008103C0001031049000600372A000120\n\
-        \                    IE: Unknown: DD090010180201000C0000\n               \
-        \     IE: WPA Version 1\n                        Group Cipher : TKIP\n   \
-        \                     Pairwise Ciphers (2) : CCMP TKIP\n                 \
-        \       Authentication Suites (1) : PSK\n                    IE: Unknown:\
-        \ DD180050F2020101880003A4000027A4000042435E0062322F00\n        Cell 04 -\
-        \ Address: AA:AA:AA:AA:AA:AA\n                    Channel:1\n            \
-        \        Frequency:2.412 GHz (Channel 1)\n                    Quality=21/70\
-        \  Signal level=-89 dBm  \n                    Encryption key:on\n       \
-        \             ESSID:\"\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\"\
-        \n                    Bit Rates:1 Mb/s; 2 Mb/s; 5.5 Mb/s; 11 Mb/s; 18 Mb/s\n\
-        \                            24 Mb/s; 36 Mb/s; 54 Mb/s\n                 \
-        \   Bit Rates:6 Mb/s; 9 Mb/s; 12 Mb/s; 48 Mb/s\n                    Mode:Master\n\
-        \                    Extra:tsf=0000001e1f45fb42\n                    Extra:\
-        \ Last beacon: 3215ms ago\n                    IE: Unknown: 000A00000000000000000000\n\
-        \                    IE: Unknown: 010882848B962430486C\n                 \
-        \   IE: Unknown: 030101\n                    IE: Unknown: 050402030000\n \
-        \                   IE: Unknown: 0706444520010D14\n                    IE:\
-        \ Unknown: 200100\n                    IE: Unknown: 23021100\n           \
-        \         IE: Unknown: 2A0100\n                    IE: Unknown: 32040C121860\n\
-        \                    IE: IEEE 802.11i/WPA2 Version 1\n                   \
-        \     Group Cipher : CCMP\n                        Pairwise Ciphers (1) :\
-        \ CCMP\n                        Authentication Suites (1) : PSK\n        \
-        \            IE: Unknown: 0B050000780000\n                    IE: Unknown:\
-        \ 42020000\n                    IE: Unknown: 2D1A2D0817FFFF000000000000000000000000000000000000000000\n\
-        \                    IE: Unknown: 3D1601081100000000000000000000000000000000000000\n\
-        \                    IE: Unknown: 7F080400080000000040\n                 \
-        \   IE: Unknown: DD090010180200101C0000\n                    IE: Unknown:\
-        \ DD180050F2020101800003A4000027A4000042435E0062322F00\n        Cell 05 -\
-        \ Address: BB:BB:BB:BB:BB:BB\n                    Channel:1\n            \
-        \        Frequency:2.412 GHz (Channel 1)\n                    Quality=24/70\
-        \  Signal level=-86 dBm  \n                    Encryption key:on\n       \
-        \             ESSID:\"Vodafone-000A\"\n                    Bit Rates:1 Mb/s;\
-        \ 2 Mb/s; 5.5 Mb/s; 11 Mb/s; 18 Mb/s\n                            24 Mb/s;\
-        \ 36 Mb/s; 54 Mb/s\n                    Bit Rates:6 Mb/s; 9 Mb/s; 12 Mb/s;\
-        \ 48 Mb/s\n                    Mode:Master\n                    Extra:tsf=00000178fac80ae7\n\
-        \                    Extra: Last beacon: 667ms ago\n                    IE:\
-        \ Unknown: 000D566F6461666F6E652D37423034\n                    IE: Unknown:\
-        \ 010882848B962430486C\n                    IE: Unknown: 030101\n        \
-        \            IE: Unknown: 050400010000\n                    IE: Unknown: 23021200\n\
-        \                    IE: Unknown: 2A0104\n                    IE: Unknown:\
-        \ 32040C121860\n                    IE: IEEE 802.11i/WPA2 Version 1\n    \
-        \                    Group Cipher : CCMP\n                        Pairwise\
-        \ Ciphers (1) : CCMP\n                        Authentication Suites (1) :\
-        \ PSK\n                    IE: Unknown: 0B050000390000\n                 \
-        \   IE: Unknown: 46053000000000\n                    IE: Unknown: 2D1AE31117FFFFFFFF00000000000000000000000000000000000000\n\
-        \                    IE: Unknown: 3D1601081100000000000000000000000000000000000000\n\
-        \                    IE: Unknown: 4A0E14000A002C01C800140005001900\n     \
-        \               IE: Unknown: 7F0A05000880010000C00140\n                  \
-        \  IE: Unknown: FF2323050008120010222002C00F438518000C00AAFFAAFF7B1CC7711CC7711CC7711CC771\n\
-        \                    IE: Unknown: FF0724F43F0013FCFF\n                   \
-        \ IE: Unknown: FF0E260C00A40820A408404308603208\n                    IE: Unknown:\
-        \ DD1D0050F204104A0001101044000102103C0001031049000600372A000120\n       \
-        \             IE: Unknown: DD1E00904C0418BF0CB1798B0FAAFF0000AAFF0000C0050001000000C3020027\n\
-        \                    IE: Unknown: DD0A0010180200001C000001\n             \
-        \       IE: Unknown: DD180050F20201018C0003A4000027A4000042435E0062322F00\n\
-        \                    IE: Unknown: 6C027F00\n        Cell 06 - Address: BB:BB:BB:BB:BB:BB\n\
-        \                    Channel:1\n                    Frequency:2.412 GHz (Channel\
-        \ 1)\n                    Quality=21/70  Signal level=-89 dBm  \n        \
-        \            Encryption key:on\n                    ESSID:\"\\x00\\x00\\x00\\\
-        x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\"\n                    Bit Rates:1\
-        \ Mb/s; 2 Mb/s; 5.5 Mb/s; 11 Mb/s; 18 Mb/s\n                            24\
-        \ Mb/s; 36 Mb/s; 54 Mb/s\n                    Bit Rates:6 Mb/s; 9 Mb/s; 12\
-        \ Mb/s; 48 Mb/s\n                    Mode:Master\n                    Extra:tsf=0000001e1f447431\n\
-        \                    Extra: Last beacon: 3315ms ago\n                    IE:\
-        \ Unknown: 000B0000000000000000000000\n                    IE: Unknown: 010882848B962430486C\n\
-        \                    IE: Unknown: 030101\n                    IE: Unknown:\
-        \ 050400030000\n                    IE: Unknown: 0706444520010D14\n      \
-        \              IE: Unknown: 200100\n                    IE: Unknown: 23021100\n\
-        \                    IE: Unknown: 2A0100\n                    IE: Unknown:\
-        \ 32040C121860\n                    IE: IEEE 802.11i/WPA2 Version 1\n    \
-        \                    Group Cipher : CCMP\n                        Pairwise\
-        \ Ciphers (1) : CCMP\n                        Authentication Suites (1) :\
-        \ PSK\n                    IE: Unknown: 0B050000780000\n                 \
-        \   IE: Unknown: 42020000\n                    IE: Unknown: 2D1A2D0817FFFF000000000000000000000000000000000000000000\n\
-        \                    IE: Unknown: 3D1601081100000000000000000000000000000000000000\n\
-        \                    IE: Unknown: 7F080400080000000040\n                 \
-        \   IE: Unknown: DD090010180200101C0000\n                    IE: Unknown:\
-        \ DD180050F2020101000003A4000027A4000042435E0062322F00\n"
+    - "wlx6245b4e66e1a  Scan completed :\n          Cell 01 - Address: AA:AA:AA:AA:AA:AA\n\
+      \                    Channel:1\n                    Frequency:2.412 GHz (Channel\
+      \ 1)\n                    Quality=23/70  Signal level=-87 dBm  \n          \
+      \          Encryption key:on\n                    ESSID:\"MOVISTAR_9880\"\n\
+      \                    Bit Rates:1 Mb/s; 2 Mb/s; 5.5 Mb/s; 11 Mb/s; 9 Mb/s\n \
+      \                             18 Mb/s; 36 Mb/s; 54 Mb/s\n                  \
+      \  Bit Rates:6 Mb/s; 12 Mb/s; 24 Mb/s; 48 Mb/s\n                    Mode:Master\n\
+      \                    Extra:tsf=0000005ca9827456\n                    Extra:\
+      \ Last beacon: 69ms ago\n                    IE: Unknown: 000D4D4F5649535441525F39383830\n\
+      \                    IE: Unknown: 010882848B961224486C\n                   \
+      \ IE: Unknown: 030101\n                    IE: Unknown: 2A0100\n           \
+      \         IE: Unknown: 32040C183060\n                    IE: Unknown: 2D1AAC0117FFFF000000000000000000000000000000000000000000\n\
+      \                    IE: Unknown: 3D1601000700000000000000000000000000000000000000\n\
+      \                    IE: IEEE 802.11i/WPA2 Version 1\n                     \
+      \   Group Cipher : CCMP\n                        Pairwise Ciphers (1) : CCMP\n\
+      \                        Authentication Suites (1) : PSK\n                 \
+      \   IE: Unknown: 7F080100080000000000\n                    IE: Unknown: DD180050F2020101000003A4000027A4000042435E0062322F00\n\
+      \                    IE: Unknown: 23021300\n                    IE: Unknown:\
+      \ 4605F3C0010004\n                    IE: Unknown: 7F080000000100000000\n  \
+      \                  IE: Unknown: 0706455320010D10\n                    IE: Unknown:\
+      \ DD8A0050F204104A0001101044000102103B00010310470010BC329E001DD811B28601CCEDDCB29880102100094D6974726153746172102300154D697472615374617220576972656C657373204150102400065254353339321042000831323334353637381054000800060050F20400011011000C4750542D32373431474E414310080002008C103C000101\n\
+      \                    IE: Unknown: DD07000C4300000000\n          Cell 02 - Address:\
+      \ AA:AA:AA:AA:AA:AA\n                    Channel:2\n                    Frequency:2.417\
+      \ GHz (Channel 2)\n                    Quality=27/70  Signal level=-83 dBm \
+      \ \n                    Encryption key:on\n                    ESSID:\"WIFI_INVITADOS\"\
+      \n                    Bit Rates:1 Mb/s; 2 Mb/s; 5.5 Mb/s; 11 Mb/s; 18 Mb/s\n\
+      \                              24 Mb/s; 36 Mb/s; 54 Mb/s\n                 \
+      \   Bit Rates:6 Mb/s; 9 Mb/s; 12 Mb/s; 48 Mb/s\n                    Mode:Master\n\
+      \                    Extra:tsf=00000000a371bb16\n                    Extra:\
+      \ Last beacon: 53ms ago\n                    IE: Unknown: 000E574946495F494E56495441444F53\n\
+      \                    IE: Unknown: 010882848B962430486C\n                   \
+      \ IE: Unknown: 030102\n                    IE: Unknown: 2A0100\n           \
+      \         IE: Unknown: 2F0100\n                    IE: IEEE 802.11i/WPA2 Version\
+      \ 1\n                        Group Cipher : CCMP\n                        Pairwise\
+      \ Ciphers (1) : CCMP\n                        Authentication Suites (1) : PSK\n\
+      \                    IE: Unknown: 32040C121860\n                    IE: Unknown:\
+      \ 2D1AAC181BFFFF000000000000000000000000000000000000000000\n               \
+      \     IE: Unknown: 3D1602000000000000000000000000000000000000000000\n      \
+      \              IE: Unknown: 7F080000000000000040\n                    IE: Unknown:\
+      \ DD1000E0FC80000000230000000000000000\n                    IE: Unknown: DD090010180200000C0000\n\
+      \                    IE: WPA Version 1\n                        Group Cipher\
+      \ : CCMP\n                        Pairwise Ciphers (1) : CCMP\n            \
+      \            Authentication Suites (1) : PSK\n                    IE: Unknown:\
+      \ DD180050F2020101800003A4000027A4000042435E0062322F00\n          Cell 03 -\
+      \ Address: AA:AA:AA:AA:AA:AA\n                    Channel:3\n              \
+      \      Frequency:2.422 GHz (Channel 3)\n                    Quality=58/70  Signal\
+      \ level=-52 dBm  \n                    Encryption key:on\n                 \
+      \   ESSID:\"qwdnqwod\"\n                    Bit Rates:1 Mb/s; 2 Mb/s; 5.5 Mb/s;\
+      \ 11 Mb/s; 9 Mb/s\n                              18 Mb/s; 36 Mb/s; 54 Mb/s\n\
+      \                    Bit Rates:6 Mb/s; 12 Mb/s; 24 Mb/s; 48 Mb/s\n         \
+      \           Mode:Master\n                    Extra:tsf=0000004dff6e359e\n  \
+      \                  Extra: Last beacon: 7187ms ago\n                    IE: Unknown:\
+      \ 0004575F3130\n                    IE: Unknown: 010802040B161224486C\n    \
+      \                IE: Unknown: 030103\n                    IE: Unknown: 2A0104\n\
+      \                    IE: Unknown: 32040C183060\n                    IE: IEEE\
+      \ 802.11i/WPA2 Version 1\n                        Group Cipher : CCMP\n    \
+      \                    Pairwise Ciphers (1) : CCMP\n                        Authentication\
+      \ Suites (1) : PSK\n                    IE: Unknown: 2D1AEF1913FFFF000001000000000000000000000000001804870900\n\
+      \                    IE: Unknown: 3D1603050600000000000000000000000000000000000000\n\
+      \                    IE: Unknown: 4A0E14000A002C01C800140005001900\n       \
+      \             IE: Unknown: 7F080100088000000000\n                    IE: Unknown:\
+      \ 0B0502000E127A\n                    IE: Unknown: 6B09000008000000000000\n\
+      \                    IE: Unknown: 6C027F00\n                    IE: Unknown:\
+      \ DD180050F2020101800003A4000027A4000042435E0062322F00\n                   \
+      \ IE: Unknown: 46050200010000\n                    IE: Unknown: 330A53010203040506070809\n\
+      \                    IE: Unknown: 200100\n                    IE: Unknown: 23020E00\n\
+      \                    IE: Unknown: 0706465204010914\n                    IE:\
+      \ Unknown: BF0C9279C933FAFF6801FAFF6821\n                    IE: Unknown: C005000300FCFF\n\
+      \                    IE: Unknown: DD07000C430B000000\n                    IE:\
+      \ Unknown: DD21000CE708000000BF0CB101C0332AFF92042AFF9204C0050000002AFFC303010202\n\
+      \                    IE: Unknown: DD0A000CE701000000010101\n               \
+      \     IE: Unknown: DD31F832E401010102010003148FEFB4475CECF8E59D66C942A0C3C0DD4438383707045AED3B981204ECEC0000130101150100\n\
+      \                    IE: Unknown: F0020000\n          Cell 04 - Address: AA:AA:AA:AA:AA:AA\n\
+      \                    Channel:1\n                    Frequency:2.412 GHz (Channel\
+      \ 1)\n                    Quality=26/70  Signal level=-84 dBm  \n          \
+      \          Encryption key:on\n                    ESSID:\"qwdoinqwdoqwn\"\n\
+      \                    Bit Rates:1 Mb/s; 2 Mb/s; 5.5 Mb/s; 11 Mb/s; 18 Mb/s\n\
+      \                              24 Mb/s; 36 Mb/s; 54 Mb/s\n                 \
+      \   Bit Rates:6 Mb/s; 9 Mb/s; 12 Mb/s; 48 Mb/s\n                    Mode:Master\n\
+      \                    Extra:tsf=00000028ed34ed13\n                    Extra:\
+      \ Last beacon: 1792ms ago\n                    IE: Unknown: 000C766F6461666F6E6536353732\n\
+      \                    IE: Unknown: 010882848B962430486C\n                   \
+      \ IE: Unknown: 030101\n                    IE: Unknown: 0706444520010D14\n \
+      \                   IE: Unknown: 200100\n                    IE: Unknown: 23021000\n\
+      \                    IE: Unknown: 2A0100\n                    IE: Unknown: 32040C121860\n\
+      \                    IE: IEEE 802.11i/WPA2 Version 1\n                     \
+      \   Group Cipher : TKIP\n                        Pairwise Ciphers (2) : CCMP\
+      \ TKIP\n                        Authentication Suites (1) : PSK\n          \
+      \          IE: Unknown: 0B050000410000\n                    IE: Unknown: 46057208010000\n\
+      \                    IE: Unknown: 2D1ABC091BFFFF000000000000000000000000000000000000000000\n\
+      \                    IE: Unknown: 3D1601080000000000000000000000000000000000000000\n\
+      \                    IE: Unknown: 7F080400080000000040\n                   \
+      \ IE: Unknown: DD860050F204104A0001101044000102103B00010310470010F81E0F40661DC8946500EB584A1693981021000842726F6164636F6D1023000842726F6164636F6D1024000631323334353610420007303030303030311054000800060050F20400011011000D546563686E69636F6C6F724150100800022008103C0001031049000600372A000120\n\
+      \                    IE: Unknown: DD090010180200000C0000\n                 \
+      \   IE: WPA Version 1\n                        Group Cipher : TKIP\n       \
+      \                 Pairwise Ciphers (2) : CCMP TKIP\n                       \
+      \ Authentication Suites (1) : PSK\n                    IE: Unknown: DD180050F2020101880003A4000027A4000042435E0062322F00\n\
+      \          Cell 05 - Address: AA:AA:AA:AA:AA:AA\n                    Channel:1\n\
+      \                    Frequency:2.412 GHz (Channel 1)\n                    Quality=20/70\
+      \  Signal level=-90 dBm  \n                    Encryption key:on\n         \
+      \           ESSID:\"WDNIOWN\"\n                    Bit Rates:1 Mb/s; 2 Mb/s;\
+      \ 5.5 Mb/s; 11 Mb/s; 18 Mb/s\n                              24 Mb/s; 36 Mb/s;\
+      \ 54 Mb/s\n                    Bit Rates:6 Mb/s; 9 Mb/s; 12 Mb/s; 48 Mb/s\n\
+      \                    Mode:Master\n                    Extra:tsf=0000000dada2ddd0\n\
+      \                    Extra: Last beacon: 8923ms ago\n                    IE:\
+      \ Unknown: 0008576966696A617669\n                    IE: Unknown: 010882848B962430486C\n\
+      \                    IE: Unknown: 030101\n                    IE: Unknown: 050400010000\n\
+      \                    IE: Unknown: 0706444520010D14\n                    IE:\
+      \ Unknown: 200100\n                    IE: Unknown: 23020F00\n             \
+      \       IE: Unknown: 2A0104\n                    IE: Unknown: 32040C121860\n\
+      \                    IE: IEEE 802.11i/WPA2 Version 1\n                     \
+      \   Group Cipher : TKIP\n                        Pairwise Ciphers (2) : CCMP\
+      \ TKIP\n                        Authentication Suites (1) : PSK\n          \
+      \          IE: Unknown: 0B050600740000\n                    IE: Unknown: 46057208010000\n\
+      \                    IE: Unknown: 2D1AAD0917FFFFFF0000000000000000000000000000000000000000\n\
+      \                    IE: Unknown: 3D1601081500000000000000000000000000000000000000\n\
+      \                    IE: Unknown: 4A0E14000A002C01C800140005001900\n       \
+      \             IE: Unknown: 7F080500080000000040\n                    IE: Unknown:\
+      \ DD310050F204104A0001101044000102104700101E8FB990104475971B7B59198FB3BEC1103C0001031049000600372A000120\n\
+      \                    IE: Unknown: DD1E00904C0408BF0CB251820FEAFF0000EAFF0000C0050001000000C3020002\n\
+      \                    IE: Unknown: DD090010180206001C0000\n                 \
+      \   IE: WPA Version 1\n                        Group Cipher : TKIP\n       \
+      \                 Pairwise Ciphers (2) : CCMP TKIP\n                       \
+      \ Authentication Suites (1) : PSK\n                    IE: Unknown: DD180050F2020101840003A4000027A4000042435E0062322F00\n\
+      \nwlan0  Scan completed :\n        Cell 01 - Address: AA:AA:AA:AA:AA:AA\n  \
+      \                  Channel:1\n                    Frequency:2.412 GHz (Channel\
+      \ 1)\n                    Quality=19/70  Signal level=-91 dBm  \n          \
+      \          Encryption key:on\n                    ESSID:\"Wifi\"\n         \
+      \           Bit Rates:1 Mb/s; 2 Mb/s; 5.5 Mb/s; 11 Mb/s; 18 Mb/s\n         \
+      \                   24 Mb/s; 36 Mb/s; 54 Mb/s\n                    Bit Rates:6\
+      \ Mb/s; 9 Mb/s; 12 Mb/s; 48 Mb/s\n                    Mode:Master\n        \
+      \            Extra:tsf=000000012bd8ea64\n                    Extra: Last beacon:\
+      \ 35ms ago\n                    IE: Unknown: 0008576966696A617669\n        \
+      \            IE: Unknown: 010882848B962430486C\n                    IE: Unknown:\
+      \ 030101\n                    IE: Unknown: 0706444520010D14\n              \
+      \      IE: Unknown: 200100\n                    IE: Unknown: 23020F00\n    \
+      \                IE: Unknown: 2A0104\n                    IE: Unknown: 32040C121860\n\
+      \                    IE: IEEE 802.11i/WPA2 Version 1\n                     \
+      \   Group Cipher : TKIP\n                        Pairwise Ciphers (2) : CCMP\
+      \ TKIP\n                        Authentication Suites (1) : PSK\n          \
+      \          IE: Unknown: 0B050600560000\n                    IE: Unknown: 46057208010000\n\
+      \                    IE: Unknown: 2D1AAD0917FFFFFF0000000000000000000000000000000000000000\n\
+      \                    IE: Unknown: 3D1601081500000000000000000000000000000000000000\n\
+      \                    IE: Unknown: 4A0E14000A002C01C800140005001900\n       \
+      \             IE: Unknown: 7F080500080000000040\n                    IE: Unknown:\
+      \ DD830050F204104A0001101044000102103B000103104700101E8FB990104475971B7B59198FB3BEC110210008536167656D636F6D10230008536167656D636F6D1024000631323334353610420007303030303030311054000800060050F20400011011000A536167656D636F6D4150100800022008103C0001031049000600372A000120\n\
+      \                    IE: Unknown: DD1E00904C0408BF0CB251820FEAFF0000EAFF0000C0050001000000C3020002\n\
+      \                    IE: Unknown: DD090010180206001C0000\n                 \
+      \   IE: WPA Version 1\n                        Group Cipher : TKIP\n       \
+      \                 Pairwise Ciphers (2) : CCMP TKIP\n                       \
+      \ Authentication Suites (1) : PSK\n                    IE: Unknown: DD180050F2020101840003A4000027A4000042435E0062322F00\n\
+      \        Cell 02 - Address: AA:AA:AA:AA:AA:AA\n                    Channel:1\n\
+      \                    Frequency:2.412 GHz (Channel 1)\n                    Quality=22/70\
+      \  Signal level=-88 dBm  \n                    Encryption key:on\n         \
+      \           ESSID:\"HECTOR\"\n                    Bit Rates:1 Mb/s; 2 Mb/s;\
+      \ 5.5 Mb/s; 11 Mb/s; 18 Mb/s\n                            24 Mb/s; 36 Mb/s;\
+      \ 54 Mb/s\n                    Bit Rates:6 Mb/s; 9 Mb/s; 12 Mb/s; 48 Mb/s\n\
+      \                    Mode:Master\n                    Extra:tsf=0000001e1f01376e\n\
+      \                    Extra: Last beacon: 7721ms ago\n                    IE:\
+      \ Unknown: 0006484543544F52\n                    IE: Unknown: 010882848B962430486C\n\
+      \                    IE: Unknown: 030101\n                    IE: Unknown: 050401030000\n\
+      \                    IE: Unknown: 0706444520010D14\n                    IE:\
+      \ Unknown: 200100\n                    IE: Unknown: 23021100\n             \
+      \       IE: Unknown: 2A0100\n                    IE: Unknown: 32040C121860\n\
+      \                    IE: IEEE 802.11i/WPA2 Version 1\n                     \
+      \   Group Cipher : CCMP\n                        Pairwise Ciphers (1) : CCMP\n\
+      \                        Authentication Suites (1) : PSK\n                 \
+      \   IE: Unknown: 0B050000590000\n                    IE: Unknown: 42020000\n\
+      \                    IE: Unknown: 46050100000000\n                    IE: Unknown:\
+      \ 2D1A2D0817FFFF000000000000000000000000000000000000000000\n               \
+      \     IE: Unknown: 3D1601081100000000000000000000000000000000000000\n      \
+      \              IE: Unknown: 7F080400080000000040\n                    IE: Unknown:\
+      \ DD350050F204104A000110104400010210470010D96C7EFC2F8938F1EFBD6E5148BFA812103C0001031049000A00372A00012005020284\n\
+      \                    IE: Unknown: DD090010180200101C0000\n                 \
+      \   IE: Unknown: DD180050F2020101800003A4000027A4000042435E0062322F00\n    \
+      \    Cell 03 - Address: AA:AA:AA:AA:AA:AA\n                    Channel:1\n \
+      \                   Frequency:2.412 GHz (Channel 1)\n                    Quality=25/70\
+      \  Signal level=-85 dBm  \n                    Encryption key:on\n         \
+      \           ESSID:\"vodafone6572\"\n                    Bit Rates:1 Mb/s; 2\
+      \ Mb/s; 5.5 Mb/s; 11 Mb/s; 18 Mb/s\n                            24 Mb/s; 36\
+      \ Mb/s; 54 Mb/s\n                    Bit Rates:6 Mb/s; 9 Mb/s; 12 Mb/s; 48 Mb/s\n\
+      \                    Mode:Master\n                    Extra:tsf=0000003b1ff71990\n\
+      \                    Extra: Last beacon: 381ms ago\n                    IE:\
+      \ Unknown: 000C766F6461666F6E6536353732\n                    IE: Unknown: 010882848B962430486C\n\
+      \                    IE: Unknown: 030101\n                    IE: Unknown: 0706444520010D14\n\
+      \                    IE: Unknown: 200100\n                    IE: Unknown: 23021000\n\
+      \                    IE: Unknown: 2A0100\n                    IE: Unknown: 32040C121860\n\
+      \                    IE: IEEE 802.11i/WPA2 Version 1\n                     \
+      \   Group Cipher : TKIP\n                        Pairwise Ciphers (2) : CCMP\
+      \ TKIP\n                        Authentication Suites (1) : PSK\n          \
+      \          IE: Unknown: 0B0501002B0000\n                    IE: Unknown: 46057208010000\n\
+      \                    IE: Unknown: 2D1ABC091BFFFF000000000000000000000000000000000000000000\n\
+      \                    IE: Unknown: 3D1601080400000000000000000000000000000000000000\n\
+      \                    IE: Unknown: 7F080400080000000040\n                   \
+      \ IE: Unknown: DD860050F204104A0001101044000102103B00010310470010F81E0F40661DC8946500EB584A1693981021000842726F6164636F6D1023000842726F6164636F6D1024000631323334353610420007303030303030311054000800060050F20400011011000D546563686E69636F6C6F724150100800022008103C0001031049000600372A000120\n\
+      \                    IE: Unknown: DD090010180201000C0000\n                 \
+      \   IE: WPA Version 1\n                        Group Cipher : TKIP\n       \
+      \                 Pairwise Ciphers (2) : CCMP TKIP\n                       \
+      \ Authentication Suites (1) : PSK\n                    IE: Unknown: DD180050F2020101880003A4000027A4000042435E0062322F00\n\
+      \        Cell 04 - Address: AA:AA:AA:AA:AA:AA\n                    Channel:1\n\
+      \                    Frequency:2.412 GHz (Channel 1)\n                    Quality=21/70\
+      \  Signal level=-89 dBm  \n                    Encryption key:on\n         \
+      \           ESSID:\"\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\"\n \
+      \                   Bit Rates:1 Mb/s; 2 Mb/s; 5.5 Mb/s; 11 Mb/s; 18 Mb/s\n \
+      \                           24 Mb/s; 36 Mb/s; 54 Mb/s\n                    Bit\
+      \ Rates:6 Mb/s; 9 Mb/s; 12 Mb/s; 48 Mb/s\n                    Mode:Master\n\
+      \                    Extra:tsf=0000001e1f45fb42\n                    Extra:\
+      \ Last beacon: 3215ms ago\n                    IE: Unknown: 000A00000000000000000000\n\
+      \                    IE: Unknown: 010882848B962430486C\n                   \
+      \ IE: Unknown: 030101\n                    IE: Unknown: 050402030000\n     \
+      \               IE: Unknown: 0706444520010D14\n                    IE: Unknown:\
+      \ 200100\n                    IE: Unknown: 23021100\n                    IE:\
+      \ Unknown: 2A0100\n                    IE: Unknown: 32040C121860\n         \
+      \           IE: IEEE 802.11i/WPA2 Version 1\n                        Group Cipher\
+      \ : CCMP\n                        Pairwise Ciphers (1) : CCMP\n            \
+      \            Authentication Suites (1) : PSK\n                    IE: Unknown:\
+      \ 0B050000780000\n                    IE: Unknown: 42020000\n              \
+      \      IE: Unknown: 2D1A2D0817FFFF000000000000000000000000000000000000000000\n\
+      \                    IE: Unknown: 3D1601081100000000000000000000000000000000000000\n\
+      \                    IE: Unknown: 7F080400080000000040\n                   \
+      \ IE: Unknown: DD090010180200101C0000\n                    IE: Unknown: DD180050F2020101800003A4000027A4000042435E0062322F00\n\
+      \        Cell 05 - Address: BB:BB:BB:BB:BB:BB\n                    Channel:1\n\
+      \                    Frequency:2.412 GHz (Channel 1)\n                    Quality=24/70\
+      \  Signal level=-86 dBm  \n                    Encryption key:on\n         \
+      \           ESSID:\"Vodafone-000A\"\n                    Bit Rates:1 Mb/s; 2\
+      \ Mb/s; 5.5 Mb/s; 11 Mb/s; 18 Mb/s\n                            24 Mb/s; 36\
+      \ Mb/s; 54 Mb/s\n                    Bit Rates:6 Mb/s; 9 Mb/s; 12 Mb/s; 48 Mb/s\n\
+      \                    Mode:Master\n                    Extra:tsf=00000178fac80ae7\n\
+      \                    Extra: Last beacon: 667ms ago\n                    IE:\
+      \ Unknown: 000D566F6461666F6E652D37423034\n                    IE: Unknown:\
+      \ 010882848B962430486C\n                    IE: Unknown: 030101\n          \
+      \          IE: Unknown: 050400010000\n                    IE: Unknown: 23021200\n\
+      \                    IE: Unknown: 2A0104\n                    IE: Unknown: 32040C121860\n\
+      \                    IE: IEEE 802.11i/WPA2 Version 1\n                     \
+      \   Group Cipher : CCMP\n                        Pairwise Ciphers (1) : CCMP\n\
+      \                        Authentication Suites (1) : PSK\n                 \
+      \   IE: Unknown: 0B050000390000\n                    IE: Unknown: 46053000000000\n\
+      \                    IE: Unknown: 2D1AE31117FFFFFFFF00000000000000000000000000000000000000\n\
+      \                    IE: Unknown: 3D1601081100000000000000000000000000000000000000\n\
+      \                    IE: Unknown: 4A0E14000A002C01C800140005001900\n       \
+      \             IE: Unknown: 7F0A05000880010000C00140\n                    IE:\
+      \ Unknown: FF2323050008120010222002C00F438518000C00AAFFAAFF7B1CC7711CC7711CC7711CC771\n\
+      \                    IE: Unknown: FF0724F43F0013FCFF\n                    IE:\
+      \ Unknown: FF0E260C00A40820A408404308603208\n                    IE: Unknown:\
+      \ DD1D0050F204104A0001101044000102103C0001031049000600372A000120\n         \
+      \           IE: Unknown: DD1E00904C0418BF0CB1798B0FAAFF0000AAFF0000C0050001000000C3020027\n\
+      \                    IE: Unknown: DD0A0010180200001C000001\n               \
+      \     IE: Unknown: DD180050F20201018C0003A4000027A4000042435E0062322F00\n  \
+      \                  IE: Unknown: 6C027F00\n        Cell 06 - Address: BB:BB:BB:BB:BB:BB\n\
+      \                    Channel:1\n                    Frequency:2.412 GHz (Channel\
+      \ 1)\n                    Quality=21/70  Signal level=-89 dBm  \n          \
+      \          Encryption key:on\n                    ESSID:\"\\x00\\x00\\x00\\\
+      x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\"\n                    Bit Rates:1 Mb/s;\
+      \ 2 Mb/s; 5.5 Mb/s; 11 Mb/s; 18 Mb/s\n                            24 Mb/s; 36\
+      \ Mb/s; 54 Mb/s\n                    Bit Rates:6 Mb/s; 9 Mb/s; 12 Mb/s; 48 Mb/s\n\
+      \                    Mode:Master\n                    Extra:tsf=0000001e1f447431\n\
+      \                    Extra: Last beacon: 3315ms ago\n                    IE:\
+      \ Unknown: 000B0000000000000000000000\n                    IE: Unknown: 010882848B962430486C\n\
+      \                    IE: Unknown: 030101\n                    IE: Unknown: 050400030000\n\
+      \                    IE: Unknown: 0706444520010D14\n                    IE:\
+      \ Unknown: 200100\n                    IE: Unknown: 23021100\n             \
+      \       IE: Unknown: 2A0100\n                    IE: Unknown: 32040C121860\n\
+      \                    IE: IEEE 802.11i/WPA2 Version 1\n                     \
+      \   Group Cipher : CCMP\n                        Pairwise Ciphers (1) : CCMP\n\
+      \                        Authentication Suites (1) : PSK\n                 \
+      \   IE: Unknown: 0B050000780000\n                    IE: Unknown: 42020000\n\
+      \                    IE: Unknown: 2D1A2D0817FFFF000000000000000000000000000000000000000000\n\
+      \                    IE: Unknown: 3D1601081100000000000000000000000000000000000000\n\
+      \                    IE: Unknown: 7F080400080000000040\n                   \
+      \ IE: Unknown: DD090010180200101C0000\n                    IE: Unknown: DD180050F2020101000003A4000027A4000042435E0062322F00\n"
   nmcli connection show:
     output: "NAME                        UUID                                  TYPE\
       \      DEVICE \nWired connection 1          4c73e12a-1934-3ea9-96bc-b13580626d18\

--- a/simnos/plugins/nos/platforms_yaml/linux.yaml
+++ b/simnos/plugins/nos/platforms_yaml/linux.yaml
@@ -83,3 +83,663 @@ commands:
     prompt:
     - "{base_prompt}$"
     - "{base_prompt}#"
+  bluetoothctl show:
+    output: "Controller AA:AA:AA:AA:AA:AA (public)\n        Manufacturer: 0x005d (93)\n\
+      \        Version: 0x0a (10)\n        Name: ntc-AA-AAAA\n        Alias: ntc-AA-AAAA\n\
+      \        Class: 0x00000000 (0)\n        Powered: no\n        Discoverable: no\n\
+      \        DiscoverableTimeout: 0x000000b4 (180)\n        Pairable: yes\n    \
+      \    UUID: Message Notification Se.. (00001133-0000-1000-8000-00805f9b34fb)\n\
+      \        UUID: A/V Remote Control        (0000110e-0000-1000-8000-00805f9b34fb)\n\
+      \        UUID: OBEX Object Push          (00001105-0000-1000-8000-00805f9b34fb)\n\
+      \        UUID: Message Access Server     (00001132-0000-1000-8000-00805f9b34fb)\n\
+      \        UUID: PnP Information           (00001200-0000-1000-8000-00805f9b34fb)\n\
+      \        UUID: IrMC Sync                 (00001104-0000-1000-8000-00805f9b34fb)\n\
+      \        UUID: Vendor specific           (00005005-0000-1000-8000-0002ee000001)\n\
+      \        UUID: A/V Remote Control Target (0000110c-0000-1000-8000-00805f9b34fb)\n\
+      \        UUID: Generic Attribute Profile (00001801-0000-1000-8000-00805f9b34fb)\n\
+      \        UUID: Phonebook Access Server   (0000112f-0000-1000-8000-00805f9b34fb)\n\
+      \        UUID: Audio Sink                (0000110b-0000-1000-8000-00805f9b34fb)\n\
+      \        UUID: Device Information        (0000180a-0000-1000-8000-00805f9b34fb)\n\
+      \        UUID: Generic Access Profile    (00001800-0000-1000-8000-00805f9b34fb)\n\
+      \        UUID: Handsfree Audio Gateway   (0000111f-0000-1000-8000-00805f9b34fb)\n\
+      \        UUID: Audio Source              (0000110a-0000-1000-8000-00805f9b34fb)\n\
+      \        UUID: OBEX File Transfer        (00001106-0000-1000-8000-00805f9b34fb)\n\
+      \        UUID: Handsfree                 (0000111e-0000-1000-8000-00805f9b34fb)\n\
+      \        Modalias: usb:v1D6Bp0246d0548\n        Discovering: no\n        Roles:\
+      \ central\n        Roles: peripheral\nAdvertising Features:\n        ActiveInstances:\
+      \ 0x00 (0)\n        SupportedInstances: 0x04 (4)\n        SupportedIncludes:\
+      \ tx-power\n        SupportedIncludes: appearance\n        SupportedIncludes:\
+      \ local-name\n        SupportedSecondaryChannels: 1M\n        SupportedSecondaryChannels:\
+      \ 2M\n        SupportedSecondaryChannels: Coded\n"
+    help: execute the command "bluetoothctl show"
+    prompt: &id001
+      - '{base_prompt}$'
+      - '{base_prompt}#'
+    output_variants:
+      - "Controller AA:AA:AA:AA:AA:AA (public)\n        Manufacturer: 0x005d (93)\n\
+        \        Version: 0x0a (10)\n        Name: ntc-AA-AAAA\n        Alias: ntc-AA-AAAA\n\
+        \        Class: 0x007c0104 (8126724)\n        Powered: yes\n        Discoverable:\
+        \ yes\n        DiscoverableTimeout: 0x000000b4 (180)\n        Pairable: yes\n\
+        \        UUID: Message Notification Se.. (00001133-0000-1000-8000-00805f9b34fb)\n\
+        \        UUID: A/V Remote Control        (0000110e-0000-1000-8000-00805f9b34fb)\n\
+        \        UUID: OBEX Object Push          (00001105-0000-1000-8000-00805f9b34fb)\n\
+        \        UUID: Message Access Server     (00001132-0000-1000-8000-00805f9b34fb)\n\
+        \        UUID: PnP Information           (00001200-0000-1000-8000-00805f9b34fb)\n\
+        \        UUID: IrMC Sync                 (00001104-0000-1000-8000-00805f9b34fb)\n\
+        \        UUID: Vendor specific           (00005005-0000-1000-8000-0002ee000001)\n\
+        \        UUID: A/V Remote Control Target (0000110c-0000-1000-8000-00805f9b34fb)\n\
+        \        UUID: Generic Attribute Profile (00001801-0000-1000-8000-00805f9b34fb)\n\
+        \        UUID: Phonebook Access Server   (0000112f-0000-1000-8000-00805f9b34fb)\n\
+        \        UUID: Audio Sink                (0000110b-0000-1000-8000-00805f9b34fb)\n\
+        \        UUID: Device Information        (0000180a-0000-1000-8000-00805f9b34fb)\n\
+        \        UUID: Generic Access Profile    (00001800-0000-1000-8000-00805f9b34fb)\n\
+        \        UUID: Handsfree Audio Gateway   (0000111f-0000-1000-8000-00805f9b34fb)\n\
+        \        UUID: Audio Source              (0000110a-0000-1000-8000-00805f9b34fb)\n\
+        \        UUID: OBEX File Transfer        (00001106-0000-1000-8000-00805f9b34fb)\n\
+        \        UUID: Handsfree                 (0000111e-0000-1000-8000-00805f9b34fb)\n\
+        \        Modalias: usb:v1D6Bp0246d0548\n        Discovering: yes\n       \
+        \ Roles: central\n        Roles: peripheral\nAdvertising Features:\n     \
+        \   ActiveInstances: 0x00 (0)\n        SupportedInstances: 0x04 (4)\n    \
+        \    SupportedIncludes: tx-power\n        SupportedIncludes: appearance\n\
+        \        SupportedIncludes: local-name\n        SupportedSecondaryChannels:\
+        \ 1M\n        SupportedSecondaryChannels: 2M\n        SupportedSecondaryChannels:\
+        \ Coded"
+  dmidecode -t bios:
+    output: "# dmidecode 1.12\nSMBIOS 1.1 present.\n\nHandle 0x0000, DMI type 0, 24\
+      \ bytes\nBIOS Information\n\tVendor: Dell\n\tVersion: O11   \n\tRelease Date:\
+      \ 01/11/1011\n\tAddress: 0xA1110\n\tRuntime Size: 111111 bytes\n\tROM Size:\
+      \ 2048 kB\n\tCharacteristics:\n\t\tPCI is supported\n\t\tPNP is supported\n\t\
+      \tAPM is supported\n\t\tBIOS is upgradeable\n\t\tBIOS shadowing is allowed\n\
+      \t\tESCD support is available\n\t\tBoot from CD is supported\n\t\tSelectable\
+      \ boot is supported\n\t\tBIOS ROM is socketed\n\t\tEDD is supported\n\t\tPrint\
+      \ screen service is supported (int 5h)\n\t\t8042 keyboard services are supported\
+      \ (int 9h)\n\t\tSerial services are supported (int 14h)\n\t\tPrinter services\
+      \ are supported (int 17h)\n\t\tCGA/mono video services are supported (int 10h)\n\
+      \t\tACPI is supported\n\t\tUSB legacy is supported\n\t\tSmart battery is supported\n\
+      \t\t BIOS boot specification is supported\n\t\tFunction key-initiated network\
+      \ boot is supported\n\t\tTargeted content distribution is supported\n"
+    help: execute the command "dmidecode -t bios"
+    prompt: *id001
+  dmidecode -t memory:
+    output: "# dmidecode 1.11\nSMBIOS 1.1 present.\n\nHandle 0x001A, DMI type 11,\
+      \ 11 bytes\nPhysical Memory Array\n\tLocation: System Board Or Motherboard\n\
+      \t Use: System Memory\n\tError Correction Type: Multi-bit ECC\n\tMaximum Capacity:\
+      \ 16 GB\n\tError Information Handle: Not Provided\n\tNumber Of Devices: 4\n\n\
+      Handle 0x001A, DMI type 11, 11 bytes\nMemory Device\n\tArray Handle: 0x001A\n\
+      \tError Information Handle: No Error\n\tTotal Width: 10 bits\n\tData Width:\
+      \ 10 bits\n\tSize: 1111 MB\n\tForm Factor: DIMM\n\tSet: 1\n\tLocator: DIMM1A\n\
+      \tBank Locator: Not Specified\n\tType: DDR2\n\tType Detail: Synchronous\n\t\
+      Speed: 1111 MHz\n\tManufacturer: Not Specified\n\tSerial Number: Not Specified\n\
+      \tAsset Tag: Not Specified\n\tPart Number: Not Specified\n\tRank: Unknown\n\n\
+      Handle 0x001A, DMI type 11, 11 bytes\nMemory Device\n\tArray Handle: 0x001A\n\
+      \tError Information Handle: No Error\n\tTotal Width: Unknown\n\tData Width:\
+      \ Unknown\n\tSize: No Module Installed\n\tForm Factor: DIMM\n\tSet: 1\n\tLocator:\
+      \ DIMM1C\n\tBank Locator: Not Specified\n\tType: Reserved\n\tType Detail: Synchronous\n\
+      \tSpeed: Unknown\n\tManufacturer: Not Specified\n\tSerial Number: Not Specified\n\
+      \tAsset Tag: Not Specified\n\tPart Number: Not Specified\n\tRank: Unknown\n\n\
+      Handle 0x001A, DMI type 11, 11 bytes\nMemory Device\n\tArray Handle: 0x001A\n\
+      \tError Information Handle: No Error\n\tTotal Width: Unknown\n\tData Width:\
+      \ Unknown\n\tSize: No Module Installed\n\tForm Factor: DIMM\n\tSet: 1\n\tLocator:\
+      \ DIMM1B\n\tBank Locator: Not Specified\n\tType: Reserved\n\tType Detail: Synchronous\n\
+      \tSpeed: Unknown\n\tManufacturer: Not Specified\n\tSerial Number: Not Specified\n\
+      \tAsset Tag: Not Specified\n\tPart Number: Not Specified\n\tRank: Unknown\n\n\
+      Handle 0x001A, DMI type 11, 11 bytes\nMemory Device\n\tArray Handle: 0x001A\n\
+      \tError Information Handle: No Error\n\tTotal Width: Unknown\n\tData Width:\
+      \ Unknown\n\tSize: No Module Installed\n\tForm Factor: DIMM\n\tSet: 1\n\tLocator:\
+      \ DIMM1D\n\tBank Locator: Not Specified\n\tType: Reserved\n\tType Detail: Synchronous\n\
+      \tSpeed: Unknown\n\tManufacturer: Not Specified\n\tSerial Number: Not Specified\n\
+      \tAsset Tag: Not Specified\n\tPart Number: Not Specified\n\tRank: Unknown\n"
+    help: execute the command "dmidecode -t memory"
+    prompt: *id001
+  dmidecode -t processor:
+    output: "# dmidecode 1.1\nSMBIOS 1.1 present.\n\nHandle 0x0004, DMI type 4, 42\
+      \ bytes\nProcessor Information\n\tSocket Designation: CPU 1   \n\tType: Central\
+      \ Processor\n\tFamily: Core 2 Quad\n\tManufacturer: AMD\n\tID: AA AA AA AA AA\
+      \ AA AA AA\n\tSignature: Type 0, Family 1, Model 2, Stepping 3\n\tFlags:\n\t\
+      \t FPU (Floating-point unit on-chip)\n\t\tVME (Virtual mode extension)\n\t\t\
+      DE (Debugging extension)\n\t\tPSE (Page size extension)\n\t\tTSC (Time stamp\
+      \ counter)\n\t\tMSR (Model specific registers)\n\t\tPAE (Physical address extension)\n\
+      \t \tMCE (Machine check exception)\n\t\tCX8 (CMPXCHG8 instruction supported)\n\
+      \t \tAPIC (On-chip APIC hardware supported)\n\t\tSEP (Fast system call)\n\t\t\
+      MTRR (Memory type range registers)\n\t\tPGE (Page global enable)\n\t\tMCA (Machine\
+      \ check architecture)\n\t\tCMOV (Conditional move instruction supported)\n\t\
+      \t PAT (Page attribute table)\n\t\tPSE-36 (36-bit page size extension)\n\t\t\
+      CLFSH (CLFLUSH instruction supported)\n\t\tDS (Debug store)\n\t\tACPI (ACPI\
+      \ supported)\n\t\tMMX (MMX technology supported)\n\t\tFXSR (FXSAVE and FXSTOR\
+      \ instructions supported)\n\t\tSSE (Streaming SIMD extensions)\n\t\tSSE2 (Streaming\
+      \ SIMD extensions 2)\n\t\tSS (Self-snoop)\n\t\tHTT (Multi-threading)\n\t\tTM\
+      \ (Thermal monitor supported)\n\t\tPBE (Pending break enabled)\n\tVersion: Intel(R)\
+      \ AAAA(R) CPU           A1111  @ 1.10GHz\n\tVoltage: 1.2 V\n\tExternal Clock:\
+      \ 133 MHz\n\t Max Speed: 1100 MHz\n\tCurrent Speed: 1100 MHz\n\tStatus: Populated,\
+      \ Enabled\n\tUpgrade: Slot 1\n\tL1 Cache Handle: 0x0001\n\tL2 Cache Handle:\
+      \ 0x0002\n\tL3 Cache Handle: 0x0003\n\tSerial Number: Not Specified\n\tAsset\
+      \ Tag: Not Specified\n\tPart Number: Not Specified\n\tCore Count: 1\n\tCore\
+      \ Enabled: 1\n\tThread Count: 1\n\tCharacteristics:\n\t\t128-bit capable\n"
+    help: execute the command "dmidecode -t processor"
+    prompt: *id001
+  dmidecode -t system:
+    output: "# dmidecode 1.11\nSMBIOS 1.1 present.\n\nHandle 0x0001, DMI type 1, 11\
+      \ bytes\nSystem Information\n\tManufacturer: HP\n\tProduct Name: ProG4 Deepseek\
+      \ G6\n\tVersion:        \n\tSerial Number: AA111100AA\n\tUUID: 1111AA1A-AA1A-11A1-1AAA-A1111AAAA1AA\n\
+      \tWake-up Type: Power Switch\n\tSKU Number: 000000-000\n\tFamily: Not Specified\n\
+      \nHandle 0x0011, DMI type 12, 1 bytes\nSystem Configuration Options\n\tOption\
+      \ 1: Jumper settings can be described here.\n\nHandle 0x0011, DMI type 11, 11\
+      \ bytes\nSystem Event Log\n\tArea Length: 32 bytes\n\tHeader Start Offset: 0x0000\n\
+      \tHeader Length: 32 bytes\n\tData Start Offset: 0x0010\n\tAccess Method: General-purpose\
+      \ non-volatile data functions\n\tAccess Address: 0x0000\n\tStatus: Valid, Not\
+      \ Full\n\tChange Token: 0x0000001D\n\tHeader Format: Type 1\n\tSupported Log\
+      \ Type Descriptors: 3\n\tDescriptor 1: POST error\n\tData Format 1: POST results\
+      \ bitmap\n\tDescriptor 2: Single-bit ECC memory error\n\tData Format 2: Multiple-event\n\
+      \tDescriptor 3: Multi-bit ECC memory error\n\tData Format 3: Multiple-event\n\
+      \nHandle 0x001A, DMI type 23, 13 bytes\nSystem Reset\n\tStatus: Enabled\n\t\
+      Watchdog Timer: Present\n\tBoot Option: Do Not Reboot\n\tBoot Option On Limit:\
+      \ Do Not Reboot\n\tReset Count: Unknown\n\tReset Limit: Unknown\n\tTimer Interval:\
+      \ Unknown\n\tTimeout: Unknown\n\nHandle 0x001A, DMI type 32, 20 bytes\nSystem\
+      \ Boot Information\n\tStatus: No errors detected\n"
+    help: execute the command "dmidecode -t system"
+    prompt: *id001
+  iwconfig:
+    output: "lo        no wireless extensions.\n\neth0      no wireless extensions.\n\
+      \nwlan0     IEEE 802.11  ESSID:\"My_home\"  \n          Mode:Managed  Frequency:5.18\
+      \ GHz  Access Point: AA:AA:AA:AA:AA:AA   \n          Bit Rate=24 Mb/s   Tx-Power=31\
+      \ dBm   \n          Retry short limit:7   RTS thr:off   Fragment thr:off\n \
+      \         Encryption key:off\n          Power Management:on\n          Link\
+      \ Quality=56/70  Signal level=-54 dBm  \n          Rx invalid nwid:0  Rx invalid\
+      \ crypt:0  Rx invalid frag:0\n          Tx excessive retries:155  Invalid misc:0\
+      \   Missed beacon:0\n\nwlan1     IEEE 802.11  ESSID:off/any  \n          Mode:Managed\
+      \  Access Point: Not-Associated   Tx-Power=20 dBm   \n          Retry short\
+      \ limit:7   RTS thr:off   Fragment thr:off\n          Power Management:off\n\
+      \nwlan2     IEEE 802.11  ESSID:\"My_other_home\"  \n          Mode:Managed \
+      \ Frequency:5.22 GHz  Access Point: AA:AA:AA:AA:AA:AA   \n          Bit Rate=200\
+      \ Mb/s   Tx-Power=31 dBm   \n          Retry short limit:7   RTS thr:off   Fragment\
+      \ thr:off\n          Encryption key:off\n          Power Management:on\n   \
+      \       Link Quality=62/70  Signal level=-48 dBm  \n          Rx invalid nwid:0\
+      \  Rx invalid crypt:0  Rx invalid frag:0\n          Tx excessive retries:7 \
+      \ Invalid misc:0   Missed beacon:0\n\nwlan3     unassociated  Nickname:\"<WIFI@REALTEK>\"\
+      \n          Mode:Managed  Frequency=5.18 GHz  Access Point: Not-Associated \
+      \  \n          Sensitivity:0/0  \n          Retry:off   RTS thr:off   Fragment\
+      \ thr:off\n          Power Management:off\n          Link Quality:0  Signal\
+      \ level:0  Noise level:0\n          Rx invalid nwid:0  Rx invalid crypt:0  Rx\
+      \ invalid frag:0\n          Tx excessive retries:0  Invalid misc:0   Missed\
+      \ beacon:0\n        \nwlan4     IEEE 802.11AX  ESSID:\"My_home\"  Nickname:\"\
+      <WIFI@REALTEK>\"\n          Mode:Managed  Frequency:5.18 GHz  Access Point:\
+      \ AA:AA:AA:AA:AA:AA   \n          Bit Rate:574 Mb/s   Sensitivity:0/0  \n  \
+      \        Retry:off   RTS thr:off   Fragment thr:off\n          Power Management:off\n\
+      \          Link Quality=58/100  Signal level=58/100  Noise level=0/100\n   \
+      \       Rx invalid nwid:0  Rx invalid crypt:0  Rx invalid frag:0\n         \
+      \ Tx excessive retries:0  Invalid misc:0   Missed beacon:0\n\nwlan5     IEEE\
+      \ 802.11bgn  ESSID:\"HS\"  Nickname:\"<WIFI@REALTEK>\"\n          Mode:Managed\
+      \  Frequency:2.452 GHz  Access Point: AA:AA:AA:AA:AA:AA   \n          Bit Rate:300\
+      \ Mb/s   Sensitivity:0/0  \n          Retry:off   RTS thr:off   Fragment thr:off\n\
+      \          Power Management:off\n          Link Quality=60/100  Signal level=60/100\
+      \  Noise level=0/100\n          Rx invalid nwid:0  Rx invalid crypt:0  Rx invalid\
+      \ frag:0\n          Tx excessive retries:0  Invalid misc:0   Missed beacon:0\n\
+      \nwlan6    IEEE 802.11  ESSID:\"HS\"  \n          Mode:Managed  Frequency:2.452\
+      \ GHz  Access Point: AA:AA:AA:AA:AA:AA   \n          Bit Rate=72.2 Mb/s   Tx-Power=31\
+      \ dBm   \n          Retry short limit:7   RTS thr:off   Fragment thr:off\n \
+      \         Power Management:on\n          Link Quality=62/70  Signal level=-48\
+      \ dBm  \n          Rx invalid nwid:0  Rx invalid crypt:0  Rx invalid frag:0\n\
+      \          Tx excessive retries:4  Invalid misc:0   Missed beacon:0\n"
+    help: execute the command "iwconfig"
+    prompt: *id001
+    output_variants:
+      - "lo        no wireless extensions.\n\neth0      no wireless extensions.\n\n\
+        wlan0     IEEE 802.11  ESSID:off/any  \n          Mode:Managed  Access Point:\
+        \ Not-Associated   \n          Retry short limit:7   RTS thr:off   Fragment\
+        \ thr:off\n          Power Management:on\n          \nwlan1     IEEE 802.11\
+        \  Mode:Monitor  Frequency:5.805 GHz  Tx-Power=13 dBm   \n          Retry\
+        \ short limit:7   RTS thr:off   Fragment thr:off\n          Power Management:off"
+  iwlist wlan0 scanning:
+    output: "wlan1     Scan completed :\n          Cell 01 - Address: AA:AA:AA:AA:AA:AA\n\
+      \                    ESSID:\"\"\n                    Protocol:IEEE 802.11bgn\n\
+      \                    Mode:Master\n                    Frequency:2.422 GHz (Channel\
+      \ 3)\n                    Encryption key:on\n                    Bit Rates:780\
+      \ Mb/s\n                    Extra:rsn_ie=30140100000fac040100000fac040100000fac020000\n\
+      \                    IE: IEEE 802.11i/WPA2 Version 1\n                     \
+      \   Group Cipher : CCMP\n                        Pairwise Ciphers (1) : CCMP\n\
+      \                        Authentication Suites (1) : PSK\n                 \
+      \   Quality=0/100  Signal level=57/100  \n                    Extra:fm=0002\n\
+      \          Cell 03 - Address: AA:AA:AA:AA:AA:AA\n                    ESSID:\"\
+      Awdin\"\n                    Protocol:IEEE 802.11bgn\n                    Mode:Master\n\
+      \                    Frequency:2.422 GHz (Channel 3)\n                    Encryption\
+      \ key:on\n                    Bit Rates:780 Mb/s\n                    Extra:rsn_ie=30140100000fac040100000fac040100000fac020000\n\
+      \                    IE: IEEE 802.11i/WPA2 Version 1\n                     \
+      \   Group Cipher : CCMP\n                        Pairwise Ciphers (1) : CCMP\n\
+      \                        Authentication Suites (1) : PSK\n                 \
+      \   IE: Unknown: DD9F0050F204104A0001101044000102103B00010310470010BC329E001DD811B286010000000000011021001852616C696E6B20546563686E6F6C6F67792C20436F72702E1023001C52616C696E6B20576972656C6573732041636365737320506F696E74102400065254323836301042000831323334353637381054000800060050F20400011011000B52616C696E6B4150535F3010080002008C103C000101\n\
+      \                    Quality=36/100  Signal level=56/100  \n               \
+      \     Extra:fm=0003\n          Cell 05 - Address: AA:AA:AA:AA:AA:AA\n      \
+      \              ESSID:\"HS\"\n                    Protocol:IEEE 802.11bgn\n \
+      \                   Mode:Master\n                    Frequency:2.452 GHz (Channel\
+      \ 9)\n                    Encryption key:off\n                    Bit Rates:300\
+      \ Mb/s\n                    Quality=59/100  Signal level=59/100  \n        \
+      \            Extra:fm=0003\n          Cell 07 - Address: AA:AA:AA:AA:AA:AA\n\
+      \                    ESSID:\"Some-SSID2\"\n                    Protocol:IEEE\
+      \ 802.11gn\n                    Mode:Master\n                    Frequency:2.462\
+      \ GHz (Channel 11)\n                    Encryption key:on\n                \
+      \    Bit Rates:1.17 Gb/s\n                    Extra:rsn_ie=30140100000fac040100000fac040100000fac020000\n\
+      \                    IE: IEEE 802.11i/WPA2 Version 1\n                     \
+      \   Group Cipher : CCMP\n                        Pairwise Ciphers (1) : CCMP\n\
+      \                        Authentication Suites (1) : PSK\n                 \
+      \   Quality=20/100  Signal level=72/100  \n                    Extra:fm=0003\n\
+      \          Cell 49 - Address: AA:AA:AA:AA:AA:AA\n                    ESSID:\"\
+      Some-SSID\"\n                    Protocol:IEEE 802.11AC\n                  \
+      \  Mode:Master\n                    Frequency:5.805 GHz\n                  \
+      \  Encryption key:on\n                    Bit Rates:867 Mb/s\n             \
+      \       Extra:rsn_ie=30160100000fac040100000fac040100000fac023c000000\n    \
+      \                IE: IEEE 802.11i/WPA2 Version 1\n                        Group\
+      \ Cipher : CCMP\n                        Pairwise Ciphers (1) : CCMP\n     \
+      \                   Authentication Suites (1) : PSK\n                    IE:\
+      \ Unknown: DD5C0050F204104A00011010440001021049000600372A0001201054000800070050F20000001011000A53595332312D303033341049002600013720010001072002000A53595332312D303033342005000C3137322E32302E322E323032\n\
+      \                    Quality=0/100  Signal level=38/100  \n                \
+      \    Extra:fm=0002\n\n"
+    help: execute the command "iwlist wlan0 scanning"
+    prompt: *id001
+    output_variants:
+      - "wlx6245b4e66e1a  Scan completed :\n          Cell 01 - Address: AA:AA:AA:AA:AA:AA\n\
+        \                    Channel:1\n                    Frequency:2.412 GHz (Channel\
+        \ 1)\n                    Quality=23/70  Signal level=-87 dBm  \n        \
+        \            Encryption key:on\n                    ESSID:\"MOVISTAR_9880\"\
+        \n                    Bit Rates:1 Mb/s; 2 Mb/s; 5.5 Mb/s; 11 Mb/s; 9 Mb/s\n\
+        \                              18 Mb/s; 36 Mb/s; 54 Mb/s\n               \
+        \     Bit Rates:6 Mb/s; 12 Mb/s; 24 Mb/s; 48 Mb/s\n                    Mode:Master\n\
+        \                    Extra:tsf=0000005ca9827456\n                    Extra:\
+        \ Last beacon: 69ms ago\n                    IE: Unknown: 000D4D4F5649535441525F39383830\n\
+        \                    IE: Unknown: 010882848B961224486C\n                 \
+        \   IE: Unknown: 030101\n                    IE: Unknown: 2A0100\n       \
+        \             IE: Unknown: 32040C183060\n                    IE: Unknown:\
+        \ 2D1AAC0117FFFF000000000000000000000000000000000000000000\n             \
+        \       IE: Unknown: 3D1601000700000000000000000000000000000000000000\n  \
+        \                  IE: IEEE 802.11i/WPA2 Version 1\n                     \
+        \   Group Cipher : CCMP\n                        Pairwise Ciphers (1) : CCMP\n\
+        \                        Authentication Suites (1) : PSK\n               \
+        \     IE: Unknown: 7F080100080000000000\n                    IE: Unknown:\
+        \ DD180050F2020101000003A4000027A4000042435E0062322F00\n                 \
+        \   IE: Unknown: 23021300\n                    IE: Unknown: 4605F3C0010004\n\
+        \                    IE: Unknown: 7F080000000100000000\n                 \
+        \   IE: Unknown: 0706455320010D10\n                    IE: Unknown: DD8A0050F204104A0001101044000102103B00010310470010BC329E001DD811B28601CCEDDCB29880102100094D6974726153746172102300154D697472615374617220576972656C657373204150102400065254353339321042000831323334353637381054000800060050F20400011011000C4750542D32373431474E414310080002008C103C000101\n\
+        \                    IE: Unknown: DD07000C4300000000\n          Cell 02 -\
+        \ Address: AA:AA:AA:AA:AA:AA\n                    Channel:2\n            \
+        \        Frequency:2.417 GHz (Channel 2)\n                    Quality=27/70\
+        \  Signal level=-83 dBm  \n                    Encryption key:on\n       \
+        \             ESSID:\"WIFI_INVITADOS\"\n                    Bit Rates:1 Mb/s;\
+        \ 2 Mb/s; 5.5 Mb/s; 11 Mb/s; 18 Mb/s\n                              24 Mb/s;\
+        \ 36 Mb/s; 54 Mb/s\n                    Bit Rates:6 Mb/s; 9 Mb/s; 12 Mb/s;\
+        \ 48 Mb/s\n                    Mode:Master\n                    Extra:tsf=00000000a371bb16\n\
+        \                    Extra: Last beacon: 53ms ago\n                    IE:\
+        \ Unknown: 000E574946495F494E56495441444F53\n                    IE: Unknown:\
+        \ 010882848B962430486C\n                    IE: Unknown: 030102\n        \
+        \            IE: Unknown: 2A0100\n                    IE: Unknown: 2F0100\n\
+        \                    IE: IEEE 802.11i/WPA2 Version 1\n                   \
+        \     Group Cipher : CCMP\n                        Pairwise Ciphers (1) :\
+        \ CCMP\n                        Authentication Suites (1) : PSK\n        \
+        \            IE: Unknown: 32040C121860\n                    IE: Unknown: 2D1AAC181BFFFF000000000000000000000000000000000000000000\n\
+        \                    IE: Unknown: 3D1602000000000000000000000000000000000000000000\n\
+        \                    IE: Unknown: 7F080000000000000040\n                 \
+        \   IE: Unknown: DD1000E0FC80000000230000000000000000\n                  \
+        \  IE: Unknown: DD090010180200000C0000\n                    IE: WPA Version\
+        \ 1\n                        Group Cipher : CCMP\n                       \
+        \ Pairwise Ciphers (1) : CCMP\n                        Authentication Suites\
+        \ (1) : PSK\n                    IE: Unknown: DD180050F2020101800003A4000027A4000042435E0062322F00\n\
+        \          Cell 03 - Address: AA:AA:AA:AA:AA:AA\n                    Channel:3\n\
+        \                    Frequency:2.422 GHz (Channel 3)\n                   \
+        \ Quality=58/70  Signal level=-52 dBm  \n                    Encryption key:on\n\
+        \                    ESSID:\"qwdnqwod\"\n                    Bit Rates:1 Mb/s;\
+        \ 2 Mb/s; 5.5 Mb/s; 11 Mb/s; 9 Mb/s\n                              18 Mb/s;\
+        \ 36 Mb/s; 54 Mb/s\n                    Bit Rates:6 Mb/s; 12 Mb/s; 24 Mb/s;\
+        \ 48 Mb/s\n                    Mode:Master\n                    Extra:tsf=0000004dff6e359e\n\
+        \                    Extra: Last beacon: 7187ms ago\n                    IE:\
+        \ Unknown: 0004575F3130\n                    IE: Unknown: 010802040B161224486C\n\
+        \                    IE: Unknown: 030103\n                    IE: Unknown:\
+        \ 2A0104\n                    IE: Unknown: 32040C183060\n                \
+        \    IE: IEEE 802.11i/WPA2 Version 1\n                        Group Cipher\
+        \ : CCMP\n                        Pairwise Ciphers (1) : CCMP\n          \
+        \              Authentication Suites (1) : PSK\n                    IE: Unknown:\
+        \ 2D1AEF1913FFFF000001000000000000000000000000001804870900\n             \
+        \       IE: Unknown: 3D1603050600000000000000000000000000000000000000\n  \
+        \                  IE: Unknown: 4A0E14000A002C01C800140005001900\n       \
+        \             IE: Unknown: 7F080100088000000000\n                    IE: Unknown:\
+        \ 0B0502000E127A\n                    IE: Unknown: 6B09000008000000000000\n\
+        \                    IE: Unknown: 6C027F00\n                    IE: Unknown:\
+        \ DD180050F2020101800003A4000027A4000042435E0062322F00\n                 \
+        \   IE: Unknown: 46050200010000\n                    IE: Unknown: 330A53010203040506070809\n\
+        \                    IE: Unknown: 200100\n                    IE: Unknown:\
+        \ 23020E00\n                    IE: Unknown: 0706465204010914\n          \
+        \          IE: Unknown: BF0C9279C933FAFF6801FAFF6821\n                   \
+        \ IE: Unknown: C005000300FCFF\n                    IE: Unknown: DD07000C430B000000\n\
+        \                    IE: Unknown: DD21000CE708000000BF0CB101C0332AFF92042AFF9204C0050000002AFFC303010202\n\
+        \                    IE: Unknown: DD0A000CE701000000010101\n             \
+        \       IE: Unknown: DD31F832E401010102010003148FEFB4475CECF8E59D66C942A0C3C0DD4438383707045AED3B981204ECEC0000130101150100\n\
+        \                    IE: Unknown: F0020000\n          Cell 04 - Address: AA:AA:AA:AA:AA:AA\n\
+        \                    Channel:1\n                    Frequency:2.412 GHz (Channel\
+        \ 1)\n                    Quality=26/70  Signal level=-84 dBm  \n        \
+        \            Encryption key:on\n                    ESSID:\"qwdoinqwdoqwn\"\
+        \n                    Bit Rates:1 Mb/s; 2 Mb/s; 5.5 Mb/s; 11 Mb/s; 18 Mb/s\n\
+        \                              24 Mb/s; 36 Mb/s; 54 Mb/s\n               \
+        \     Bit Rates:6 Mb/s; 9 Mb/s; 12 Mb/s; 48 Mb/s\n                    Mode:Master\n\
+        \                    Extra:tsf=00000028ed34ed13\n                    Extra:\
+        \ Last beacon: 1792ms ago\n                    IE: Unknown: 000C766F6461666F6E6536353732\n\
+        \                    IE: Unknown: 010882848B962430486C\n                 \
+        \   IE: Unknown: 030101\n                    IE: Unknown: 0706444520010D14\n\
+        \                    IE: Unknown: 200100\n                    IE: Unknown:\
+        \ 23021000\n                    IE: Unknown: 2A0100\n                    IE:\
+        \ Unknown: 32040C121860\n                    IE: IEEE 802.11i/WPA2 Version\
+        \ 1\n                        Group Cipher : TKIP\n                       \
+        \ Pairwise Ciphers (2) : CCMP TKIP\n                        Authentication\
+        \ Suites (1) : PSK\n                    IE: Unknown: 0B050000410000\n    \
+        \                IE: Unknown: 46057208010000\n                    IE: Unknown:\
+        \ 2D1ABC091BFFFF000000000000000000000000000000000000000000\n             \
+        \       IE: Unknown: 3D1601080000000000000000000000000000000000000000\n  \
+        \                  IE: Unknown: 7F080400080000000040\n                   \
+        \ IE: Unknown: DD860050F204104A0001101044000102103B00010310470010F81E0F40661DC8946500EB584A1693981021000842726F6164636F6D1023000842726F6164636F6D1024000631323334353610420007303030303030311054000800060050F20400011011000D546563686E69636F6C6F724150100800022008103C0001031049000600372A000120\n\
+        \                    IE: Unknown: DD090010180200000C0000\n               \
+        \     IE: WPA Version 1\n                        Group Cipher : TKIP\n   \
+        \                     Pairwise Ciphers (2) : CCMP TKIP\n                 \
+        \       Authentication Suites (1) : PSK\n                    IE: Unknown:\
+        \ DD180050F2020101880003A4000027A4000042435E0062322F00\n          Cell 05\
+        \ - Address: AA:AA:AA:AA:AA:AA\n                    Channel:1\n          \
+        \          Frequency:2.412 GHz (Channel 1)\n                    Quality=20/70\
+        \  Signal level=-90 dBm  \n                    Encryption key:on\n       \
+        \             ESSID:\"WDNIOWN\"\n                    Bit Rates:1 Mb/s; 2 Mb/s;\
+        \ 5.5 Mb/s; 11 Mb/s; 18 Mb/s\n                              24 Mb/s; 36 Mb/s;\
+        \ 54 Mb/s\n                    Bit Rates:6 Mb/s; 9 Mb/s; 12 Mb/s; 48 Mb/s\n\
+        \                    Mode:Master\n                    Extra:tsf=0000000dada2ddd0\n\
+        \                    Extra: Last beacon: 8923ms ago\n                    IE:\
+        \ Unknown: 0008576966696A617669\n                    IE: Unknown: 010882848B962430486C\n\
+        \                    IE: Unknown: 030101\n                    IE: Unknown:\
+        \ 050400010000\n                    IE: Unknown: 0706444520010D14\n      \
+        \              IE: Unknown: 200100\n                    IE: Unknown: 23020F00\n\
+        \                    IE: Unknown: 2A0104\n                    IE: Unknown:\
+        \ 32040C121860\n                    IE: IEEE 802.11i/WPA2 Version 1\n    \
+        \                    Group Cipher : TKIP\n                        Pairwise\
+        \ Ciphers (2) : CCMP TKIP\n                        Authentication Suites (1)\
+        \ : PSK\n                    IE: Unknown: 0B050600740000\n               \
+        \     IE: Unknown: 46057208010000\n                    IE: Unknown: 2D1AAD0917FFFFFF0000000000000000000000000000000000000000\n\
+        \                    IE: Unknown: 3D1601081500000000000000000000000000000000000000\n\
+        \                    IE: Unknown: 4A0E14000A002C01C800140005001900\n     \
+        \               IE: Unknown: 7F080500080000000040\n                    IE:\
+        \ Unknown: DD310050F204104A0001101044000102104700101E8FB990104475971B7B59198FB3BEC1103C0001031049000600372A000120\n\
+        \                    IE: Unknown: DD1E00904C0408BF0CB251820FEAFF0000EAFF0000C0050001000000C3020002\n\
+        \                    IE: Unknown: DD090010180206001C0000\n               \
+        \     IE: WPA Version 1\n                        Group Cipher : TKIP\n   \
+        \                     Pairwise Ciphers (2) : CCMP TKIP\n                 \
+        \       Authentication Suites (1) : PSK\n                    IE: Unknown:\
+        \ DD180050F2020101840003A4000027A4000042435E0062322F00\n\nwlan0  Scan completed\
+        \ :\n        Cell 01 - Address: AA:AA:AA:AA:AA:AA\n                    Channel:1\n\
+        \                    Frequency:2.412 GHz (Channel 1)\n                   \
+        \ Quality=19/70  Signal level=-91 dBm  \n                    Encryption key:on\n\
+        \                    ESSID:\"Wifi\"\n                    Bit Rates:1 Mb/s;\
+        \ 2 Mb/s; 5.5 Mb/s; 11 Mb/s; 18 Mb/s\n                            24 Mb/s;\
+        \ 36 Mb/s; 54 Mb/s\n                    Bit Rates:6 Mb/s; 9 Mb/s; 12 Mb/s;\
+        \ 48 Mb/s\n                    Mode:Master\n                    Extra:tsf=000000012bd8ea64\n\
+        \                    Extra: Last beacon: 35ms ago\n                    IE:\
+        \ Unknown: 0008576966696A617669\n                    IE: Unknown: 010882848B962430486C\n\
+        \                    IE: Unknown: 030101\n                    IE: Unknown:\
+        \ 0706444520010D14\n                    IE: Unknown: 200100\n            \
+        \        IE: Unknown: 23020F00\n                    IE: Unknown: 2A0104\n\
+        \                    IE: Unknown: 32040C121860\n                    IE: IEEE\
+        \ 802.11i/WPA2 Version 1\n                        Group Cipher : TKIP\n  \
+        \                      Pairwise Ciphers (2) : CCMP TKIP\n                \
+        \        Authentication Suites (1) : PSK\n                    IE: Unknown:\
+        \ 0B050600560000\n                    IE: Unknown: 46057208010000\n      \
+        \              IE: Unknown: 2D1AAD0917FFFFFF0000000000000000000000000000000000000000\n\
+        \                    IE: Unknown: 3D1601081500000000000000000000000000000000000000\n\
+        \                    IE: Unknown: 4A0E14000A002C01C800140005001900\n     \
+        \               IE: Unknown: 7F080500080000000040\n                    IE:\
+        \ Unknown: DD830050F204104A0001101044000102103B000103104700101E8FB990104475971B7B59198FB3BEC110210008536167656D636F6D10230008536167656D636F6D1024000631323334353610420007303030303030311054000800060050F20400011011000A536167656D636F6D4150100800022008103C0001031049000600372A000120\n\
+        \                    IE: Unknown: DD1E00904C0408BF0CB251820FEAFF0000EAFF0000C0050001000000C3020002\n\
+        \                    IE: Unknown: DD090010180206001C0000\n               \
+        \     IE: WPA Version 1\n                        Group Cipher : TKIP\n   \
+        \                     Pairwise Ciphers (2) : CCMP TKIP\n                 \
+        \       Authentication Suites (1) : PSK\n                    IE: Unknown:\
+        \ DD180050F2020101840003A4000027A4000042435E0062322F00\n        Cell 02 -\
+        \ Address: AA:AA:AA:AA:AA:AA\n                    Channel:1\n            \
+        \        Frequency:2.412 GHz (Channel 1)\n                    Quality=22/70\
+        \  Signal level=-88 dBm  \n                    Encryption key:on\n       \
+        \             ESSID:\"HECTOR\"\n                    Bit Rates:1 Mb/s; 2 Mb/s;\
+        \ 5.5 Mb/s; 11 Mb/s; 18 Mb/s\n                            24 Mb/s; 36 Mb/s;\
+        \ 54 Mb/s\n                    Bit Rates:6 Mb/s; 9 Mb/s; 12 Mb/s; 48 Mb/s\n\
+        \                    Mode:Master\n                    Extra:tsf=0000001e1f01376e\n\
+        \                    Extra: Last beacon: 7721ms ago\n                    IE:\
+        \ Unknown: 0006484543544F52\n                    IE: Unknown: 010882848B962430486C\n\
+        \                    IE: Unknown: 030101\n                    IE: Unknown:\
+        \ 050401030000\n                    IE: Unknown: 0706444520010D14\n      \
+        \              IE: Unknown: 200100\n                    IE: Unknown: 23021100\n\
+        \                    IE: Unknown: 2A0100\n                    IE: Unknown:\
+        \ 32040C121860\n                    IE: IEEE 802.11i/WPA2 Version 1\n    \
+        \                    Group Cipher : CCMP\n                        Pairwise\
+        \ Ciphers (1) : CCMP\n                        Authentication Suites (1) :\
+        \ PSK\n                    IE: Unknown: 0B050000590000\n                 \
+        \   IE: Unknown: 42020000\n                    IE: Unknown: 46050100000000\n\
+        \                    IE: Unknown: 2D1A2D0817FFFF000000000000000000000000000000000000000000\n\
+        \                    IE: Unknown: 3D1601081100000000000000000000000000000000000000\n\
+        \                    IE: Unknown: 7F080400080000000040\n                 \
+        \   IE: Unknown: DD350050F204104A000110104400010210470010D96C7EFC2F8938F1EFBD6E5148BFA812103C0001031049000A00372A00012005020284\n\
+        \                    IE: Unknown: DD090010180200101C0000\n               \
+        \     IE: Unknown: DD180050F2020101800003A4000027A4000042435E0062322F00\n\
+        \        Cell 03 - Address: AA:AA:AA:AA:AA:AA\n                    Channel:1\n\
+        \                    Frequency:2.412 GHz (Channel 1)\n                   \
+        \ Quality=25/70  Signal level=-85 dBm  \n                    Encryption key:on\n\
+        \                    ESSID:\"vodafone6572\"\n                    Bit Rates:1\
+        \ Mb/s; 2 Mb/s; 5.5 Mb/s; 11 Mb/s; 18 Mb/s\n                            24\
+        \ Mb/s; 36 Mb/s; 54 Mb/s\n                    Bit Rates:6 Mb/s; 9 Mb/s; 12\
+        \ Mb/s; 48 Mb/s\n                    Mode:Master\n                    Extra:tsf=0000003b1ff71990\n\
+        \                    Extra: Last beacon: 381ms ago\n                    IE:\
+        \ Unknown: 000C766F6461666F6E6536353732\n                    IE: Unknown:\
+        \ 010882848B962430486C\n                    IE: Unknown: 030101\n        \
+        \            IE: Unknown: 0706444520010D14\n                    IE: Unknown:\
+        \ 200100\n                    IE: Unknown: 23021000\n                    IE:\
+        \ Unknown: 2A0100\n                    IE: Unknown: 32040C121860\n       \
+        \             IE: IEEE 802.11i/WPA2 Version 1\n                        Group\
+        \ Cipher : TKIP\n                        Pairwise Ciphers (2) : CCMP TKIP\n\
+        \                        Authentication Suites (1) : PSK\n               \
+        \     IE: Unknown: 0B0501002B0000\n                    IE: Unknown: 46057208010000\n\
+        \                    IE: Unknown: 2D1ABC091BFFFF000000000000000000000000000000000000000000\n\
+        \                    IE: Unknown: 3D1601080400000000000000000000000000000000000000\n\
+        \                    IE: Unknown: 7F080400080000000040\n                 \
+        \   IE: Unknown: DD860050F204104A0001101044000102103B00010310470010F81E0F40661DC8946500EB584A1693981021000842726F6164636F6D1023000842726F6164636F6D1024000631323334353610420007303030303030311054000800060050F20400011011000D546563686E69636F6C6F724150100800022008103C0001031049000600372A000120\n\
+        \                    IE: Unknown: DD090010180201000C0000\n               \
+        \     IE: WPA Version 1\n                        Group Cipher : TKIP\n   \
+        \                     Pairwise Ciphers (2) : CCMP TKIP\n                 \
+        \       Authentication Suites (1) : PSK\n                    IE: Unknown:\
+        \ DD180050F2020101880003A4000027A4000042435E0062322F00\n        Cell 04 -\
+        \ Address: AA:AA:AA:AA:AA:AA\n                    Channel:1\n            \
+        \        Frequency:2.412 GHz (Channel 1)\n                    Quality=21/70\
+        \  Signal level=-89 dBm  \n                    Encryption key:on\n       \
+        \             ESSID:\"\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\"\
+        \n                    Bit Rates:1 Mb/s; 2 Mb/s; 5.5 Mb/s; 11 Mb/s; 18 Mb/s\n\
+        \                            24 Mb/s; 36 Mb/s; 54 Mb/s\n                 \
+        \   Bit Rates:6 Mb/s; 9 Mb/s; 12 Mb/s; 48 Mb/s\n                    Mode:Master\n\
+        \                    Extra:tsf=0000001e1f45fb42\n                    Extra:\
+        \ Last beacon: 3215ms ago\n                    IE: Unknown: 000A00000000000000000000\n\
+        \                    IE: Unknown: 010882848B962430486C\n                 \
+        \   IE: Unknown: 030101\n                    IE: Unknown: 050402030000\n \
+        \                   IE: Unknown: 0706444520010D14\n                    IE:\
+        \ Unknown: 200100\n                    IE: Unknown: 23021100\n           \
+        \         IE: Unknown: 2A0100\n                    IE: Unknown: 32040C121860\n\
+        \                    IE: IEEE 802.11i/WPA2 Version 1\n                   \
+        \     Group Cipher : CCMP\n                        Pairwise Ciphers (1) :\
+        \ CCMP\n                        Authentication Suites (1) : PSK\n        \
+        \            IE: Unknown: 0B050000780000\n                    IE: Unknown:\
+        \ 42020000\n                    IE: Unknown: 2D1A2D0817FFFF000000000000000000000000000000000000000000\n\
+        \                    IE: Unknown: 3D1601081100000000000000000000000000000000000000\n\
+        \                    IE: Unknown: 7F080400080000000040\n                 \
+        \   IE: Unknown: DD090010180200101C0000\n                    IE: Unknown:\
+        \ DD180050F2020101800003A4000027A4000042435E0062322F00\n        Cell 05 -\
+        \ Address: BB:BB:BB:BB:BB:BB\n                    Channel:1\n            \
+        \        Frequency:2.412 GHz (Channel 1)\n                    Quality=24/70\
+        \  Signal level=-86 dBm  \n                    Encryption key:on\n       \
+        \             ESSID:\"Vodafone-000A\"\n                    Bit Rates:1 Mb/s;\
+        \ 2 Mb/s; 5.5 Mb/s; 11 Mb/s; 18 Mb/s\n                            24 Mb/s;\
+        \ 36 Mb/s; 54 Mb/s\n                    Bit Rates:6 Mb/s; 9 Mb/s; 12 Mb/s;\
+        \ 48 Mb/s\n                    Mode:Master\n                    Extra:tsf=00000178fac80ae7\n\
+        \                    Extra: Last beacon: 667ms ago\n                    IE:\
+        \ Unknown: 000D566F6461666F6E652D37423034\n                    IE: Unknown:\
+        \ 010882848B962430486C\n                    IE: Unknown: 030101\n        \
+        \            IE: Unknown: 050400010000\n                    IE: Unknown: 23021200\n\
+        \                    IE: Unknown: 2A0104\n                    IE: Unknown:\
+        \ 32040C121860\n                    IE: IEEE 802.11i/WPA2 Version 1\n    \
+        \                    Group Cipher : CCMP\n                        Pairwise\
+        \ Ciphers (1) : CCMP\n                        Authentication Suites (1) :\
+        \ PSK\n                    IE: Unknown: 0B050000390000\n                 \
+        \   IE: Unknown: 46053000000000\n                    IE: Unknown: 2D1AE31117FFFFFFFF00000000000000000000000000000000000000\n\
+        \                    IE: Unknown: 3D1601081100000000000000000000000000000000000000\n\
+        \                    IE: Unknown: 4A0E14000A002C01C800140005001900\n     \
+        \               IE: Unknown: 7F0A05000880010000C00140\n                  \
+        \  IE: Unknown: FF2323050008120010222002C00F438518000C00AAFFAAFF7B1CC7711CC7711CC7711CC771\n\
+        \                    IE: Unknown: FF0724F43F0013FCFF\n                   \
+        \ IE: Unknown: FF0E260C00A40820A408404308603208\n                    IE: Unknown:\
+        \ DD1D0050F204104A0001101044000102103C0001031049000600372A000120\n       \
+        \             IE: Unknown: DD1E00904C0418BF0CB1798B0FAAFF0000AAFF0000C0050001000000C3020027\n\
+        \                    IE: Unknown: DD0A0010180200001C000001\n             \
+        \       IE: Unknown: DD180050F20201018C0003A4000027A4000042435E0062322F00\n\
+        \                    IE: Unknown: 6C027F00\n        Cell 06 - Address: BB:BB:BB:BB:BB:BB\n\
+        \                    Channel:1\n                    Frequency:2.412 GHz (Channel\
+        \ 1)\n                    Quality=21/70  Signal level=-89 dBm  \n        \
+        \            Encryption key:on\n                    ESSID:\"\\x00\\x00\\x00\\\
+        x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\"\n                    Bit Rates:1\
+        \ Mb/s; 2 Mb/s; 5.5 Mb/s; 11 Mb/s; 18 Mb/s\n                            24\
+        \ Mb/s; 36 Mb/s; 54 Mb/s\n                    Bit Rates:6 Mb/s; 9 Mb/s; 12\
+        \ Mb/s; 48 Mb/s\n                    Mode:Master\n                    Extra:tsf=0000001e1f447431\n\
+        \                    Extra: Last beacon: 3315ms ago\n                    IE:\
+        \ Unknown: 000B0000000000000000000000\n                    IE: Unknown: 010882848B962430486C\n\
+        \                    IE: Unknown: 030101\n                    IE: Unknown:\
+        \ 050400030000\n                    IE: Unknown: 0706444520010D14\n      \
+        \              IE: Unknown: 200100\n                    IE: Unknown: 23021100\n\
+        \                    IE: Unknown: 2A0100\n                    IE: Unknown:\
+        \ 32040C121860\n                    IE: IEEE 802.11i/WPA2 Version 1\n    \
+        \                    Group Cipher : CCMP\n                        Pairwise\
+        \ Ciphers (1) : CCMP\n                        Authentication Suites (1) :\
+        \ PSK\n                    IE: Unknown: 0B050000780000\n                 \
+        \   IE: Unknown: 42020000\n                    IE: Unknown: 2D1A2D0817FFFF000000000000000000000000000000000000000000\n\
+        \                    IE: Unknown: 3D1601081100000000000000000000000000000000000000\n\
+        \                    IE: Unknown: 7F080400080000000040\n                 \
+        \   IE: Unknown: DD090010180200101C0000\n                    IE: Unknown:\
+        \ DD180050F2020101000003A4000027A4000042435E0062322F00\n"
+  nmcli connection show:
+    output: "NAME                        UUID                                  TYPE\
+      \      DEVICE \nWired connection 1          4c73e12a-1934-3ea9-96bc-b13580626d18\
+      \  ethernet  eth0   \nlo                          8fa1d0f5-729e-47d6-b791-ba82a1ecff0c\
+      \  loopback  lo     \nMy_other_home               a48f5437-163b-4fb0-983f-c98d0fa117c6\
+      \  wifi      wlan0  \nMy_home                     2c794a07-a61d-4276-bc16-c90459cb17ab\
+      \  wifi      --  \n"
+    help: execute the command "nmcli connection show"
+    prompt: *id001
+  pct config 1:
+    output: '
+
+      arch: amd11
+
+      cores: 1111
+
+      cpulimit: 1
+
+      cpuunits: 1111
+
+      description:  Something really bad
+
+      features: nesting=1
+
+      hostname: ntc_templates
+
+      memory: 1111
+
+      net0: name=eth0,bridge=vmbr0,firewall=1,gw=1.1.1.1,hwaddr=AA:AA:AA:AA:AA:AA,ip=1.1.1.2/8,type=veth
+
+      onboot: 1
+
+      ostype: ubuntu
+
+      rootfs: local:1/vm-1-disk-0.raw,size=1000G
+
+      swap: 1111
+
+      unprivileged: 0
+
+      lxc.apparmor.profile: unconfined
+
+      lxc.cgroup.devices.allow: a
+
+      lxc.apparmor.profile: unconfined
+
+      lxc.cgroup.devices.allow: a
+
+      tags: tag1,tag2,tag3
+
+      '
+    help: execute the command "pct config 1"
+    prompt: *id001
+  pct list:
+    output: "\nVMID       Status     Lock         Name                \n100      \
+      \  stopped                 netmiko       \n101        stopped              \
+      \   ntc_templates    \n1001       running                 something"
+    help: execute the command "pct list"
+    prompt: *id001
+  pveversion:
+    output: 'pve-manager/1.1-1/101a1111 (running kernel: 1.1.11-11-pve)'
+    help: execute the command "pveversion"
+    prompt: *id001
+  qm config 1:
+    output: '
+
+      bootdisk: ide0
+
+      cores: 2
+
+      cpulimit: 1
+
+      ide0: local:111/vm-111-disk-0.qcow2,size=10G
+
+      ide2: local:iso/ubuntu-24.04-live-server-amd64.iso,media=cdrom
+
+      memory: 1111
+
+      name: Super-Linux-Proxmox
+
+      net0: e1000=AA:AA:AA:AA:AA:AA,bridge=vmbr0
+
+      numa: 0
+
+      onboot: 1
+
+      ostype: other
+
+      smbios1: uuid=00a0a000-0aa0-0a00-a0aa-0aa0a0000a00
+
+      sockets: 1
+
+      '
+    help: execute the command "qm config 1"
+    prompt: *id001
+  qm list:
+    output: "\n      VMID NAME                 STATUS     MEM(MB)    BOOTDISK(GB)\
+      \ PID       \n       100 Screen-Sun-AAAAAAA   running    1111              11.00\
+      \ 1111111   \n"
+    help: execute the command "qm list"
+    prompt: *id001
+  top:
+    output: "top - 12:33:53 up  2:11,  5 users,  load average: 0.12, 0.40, 0.66\n\
+      Tasks: 200 total,   1 running, 189 sleeping,   5 stopped,   5 zombie\n%Cpu(s):\
+      \ 12.5 us, 12.5 sy,  0.0 ni, 62.5 id, 12.5 wa,  0.0 hi,  0.0 si,  0.0 st \n\
+      MiB Mem :   7809.9 total,   4753.7 free,   2052.9 used,   1126.5 buff/cache\
+      \     \nMiB Swap:    512.0 total,    512.0 free,      0.0 used.   5757.0 avail\
+      \ Mem \n\n    PID USER      PR  NI    VIRT    RES    SHR S  %CPU  %MEM     TIME+\
+      \ COMMAND\n  19516 admin     20   0   28.7g 880836  52224 S  12.5  11.0   6:51.26\
+      \ node\n  30427 admin     20   0   11708   4864   2816 R   6.2   0.1   0:00.03\
+      \ top\n      1 root      20   0  168332  11152   8400 S   0.0   0.1   0:01.14\
+      \ systemd\n      4 root       0 -20       0      0      0 I   0.0   0.0   0:00.00\
+      \ kworker/R-rcu_g\n    395 systemd+  20   0   90708   6784   5888 S   0.0  \
+      \ 0.1   0:00.18 systemd-timesyn\n    397 root       0 -20       0      0   \
+      \   0 I   0.0   0.0   0:00.68 kworker/u13:1-brcmf_wq/mmc1:0001:1\n    402 root\
+      \     -51   0       0      0      0 S   0.0   0.0   0:00.00 irq/41-vc4 hdmi\
+      \ hpd connected\n  30343 admin     20   0    5200   1408   1408 S   0.0   0.0\
+      \   0:00.00 sleep"
+    help: execute the command "top"
+    prompt: *id001
+  vzlist:
+    output: "      CTID      NPROC STATUS    IP_ADDR         HOSTNAME\n      1110\
+      \          1 running   -               something\n      1111        111 running\
+      \   192.168.0.1     something-bad\n      1112         11 running   -       \
+      \        something-ugly\n      1113         11 running   -               something-good"
+    help: execute the command "vzlist"
+    prompt: *id001

--- a/simnos/plugins/nos/platforms_yaml/mikrotik_routeros.yaml
+++ b/simnos/plugins/nos/platforms_yaml/mikrotik_routeros.yaml
@@ -266,16 +266,16 @@ commands:
     help: execute the command "interface bonding print detail"
     prompt: '[admin@{base_prompt}] >'
     output_variants:
-      - "Flags: X - disabled; R - running\n 0  R ;;; Link to Mikrotik\n      name=\"\
-        bond1\" mtu=1500 mac-address=48:A9:8A:5D:24:05 arp=enabled arp-timeout=auto\
-        \ slaves=sfp-sfpplus9,sfp-sfpplus10 mode=802.3ad primary=none link-monitoring=mii\
-        \ arp-interval=100ms arp-ip-targets=\"\" mii-interval=100ms down-delay=0ms\
-        \ up-delay=0ms lacp-rate=30secs transmit-hash-policy=layer-2 min-links=0\n"
-      - "Flags: X - disabled; R - running\n 0  R ;;; Link to Mikrotik\nand other things\n\
-        \      name=\"bond1\" mtu=1500 mac-address=48:A9:8A:5D:24:05 arp=enabled arp-timeout=auto\
-        \ slaves=sfp-sfpplus9,sfp-sfpplus10 mode=802.3ad primary=none link-monitoring=mii\
-        \ arp-interval=100ms arp-ip-targets=\"\" mii-interval=100ms down-delay=0ms\
-        \ up-delay=0ms lacp-rate=30secs transmit-hash-policy=layer-2 min-links=0\n"
+    - "Flags: X - disabled; R - running\n 0  R ;;; Link to Mikrotik\n      name=\"\
+      bond1\" mtu=1500 mac-address=48:A9:8A:5D:24:05 arp=enabled arp-timeout=auto\
+      \ slaves=sfp-sfpplus9,sfp-sfpplus10 mode=802.3ad primary=none link-monitoring=mii\
+      \ arp-interval=100ms arp-ip-targets=\"\" mii-interval=100ms down-delay=0ms up-delay=0ms\
+      \ lacp-rate=30secs transmit-hash-policy=layer-2 min-links=0\n"
+    - "Flags: X - disabled; R - running\n 0  R ;;; Link to Mikrotik\nand other things\n\
+      \      name=\"bond1\" mtu=1500 mac-address=48:A9:8A:5D:24:05 arp=enabled arp-timeout=auto\
+      \ slaves=sfp-sfpplus9,sfp-sfpplus10 mode=802.3ad primary=none link-monitoring=mii\
+      \ arp-interval=100ms arp-ip-targets=\"\" mii-interval=100ms down-delay=0ms up-delay=0ms\
+      \ lacp-rate=30secs transmit-hash-policy=layer-2 min-links=0\n"
   interface bridge host print terse without-paging:
     output: '0 D E  mac-address=11:22:33:44:55:01 interface=ether4 bridge=lan-bridge
       on-interface=ether4
@@ -341,89 +341,87 @@ commands:
     help: execute the command "interface print detail"
     prompt: '[admin@{base_prompt}] >'
     output_variants:
-      - "Flags: D - dynamic; X - disabled, R - running; S - slave; P - passthrough\n\
-        \ 0  R   ;;; Management Port - 4G OOB\n        name=\"ether1\" default-name=\"\
-        ether1\" type=\"ether\" mtu=1500 actual-mtu=1500 l2mtu=1600 max-l2mtu=9586\
-        \ mac-address=AA:BB:CC:11:22:33 ifname=\"eth0\" ifindex=7 id=1 last-link-down-time=2024-10-08\
-        \ 11:14:27 last-link-up-time=2024-10-08 11:14:36 link-downs=166\n\n 1  R \
-        \  ;;; Uplink\n        name=\"sfp-sfpplus1\" default-name=\"sfp-sfpplus1\"\
-        \ type=\"ether\" mtu=9216 actual-mtu=9216 l2mtu=9216 max-l2mtu=9578 mac-address=AA:BB:CC:11:22:33\
-        \ ifname=\"eth1\" ifindex=9 id=2 last-link-up-time=2024-07-23 10:13:23 link-downs=0\n\
-        \n 2  X   ;;; Spare Optic\n        name=\"sfp-sfpplus2\" default-name=\"sfp-sfpplus2\"\
-        \ type=\"ether\" mtu=9216 actual-mtu=9216 l2mtu=9216 max-l2mtu=9578 mac-address=AA:BB:CC:11:22:33\
-        \ ifname=\"eth2\" ifindex=10 id=3 link-downs=0\n\n 3  X   name=\"sfp-sfpplus3\"\
-        \ default-name=\"sfp-sfpplus3\" type=\"ether\" mtu=9216 actual-mtu=9216 l2mtu=9216\
-        \ max-l2mtu=9578 mac-address=AA:BB:CC:11:22:33 ifname=\"eth3\" ifindex=11\
-        \ id=4 link-downs=0\n\n 4  X   name=\"sfp-sfpplus4\" default-name=\"sfp-sfpplus4\"\
-        \ type=\"ether\" mtu=9216 actual-mtu=9216 l2mtu=9216 max-l2mtu=9578 mac-address=AA:BB:CC:11:22:33\
-        \ ifname=\"eth4\" ifindex=12 id=5 link-downs=0\n\n 5  X   name=\"sfp-sfpplus5\"\
-        \ default-name=\"sfp-sfpplus5\" type=\"ether\" mtu=9216 actual-mtu=9216 l2mtu=9216\
-        \ max-l2mtu=9578 mac-address=AA:BB:CC:11:22:33 ifname=\"eth5\" ifindex=13\
-        \ id=6 link-downs=0\n\n 6  X   name=\"sfp-sfpplus6\" default-name=\"sfp-sfpplus6\"\
-        \ type=\"ether\" mtu=9216 actual-mtu=9216 l2mtu=9216 max-l2mtu=9578 mac-address=AA:BB:CC:11:22:33\
-        \ ifname=\"eth6\" ifindex=14 id=7 link-downs=0\n\n 7  X   name=\"sfp-sfpplus7\"\
-        \ default-name=\"sfp-sfpplus7\" type=\"ether\" mtu=9216 actual-mtu=9216 l2mtu=9216\
-        \ max-l2mtu=9578 mac-address=AA:BB:CC:11:22:33 ifname=\"eth7\" ifindex=15\
-        \ id=8 link-downs=0\n\n 8  X   name=\"sfp-sfpplus8\" default-name=\"sfp-sfpplus8\"\
-        \ type=\"ether\" mtu=9216 actual-mtu=9216 l2mtu=9216 max-l2mtu=9578 mac-address=AA:BB:CC:11:22:33\
-        \ ifname=\"eth8\" ifindex=16 id=9 link-downs=0\n\n 9  RS  ;;; Link to\n  \
-        \      name=\"sfp-sfpplus9\" default-name=\"sfp-sfpplus9\" type=\"ether\"\
-        \ mtu=9216 actual-mtu=9216 l2mtu=9216 max-l2mtu=9578 mac-address=AA:BB:CC:11:22:33\
-        \ ifname=\"eth9\" ifindex=17 id=10 last-link-down-time=2024-08-23 12:53:56\
-        \ last-link-up-time=2024-08-23 12:53:56 link-downs=4\n\n10  RS  ;;; Link to\n\
-        \        name=\"sfp-sfpplus10\" default-name=\"sfp-sfpplus10\" type=\"ether\"\
-        \ mtu=9216 actual-mtu=9216 l2mtu=9216 max-l2mtu=9578 mac-address=AA:BB:CC:11:22:33\
-        \ ifname=\"eth10\" ifindex=18 id=11 last-link-down-time=2024-08-23 12:53:27\
-        \ last-link-up-time=2024-08-23 12:53:55 link-downs=5\n\n11  R   ;;; Cust\n\
-        \        name=\"sfp-sfpplus11\" default-name=\"sfp-sfpplus11\" type=\"ether\"\
-        \ mtu=9216 actual-mtu=9216 l2mtu=9216 max-l2mtu=9578 mac-address=AA:BB:CC:11:22:33\
-        \ ifname=\"eth11\" ifindex=19 id=12 last-link-down-time=2024-08-29 20:57:53\
-        \ last-link-up-time=2024-09-19 23:00:35 link-downs=1\n\n12  X   ;;; Cust\n\
-        \        name=\"sfp-sfpplus12\" default-name=\"sfp-sfpplus12\" type=\"ether\"\
-        \ mtu=9216 actual-mtu=9216 l2mtu=9216 max-l2mtu=9578 mac-address=AA:BB:CC:11:22:33\
-        \ ifname=\"eth12\" ifindex=20 id=13 link-downs=0\n\n13  X   name=\"sfp28-1\"\
-        \ default-name=\"sfp28-1\" type=\"ether\" mtu=9216 actual-mtu=9216 l2mtu=9216\
-        \ max-l2mtu=9578 mac-address=AA:BB:CC:11:22:33 ifname=\"eth13\" ifindex=21\
-        \ id=14 link-downs=0\n\n14  X   name=\"sfp28-2\" default-name=\"sfp28-2\"\
-        \ type=\"ether\" mtu=9216 actual-mtu=9216 l2mtu=9216 max-l2mtu=9578 mac-address=AA:BB:CC:11:22:33\
-        \ ifname=\"eth14\" ifindex=22 id=15 link-downs=0\n\n15  R   ;;; Loopback\n\
-        \        name=\"Lo0\" type=\"bridge\" mtu=auto actual-mtu=1500 l2mtu=65535\
-        \ mac-address=AA:BB:CC:11:22:33 ifname=\"br0\" ifindex=24 id=23 last-link-up-time=2024-07-23\
-        \ 10:13:19 link-downs=0\n\n16  R   ;;; INET Loopback\n        name=\"Lo1\"\
-        \ type=\"bridge\" mtu=auto actual-mtu=1500 l2mtu=65535 vrf=INET mac-address=AA:BB:CC:11:22:33\
-        \ ifname=\"br1\" ifindex=36 id=27 last-link-up-time=2024-07-23 10:19:01 link-downs=0\n\
-        \n17  R   ;;; Link to\n        name=\"bond1\" type=\"bond\" mtu=1500 actual-mtu=1500\
-        \ l2mtu=9216 mac-address=AA:BB:CC:11:22:33 ifname=\"bond24\" ifindex=23 id=24\
-        \ last-link-down-time=2024-08-23 12:53:27 last-link-up-time=2024-08-23 12:53:55\
-        \ link-downs=3\n\n18  R   name=\"pppoe-out1\" type=\"pppoe-out\" mtu=1400\
-        \ actual-mtu=1400 ifname=\"ppp25889\" ifindex=25948 id=20 last-link-down-time=2024-10-08\
-        \ 12:36:57 last-link-up-time=2024-10-08 12:39:16 link-downs=7208\n\n19  R\
-        \   ;;; MGMT\n        name=\"vlan1@bond1\" type=\"vlan\" mtu=1574 actual-mtu=1574\
-        \ l2mtu=9212 mac-address=AA:BB:CC:11:22:33 ifname=\"vlan25\" ifindex=27 id=25\
-        \ last-link-down-time=2024-08-23 12:53:27 last-link-up-time=2024-08-23 12:53:55\
-        \ link-downs=3\n\n20  R   ;;; INET\n        name=\"vlan2@bond1\" type=\"vlan\"\
-        \ mtu=1574 actual-mtu=1574 l2mtu=9212 vrf=INET mac-address=AA:BB:CC:11:22:33\
-        \ ifname=\"vlan26\" ifindex=28 id=26 last-link-down-time=2024-08-23 12:53:27\
-        \ last-link-up-time=2024-08-23 12:53:55 link-downs=3\n\n21  R   ;;; MGMT Uplink\
-        \ YDCE-M1\n        name=\"vlan10@vlan975@sfp-sfpplus1\" type=\"vlan\" mtu=1574\
-        \ actual-mtu=1574 l2mtu=9208 mac-address=AA:BB:CC:11:22:33 ifname=\"vlan22\"\
-        \ ifindex=33 id=22 last-link-up-time=2024-07-23 10:13:23 link-downs=0\n\n\
-        22  R   ;;; INET: IX\n        name=\"vlan11@vlan975@sfp-sfpplus1\" type=\"\
-        vlan\" mtu=1500 actual-mtu=1500 l2mtu=9208 vrf=INET mac-address=AA:BB:CC:11:22:33\
-        \ ifname=\"vlan21\" ifindex=31 id=21 last-link-up-time=2024-07-23 10:13:23\
-        \ link-downs=0\n\n23  R   ;;; INET: IX\n        name=\"vlan12@vlan975@sfp-sfpplus1\"\
-        \ type=\"vlan\" mtu=1500 actual-mtu=1500 l2mtu=9208 vrf=INET mac-address=AA:BB:CC:11:22:33\
-        \ ifname=\"vlan29\" ifindex=38 id=29 last-link-up-time=2024-07-23 11:45:31\
-        \ link-downs=0\n\n24  R   ;;; INET: IX\n        name=\"vlan111@sfp-sfpplus1\"\
-        \ type=\"vlan\" mtu=1500 actual-mtu=1500 l2mtu=9212 vrf=INET mac-address=AA:BB:CC:11:22:33\
-        \ ifname=\"vlan18\" ifindex=26 id=18 last-link-up-time=2024-07-23 10:13:23\
-        \ link-downs=0\n\n25  R   ;;; Intercap\n        name=\"vlan975@sfp-sfpplus1\"\
-        \ type=\"vlan\" mtu=1500 actual-mtu=1500 l2mtu=9212 mac-address=AA:BB:CC:11:22:33\
-        \ ifname=\"vlan16\" ifindex=25 id=16 last-link-up-time=2024-07-23 10:13:23\
-        \ link-downs=0\n\n26  R   name=\"vlan4050@sfp-sfpplus11\" type=\"vlan\" mtu=9212\
-        \ actual-mtu=9212 l2mtu=9212 vrf=INET mac-address=AA:BB:CC:11:22:33 ifname=\"\
-        vlan30\" ifindex=239 id=30 last-link-down-time=2024-08-29 20:57:53 last-link-up-time=2024-09-19\
-        \ 23:00:35 link-downs=1"
+    - "Flags: D - dynamic; X - disabled, R - running; S - slave; P - passthrough\n\
+      \ 0  R   ;;; Management Port - 4G OOB\n        name=\"ether1\" default-name=\"\
+      ether1\" type=\"ether\" mtu=1500 actual-mtu=1500 l2mtu=1600 max-l2mtu=9586 mac-address=AA:BB:CC:11:22:33\
+      \ ifname=\"eth0\" ifindex=7 id=1 last-link-down-time=2024-10-08 11:14:27 last-link-up-time=2024-10-08\
+      \ 11:14:36 link-downs=166\n\n 1  R   ;;; Uplink\n        name=\"sfp-sfpplus1\"\
+      \ default-name=\"sfp-sfpplus1\" type=\"ether\" mtu=9216 actual-mtu=9216 l2mtu=9216\
+      \ max-l2mtu=9578 mac-address=AA:BB:CC:11:22:33 ifname=\"eth1\" ifindex=9 id=2\
+      \ last-link-up-time=2024-07-23 10:13:23 link-downs=0\n\n 2  X   ;;; Spare Optic\n\
+      \        name=\"sfp-sfpplus2\" default-name=\"sfp-sfpplus2\" type=\"ether\"\
+      \ mtu=9216 actual-mtu=9216 l2mtu=9216 max-l2mtu=9578 mac-address=AA:BB:CC:11:22:33\
+      \ ifname=\"eth2\" ifindex=10 id=3 link-downs=0\n\n 3  X   name=\"sfp-sfpplus3\"\
+      \ default-name=\"sfp-sfpplus3\" type=\"ether\" mtu=9216 actual-mtu=9216 l2mtu=9216\
+      \ max-l2mtu=9578 mac-address=AA:BB:CC:11:22:33 ifname=\"eth3\" ifindex=11 id=4\
+      \ link-downs=0\n\n 4  X   name=\"sfp-sfpplus4\" default-name=\"sfp-sfpplus4\"\
+      \ type=\"ether\" mtu=9216 actual-mtu=9216 l2mtu=9216 max-l2mtu=9578 mac-address=AA:BB:CC:11:22:33\
+      \ ifname=\"eth4\" ifindex=12 id=5 link-downs=0\n\n 5  X   name=\"sfp-sfpplus5\"\
+      \ default-name=\"sfp-sfpplus5\" type=\"ether\" mtu=9216 actual-mtu=9216 l2mtu=9216\
+      \ max-l2mtu=9578 mac-address=AA:BB:CC:11:22:33 ifname=\"eth5\" ifindex=13 id=6\
+      \ link-downs=0\n\n 6  X   name=\"sfp-sfpplus6\" default-name=\"sfp-sfpplus6\"\
+      \ type=\"ether\" mtu=9216 actual-mtu=9216 l2mtu=9216 max-l2mtu=9578 mac-address=AA:BB:CC:11:22:33\
+      \ ifname=\"eth6\" ifindex=14 id=7 link-downs=0\n\n 7  X   name=\"sfp-sfpplus7\"\
+      \ default-name=\"sfp-sfpplus7\" type=\"ether\" mtu=9216 actual-mtu=9216 l2mtu=9216\
+      \ max-l2mtu=9578 mac-address=AA:BB:CC:11:22:33 ifname=\"eth7\" ifindex=15 id=8\
+      \ link-downs=0\n\n 8  X   name=\"sfp-sfpplus8\" default-name=\"sfp-sfpplus8\"\
+      \ type=\"ether\" mtu=9216 actual-mtu=9216 l2mtu=9216 max-l2mtu=9578 mac-address=AA:BB:CC:11:22:33\
+      \ ifname=\"eth8\" ifindex=16 id=9 link-downs=0\n\n 9  RS  ;;; Link to\n    \
+      \    name=\"sfp-sfpplus9\" default-name=\"sfp-sfpplus9\" type=\"ether\" mtu=9216\
+      \ actual-mtu=9216 l2mtu=9216 max-l2mtu=9578 mac-address=AA:BB:CC:11:22:33 ifname=\"\
+      eth9\" ifindex=17 id=10 last-link-down-time=2024-08-23 12:53:56 last-link-up-time=2024-08-23\
+      \ 12:53:56 link-downs=4\n\n10  RS  ;;; Link to\n        name=\"sfp-sfpplus10\"\
+      \ default-name=\"sfp-sfpplus10\" type=\"ether\" mtu=9216 actual-mtu=9216 l2mtu=9216\
+      \ max-l2mtu=9578 mac-address=AA:BB:CC:11:22:33 ifname=\"eth10\" ifindex=18 id=11\
+      \ last-link-down-time=2024-08-23 12:53:27 last-link-up-time=2024-08-23 12:53:55\
+      \ link-downs=5\n\n11  R   ;;; Cust\n        name=\"sfp-sfpplus11\" default-name=\"\
+      sfp-sfpplus11\" type=\"ether\" mtu=9216 actual-mtu=9216 l2mtu=9216 max-l2mtu=9578\
+      \ mac-address=AA:BB:CC:11:22:33 ifname=\"eth11\" ifindex=19 id=12 last-link-down-time=2024-08-29\
+      \ 20:57:53 last-link-up-time=2024-09-19 23:00:35 link-downs=1\n\n12  X   ;;;\
+      \ Cust\n        name=\"sfp-sfpplus12\" default-name=\"sfp-sfpplus12\" type=\"\
+      ether\" mtu=9216 actual-mtu=9216 l2mtu=9216 max-l2mtu=9578 mac-address=AA:BB:CC:11:22:33\
+      \ ifname=\"eth12\" ifindex=20 id=13 link-downs=0\n\n13  X   name=\"sfp28-1\"\
+      \ default-name=\"sfp28-1\" type=\"ether\" mtu=9216 actual-mtu=9216 l2mtu=9216\
+      \ max-l2mtu=9578 mac-address=AA:BB:CC:11:22:33 ifname=\"eth13\" ifindex=21 id=14\
+      \ link-downs=0\n\n14  X   name=\"sfp28-2\" default-name=\"sfp28-2\" type=\"\
+      ether\" mtu=9216 actual-mtu=9216 l2mtu=9216 max-l2mtu=9578 mac-address=AA:BB:CC:11:22:33\
+      \ ifname=\"eth14\" ifindex=22 id=15 link-downs=0\n\n15  R   ;;; Loopback\n \
+      \       name=\"Lo0\" type=\"bridge\" mtu=auto actual-mtu=1500 l2mtu=65535 mac-address=AA:BB:CC:11:22:33\
+      \ ifname=\"br0\" ifindex=24 id=23 last-link-up-time=2024-07-23 10:13:19 link-downs=0\n\
+      \n16  R   ;;; INET Loopback\n        name=\"Lo1\" type=\"bridge\" mtu=auto actual-mtu=1500\
+      \ l2mtu=65535 vrf=INET mac-address=AA:BB:CC:11:22:33 ifname=\"br1\" ifindex=36\
+      \ id=27 last-link-up-time=2024-07-23 10:19:01 link-downs=0\n\n17  R   ;;; Link\
+      \ to\n        name=\"bond1\" type=\"bond\" mtu=1500 actual-mtu=1500 l2mtu=9216\
+      \ mac-address=AA:BB:CC:11:22:33 ifname=\"bond24\" ifindex=23 id=24 last-link-down-time=2024-08-23\
+      \ 12:53:27 last-link-up-time=2024-08-23 12:53:55 link-downs=3\n\n18  R   name=\"\
+      pppoe-out1\" type=\"pppoe-out\" mtu=1400 actual-mtu=1400 ifname=\"ppp25889\"\
+      \ ifindex=25948 id=20 last-link-down-time=2024-10-08 12:36:57 last-link-up-time=2024-10-08\
+      \ 12:39:16 link-downs=7208\n\n19  R   ;;; MGMT\n        name=\"vlan1@bond1\"\
+      \ type=\"vlan\" mtu=1574 actual-mtu=1574 l2mtu=9212 mac-address=AA:BB:CC:11:22:33\
+      \ ifname=\"vlan25\" ifindex=27 id=25 last-link-down-time=2024-08-23 12:53:27\
+      \ last-link-up-time=2024-08-23 12:53:55 link-downs=3\n\n20  R   ;;; INET\n \
+      \       name=\"vlan2@bond1\" type=\"vlan\" mtu=1574 actual-mtu=1574 l2mtu=9212\
+      \ vrf=INET mac-address=AA:BB:CC:11:22:33 ifname=\"vlan26\" ifindex=28 id=26\
+      \ last-link-down-time=2024-08-23 12:53:27 last-link-up-time=2024-08-23 12:53:55\
+      \ link-downs=3\n\n21  R   ;;; MGMT Uplink YDCE-M1\n        name=\"vlan10@vlan975@sfp-sfpplus1\"\
+      \ type=\"vlan\" mtu=1574 actual-mtu=1574 l2mtu=9208 mac-address=AA:BB:CC:11:22:33\
+      \ ifname=\"vlan22\" ifindex=33 id=22 last-link-up-time=2024-07-23 10:13:23 link-downs=0\n\
+      \n22  R   ;;; INET: IX\n        name=\"vlan11@vlan975@sfp-sfpplus1\" type=\"\
+      vlan\" mtu=1500 actual-mtu=1500 l2mtu=9208 vrf=INET mac-address=AA:BB:CC:11:22:33\
+      \ ifname=\"vlan21\" ifindex=31 id=21 last-link-up-time=2024-07-23 10:13:23 link-downs=0\n\
+      \n23  R   ;;; INET: IX\n        name=\"vlan12@vlan975@sfp-sfpplus1\" type=\"\
+      vlan\" mtu=1500 actual-mtu=1500 l2mtu=9208 vrf=INET mac-address=AA:BB:CC:11:22:33\
+      \ ifname=\"vlan29\" ifindex=38 id=29 last-link-up-time=2024-07-23 11:45:31 link-downs=0\n\
+      \n24  R   ;;; INET: IX\n        name=\"vlan111@sfp-sfpplus1\" type=\"vlan\"\
+      \ mtu=1500 actual-mtu=1500 l2mtu=9212 vrf=INET mac-address=AA:BB:CC:11:22:33\
+      \ ifname=\"vlan18\" ifindex=26 id=18 last-link-up-time=2024-07-23 10:13:23 link-downs=0\n\
+      \n25  R   ;;; Intercap\n        name=\"vlan975@sfp-sfpplus1\" type=\"vlan\"\
+      \ mtu=1500 actual-mtu=1500 l2mtu=9212 mac-address=AA:BB:CC:11:22:33 ifname=\"\
+      vlan16\" ifindex=25 id=16 last-link-up-time=2024-07-23 10:13:23 link-downs=0\n\
+      \n26  R   name=\"vlan4050@sfp-sfpplus11\" type=\"vlan\" mtu=9212 actual-mtu=9212\
+      \ l2mtu=9212 vrf=INET mac-address=AA:BB:CC:11:22:33 ifname=\"vlan30\" ifindex=239\
+      \ id=30 last-link-down-time=2024-08-29 20:57:53 last-link-up-time=2024-09-19\
+      \ 23:00:35 link-downs=1"
   interface vlan print detail:
     output: "Flags: X - disabled, R - running\n 0 R ;;; MGMT\n     name=\"vlan1@bond1\"\
       \ mtu=1574 l2mtu=9212 mac-address=AA:BB:CC:11:22:33 arp=enabled arp-timeout=auto\
@@ -457,40 +455,40 @@ commands:
     help: execute the command "interface vlan print detail"
     prompt: '[admin@{base_prompt}] >'
     output_variants:
-      - "Flags: X - disabled, R - running\n 0 R ;;; CUST\n     name=\"vlan1@vlan602@interface\"\
-        \ mtu=1574 l2mtu=8992 mac-address=AA:BB:CC:11:22:33 arp=enabled arp-timeout=auto\
-        \ loop-protect=default loop-protect-status=off loop-protect-send-interval=5s\
-        \ loop-protect-disable-time=5m vlan-id=1 interface=vlan602@interface use-service-tag=no\n\
-        \n 1 R ;;; PPPoE Termination on BNGs\n     name=\"vlan6@bond1\" mtu=1508 l2mtu=8996\
-        \ mac-address=AA:BB:CC:11:22:33 arp=enabled arp-timeout=auto loop-protect=default\
-        \ loop-protect-status=off loop-protect-send-interval=5s loop-protect-disable-time=5m\
-        \ vlan-id=6 interface=bond1 use-service-tag=no\n\n 2 R ;;; Cust\n     name=\"\
-        vlan10@vlan975@interface\" mtu=1574 l2mtu=8992 mac-address=AA:BB:CC:11:22:33\
-        \ arp=enabled arp-timeout=auto loop-protect=default loop-protect-status=off\
-        \ loop-protect-send-interval=5s loop-protect-disable-time=5m vlan-id=10 interface=vlan975@interface\
-        \ use-service-tag=no\n\n 3 R ;;; test pppoe\n     name=\"vlan11@bond1\" mtu=1500\
-        \ l2mtu=8996 mac-address=AA:BB:CC:11:22:33 arp=enabled arp-timeout=auto loop-protect=default\
-        \ loop-protect-status=off loop-protect-send-interval=5s loop-protect-disable-time=5m\
-        \ vlan-id=11 interface=bond1 use-service-tag=no\n\n 4 R ;;; Intercap\n   \
-        \  name=\"vlan11@vlan975@interface\" mtu=1574 l2mtu=8992 mac-address=AA:BB:CC:11:22:33\
-        \ arp=enabled arp-timeout=auto loop-protect=default loop-protect-status=off\
-        \ loop-protect-send-interval=5s loop-protect-disable-time=5m vlan-id=11 interface=vlan975@interface\
-        \ use-service-tag=no\n\n 5 R ;;; Intercap\n     name=\"vlan12@vlan975@interface\"\
-        \ mtu=1574 l2mtu=8992 mac-address=AA:BB:CC:11:22:33 arp=enabled arp-timeout=auto\
-        \ loop-protect=default loop-protect-status=off loop-protect-send-interval=5s\
-        \ loop-protect-disable-time=5m vlan-id=12 interface=vlan975@interface use-service-tag=no\n\
-        \n 6 R ;;; Carrier\n     name=\"vlan60@interface\" mtu=1600 l2mtu=8996 mac-address=AA:BB:CC:11:22:33\
-        \ arp=enabled arp-timeout=auto loop-protect=default loop-protect-status=off\
-        \ loop-protect-send-interval=5s loop-protect-disable-time=5m vlan-id=60 interface=sfp-sfpplus1\
-        \ use-service-tag=no\n\n 7 R ;;; Carrier\n     name=\"vlan60@bond1\" mtu=1600\
-        \ l2mtu=8996 mac-address=AA:BB:CC:11:22:33 arp=enabled arp-timeout=auto loop-protect=default\
-        \ loop-protect-status=off loop-protect-send-interval=5s loop-protect-disable-time=5m\
-        \ vlan-id=60 interface=bond1 use-service-tag=no\n"
-      - "Flags: X - disabled, R - running\n 0 R ;;; CUST\nwho has a multiline comment\n\
-        \     name=\"vlan1@vlan602@interface\" mtu=1574 l2mtu=8992 mac-address=AA:BB:CC:11:22:33\
-        \ arp=enabled arp-timeout=auto loop-protect=default loop-protect-status=off\
-        \ loop-protect-send-interval=5s loop-protect-disable-time=5m vlan-id=1 interface=vlan602@interface\
-        \ use-service-tag=no\n"
+    - "Flags: X - disabled, R - running\n 0 R ;;; CUST\n     name=\"vlan1@vlan602@interface\"\
+      \ mtu=1574 l2mtu=8992 mac-address=AA:BB:CC:11:22:33 arp=enabled arp-timeout=auto\
+      \ loop-protect=default loop-protect-status=off loop-protect-send-interval=5s\
+      \ loop-protect-disable-time=5m vlan-id=1 interface=vlan602@interface use-service-tag=no\n\
+      \n 1 R ;;; PPPoE Termination on BNGs\n     name=\"vlan6@bond1\" mtu=1508 l2mtu=8996\
+      \ mac-address=AA:BB:CC:11:22:33 arp=enabled arp-timeout=auto loop-protect=default\
+      \ loop-protect-status=off loop-protect-send-interval=5s loop-protect-disable-time=5m\
+      \ vlan-id=6 interface=bond1 use-service-tag=no\n\n 2 R ;;; Cust\n     name=\"\
+      vlan10@vlan975@interface\" mtu=1574 l2mtu=8992 mac-address=AA:BB:CC:11:22:33\
+      \ arp=enabled arp-timeout=auto loop-protect=default loop-protect-status=off\
+      \ loop-protect-send-interval=5s loop-protect-disable-time=5m vlan-id=10 interface=vlan975@interface\
+      \ use-service-tag=no\n\n 3 R ;;; test pppoe\n     name=\"vlan11@bond1\" mtu=1500\
+      \ l2mtu=8996 mac-address=AA:BB:CC:11:22:33 arp=enabled arp-timeout=auto loop-protect=default\
+      \ loop-protect-status=off loop-protect-send-interval=5s loop-protect-disable-time=5m\
+      \ vlan-id=11 interface=bond1 use-service-tag=no\n\n 4 R ;;; Intercap\n     name=\"\
+      vlan11@vlan975@interface\" mtu=1574 l2mtu=8992 mac-address=AA:BB:CC:11:22:33\
+      \ arp=enabled arp-timeout=auto loop-protect=default loop-protect-status=off\
+      \ loop-protect-send-interval=5s loop-protect-disable-time=5m vlan-id=11 interface=vlan975@interface\
+      \ use-service-tag=no\n\n 5 R ;;; Intercap\n     name=\"vlan12@vlan975@interface\"\
+      \ mtu=1574 l2mtu=8992 mac-address=AA:BB:CC:11:22:33 arp=enabled arp-timeout=auto\
+      \ loop-protect=default loop-protect-status=off loop-protect-send-interval=5s\
+      \ loop-protect-disable-time=5m vlan-id=12 interface=vlan975@interface use-service-tag=no\n\
+      \n 6 R ;;; Carrier\n     name=\"vlan60@interface\" mtu=1600 l2mtu=8996 mac-address=AA:BB:CC:11:22:33\
+      \ arp=enabled arp-timeout=auto loop-protect=default loop-protect-status=off\
+      \ loop-protect-send-interval=5s loop-protect-disable-time=5m vlan-id=60 interface=sfp-sfpplus1\
+      \ use-service-tag=no\n\n 7 R ;;; Carrier\n     name=\"vlan60@bond1\" mtu=1600\
+      \ l2mtu=8996 mac-address=AA:BB:CC:11:22:33 arp=enabled arp-timeout=auto loop-protect=default\
+      \ loop-protect-status=off loop-protect-send-interval=5s loop-protect-disable-time=5m\
+      \ vlan-id=60 interface=bond1 use-service-tag=no\n"
+    - "Flags: X - disabled, R - running\n 0 R ;;; CUST\nwho has a multiline comment\n\
+      \     name=\"vlan1@vlan602@interface\" mtu=1574 l2mtu=8992 mac-address=AA:BB:CC:11:22:33\
+      \ arp=enabled arp-timeout=auto loop-protect=default loop-protect-status=off\
+      \ loop-protect-send-interval=5s loop-protect-disable-time=5m vlan-id=1 interface=vlan602@interface\
+      \ use-service-tag=no\n"
   interface wireguard peers print terse without-paging:
     output: '0 interface=wg1 name=peer2 public-key=dcKiJ0TpLjtSWZh3G0ILJ9cL56fTIfHBAsZsXdDIlFM=
       private-key= endpoint-address= endpoint-port=0 current-endpoint-address=192.168.93.254
@@ -537,11 +535,11 @@ commands:
     help: execute the command "ip dhcp-server lease print"
     prompt: '[admin@{base_prompt}] >'
     output_variants:
-      - "Flags: D - DYNAMIC\nColumns: ADDRESS, MAC-ADDRESS, HOST-NAME, SERVER, STATUS,\
-        \ LAST-SEEN\n #   ADDRESS     MAC-ADDRESS        HOST-NAME    SERVER   STATUS\
-        \  LAST-SEEN\n0  D 10.0.1.94   BA:98:2C:BD:EA:47  raspberrypi  Clients  bound\
-        \   3m6s     \n1  D 10.0.1.99   DE:6E:70:C0:CC:B2  raspberrypi  Clients  bound\
-        \   2m48s    \n"
+    - "Flags: D - DYNAMIC\nColumns: ADDRESS, MAC-ADDRESS, HOST-NAME, SERVER, STATUS,\
+      \ LAST-SEEN\n #   ADDRESS     MAC-ADDRESS        HOST-NAME    SERVER   STATUS\
+      \  LAST-SEEN\n0  D 10.0.1.94   BA:98:2C:BD:EA:47  raspberrypi  Clients  bound\
+      \   3m6s     \n1  D 10.0.1.99   DE:6E:70:C0:CC:B2  raspberrypi  Clients  bound\
+      \   2m48s    \n"
   ip dhcp-server lease print terse without-paging:
     output: " 0 D address=192.168.69.254 address-lists=\"\" server=*1 dhcp-option=\"\
       \" status=conflict expires-after=6m59s last-seen=35w12h24m42s active-address=192.168.69.254\
@@ -553,26 +551,26 @@ commands:
     help: execute the command "ip dhcp-server lease print terse without-paging"
     prompt: '[admin@{base_prompt}] >'
     output_variants:
-      - " 0   comment=UniFi1 address=10.124.3.199 mac-address=74:83:C2:36:5A:6E client-id=1:74:83:c2:36:5a:6e\
-        \ address-lists=\"\" server=dhcp1 dhcp-option=unifi status=bound expires-after=6m51s\
-        \ last-seen=3m9s active-address=10.164.1.199 active-mac-address=74:83:C2:36:5A:6E\
-        \ active-client-id=1:74:83:c2:36:5a:6e active-server=dhcp1 host-name=Unifi3B\
-        \ \n 1   comment=PC address=10.124.3.252 mac-address=00:50:56:88:80:EE client-id=1:0:50:56:88:80:ee\
-        \ address-lists=\"\" server=dhcp1 dhcp-option=\"\" status=bound expires-after=6m18s\
-        \ last-seen=3m42s active-address=10.164.1.252 active-mac-address=00:50:56:88:80:EE\
-        \ active-client-id=1:0:50:56:88:80:ee active-server=dhcp1 host-name=RSNC-CLIENT1-VM\
-        \ \n 2   comment=SPA address=10.124.3.222 mac-address=C4:0A:CB:BC:65:C8 address-lists=\"\
-        \" server=dhcp1 dhcp-option=\"\" status=bound expires-after=5m56s last-seen=4m4s\
-        \ active-address=10.164.1.222 active-mac-address=C4:0A:CB:BC:65:C8 active-client-id=1:c4:a:cb:bc:65:c8\
-        \ active-server=dhcp1 host-name=SPA122 \n 3 D address=10.0.1.56 mac-address=C2:39:B3:FA:81:D0\
-        \ client-id=1:c2:39:b3:fa:81:d0 address-lists= server=Clients dhcp-option=\
-        \ status=bound expires-after=2m38s last-seen=2m22s age=2h11m23s active-address=10.0.1.56\
-        \ active-mac-address=C2:39:B3:FA:81:D0 active-client-id=1:c2:39:b3:fa:81:d0\
-        \ active-server=Clients\n 4 D address=192.168.80.254 mac-address=AA:C1:AB:E3:F5:E8\
-        \ client-id=1:aa:c1:ab:e3:f5:e8 address-lists= server=dhcp1 dhcp-option= status=bound\
-        \ expires-after=16m59s last-seen=13m1s age=13m1s active-address=192.168.80.254\
-        \ active-mac-address=AA:C1:AB:E3:F5:E8 active-client-id=1:aa:c1:ab:e3:f5:e8\
-        \ active-server=dhcp1 class-id=udhcp 1.37.0"
+    - " 0   comment=UniFi1 address=10.124.3.199 mac-address=74:83:C2:36:5A:6E client-id=1:74:83:c2:36:5a:6e\
+      \ address-lists=\"\" server=dhcp1 dhcp-option=unifi status=bound expires-after=6m51s\
+      \ last-seen=3m9s active-address=10.164.1.199 active-mac-address=74:83:C2:36:5A:6E\
+      \ active-client-id=1:74:83:c2:36:5a:6e active-server=dhcp1 host-name=Unifi3B\
+      \ \n 1   comment=PC address=10.124.3.252 mac-address=00:50:56:88:80:EE client-id=1:0:50:56:88:80:ee\
+      \ address-lists=\"\" server=dhcp1 dhcp-option=\"\" status=bound expires-after=6m18s\
+      \ last-seen=3m42s active-address=10.164.1.252 active-mac-address=00:50:56:88:80:EE\
+      \ active-client-id=1:0:50:56:88:80:ee active-server=dhcp1 host-name=RSNC-CLIENT1-VM\
+      \ \n 2   comment=SPA address=10.124.3.222 mac-address=C4:0A:CB:BC:65:C8 address-lists=\"\
+      \" server=dhcp1 dhcp-option=\"\" status=bound expires-after=5m56s last-seen=4m4s\
+      \ active-address=10.164.1.222 active-mac-address=C4:0A:CB:BC:65:C8 active-client-id=1:c4:a:cb:bc:65:c8\
+      \ active-server=dhcp1 host-name=SPA122 \n 3 D address=10.0.1.56 mac-address=C2:39:B3:FA:81:D0\
+      \ client-id=1:c2:39:b3:fa:81:d0 address-lists= server=Clients dhcp-option= status=bound\
+      \ expires-after=2m38s last-seen=2m22s age=2h11m23s active-address=10.0.1.56\
+      \ active-mac-address=C2:39:B3:FA:81:D0 active-client-id=1:c2:39:b3:fa:81:d0\
+      \ active-server=Clients\n 4 D address=192.168.80.254 mac-address=AA:C1:AB:E3:F5:E8\
+      \ client-id=1:aa:c1:ab:e3:f5:e8 address-lists= server=dhcp1 dhcp-option= status=bound\
+      \ expires-after=16m59s last-seen=13m1s age=13m1s active-address=192.168.80.254\
+      \ active-mac-address=AA:C1:AB:E3:F5:E8 active-client-id=1:aa:c1:ab:e3:f5:e8\
+      \ active-server=dhcp1 class-id=udhcp 1.37.0"
   ip dns cache print terse without-paging:
     output: '0 type=A data=216.58.215.142 name=google.com ttl=1m44s
 
@@ -616,30 +614,30 @@ commands:
     help: execute the command "ip neighbor print detail"
     prompt: '[admin@{base_prompt}] >'
     output_variants:
-      - ' 0 interface=ether10,bridge_255_mgmt address=1.2.4.5 address4=1.2.4.5 address6=2001:0db8:11a3:09d7:1f34:8a2e:07a0:765d
-        mac-address=12:34:56:78:90:AB identity="CLEAR" platform="MikroTik" version="7.15.1
-        (stable) 2024-06-07 12:49:11" unpack=none age=7s uptime=1d8h37m20s software-id="AAAA-BBBB"
-        board="RB450Gx4" ipv6=yes interface-name="ether1" system-description="MikroTik
-        RouterOS 7.15.1 (stable) 2024-06-07 12:49:11 RB450Gx4" system-caps=bridge,router
-        system-caps-enabled=router
+    - ' 0 interface=ether10,bridge_255_mgmt address=1.2.4.5 address4=1.2.4.5 address6=2001:0db8:11a3:09d7:1f34:8a2e:07a0:765d
+      mac-address=12:34:56:78:90:AB identity="CLEAR" platform="MikroTik" version="7.15.1
+      (stable) 2024-06-07 12:49:11" unpack=none age=7s uptime=1d8h37m20s software-id="AAAA-BBBB"
+      board="RB450Gx4" ipv6=yes interface-name="ether1" system-description="MikroTik
+      RouterOS 7.15.1 (stable) 2024-06-07 12:49:11 RB450Gx4" system-caps=bridge,router
+      system-caps-enabled=router
 
-        '
-      - " 0 interface=ether2,bridge_local mac-address=12:34:56:78:90:AB identity=\"\
-        CLEAR\" platform=\"MikroTik\" version=\"6.49.14 (stable)\" unpack=none age=37s\
-        \ uptime=1d8h37m17s software-id=\"AAAA-BBBB\" board=\"RB750UPr2\" interface-name=\"\
-        ether1\" system-description=\"MikroTik RouterOS 6.49.14 (stable) RB750UPr2\"\
-        \ system-caps=bridge,router system-caps-enabled=router\n\n 1 interface=ether10,bridge_255_mgmt\
-        \ address=1.2.4.5 address4=1.2.4.5 address6=2001:0db8:11a3:09d7:1f34:8a2e:07a0:765d\
-        \ mac-address=12:34:56:78:90:AC identity=\"Device_1\" platform=\"MikroTik\"\
-        \ version=\"7.15.1 (stable) 2024-06-07 12:49:11\" unpack=none age=7s uptime=1d8h37m20s\
-        \ software-id=\"CCCC-DDDD\" board=\"RB450Gx4\" ipv6=yes interface-name=\"\
-        ether1\" system-description=\"MikroTik RouterOS 7.15.1 (stable) 2024-06-07\
-        \ 12:49:11 RB450Gx4\" system-caps=bridge,router\n   system-caps-enabled=router\n\
-        \n 2 interface=eth1-vlan255,bridge_255_mgmt mac-address=12:34:56:78:90:AD\
-        \ identity=\"Device-2\" platform=\"MikroTik\" version=\"6.43.14 (long-term)\"\
-        \ unpack=none age=23s uptime=48w3d9h41m36s software-id=\"AAAA-ZZZZ\" board=\"\
-        RB1100x4\" ipv6=no interface-name=\"bridge_vlan255\" system-caps=\"\" system-caps-enabled=\"\
-        \"\n"
+      '
+    - " 0 interface=ether2,bridge_local mac-address=12:34:56:78:90:AB identity=\"\
+      CLEAR\" platform=\"MikroTik\" version=\"6.49.14 (stable)\" unpack=none age=37s\
+      \ uptime=1d8h37m17s software-id=\"AAAA-BBBB\" board=\"RB750UPr2\" interface-name=\"\
+      ether1\" system-description=\"MikroTik RouterOS 6.49.14 (stable) RB750UPr2\"\
+      \ system-caps=bridge,router system-caps-enabled=router\n\n 1 interface=ether10,bridge_255_mgmt\
+      \ address=1.2.4.5 address4=1.2.4.5 address6=2001:0db8:11a3:09d7:1f34:8a2e:07a0:765d\
+      \ mac-address=12:34:56:78:90:AC identity=\"Device_1\" platform=\"MikroTik\"\
+      \ version=\"7.15.1 (stable) 2024-06-07 12:49:11\" unpack=none age=7s uptime=1d8h37m20s\
+      \ software-id=\"CCCC-DDDD\" board=\"RB450Gx4\" ipv6=yes interface-name=\"ether1\"\
+      \ system-description=\"MikroTik RouterOS 7.15.1 (stable) 2024-06-07 12:49:11\
+      \ RB450Gx4\" system-caps=bridge,router\n   system-caps-enabled=router\n\n 2\
+      \ interface=eth1-vlan255,bridge_255_mgmt mac-address=12:34:56:78:90:AD identity=\"\
+      Device-2\" platform=\"MikroTik\" version=\"6.43.14 (long-term)\" unpack=none\
+      \ age=23s uptime=48w3d9h41m36s software-id=\"AAAA-ZZZZ\" board=\"RB1100x4\"\
+      \ ipv6=no interface-name=\"bridge_vlan255\" system-caps=\"\" system-caps-enabled=\"\
+      \"\n"
   ip route print detail:
     output: "Flags: X - disabled, A - active, D - dynamic, C - connect, S - static,\
       \ r - rip, b - bgp, o - ospf, m - mme, B - blackhole, U - unreachable, P - prohibit\n\
@@ -690,19 +688,19 @@ commands:
     help: execute the command "routing ospf interface print terse"
     prompt: '[admin@{base_prompt}] >'
     output_variants:
-      - '0 D address=1.1.1.1%vlan11@vlan975@sfp-sfpplus1 area=INET-v2 state=ptp network-type=ptp
-        cost=1400 use-bfd=no retransmit-interval=5s transmit-delay=1s hello-interval=1s
-        dead-interval=4s
+    - '0 D address=1.1.1.1%vlan11@vlan975@sfp-sfpplus1 area=INET-v2 state=ptp network-type=ptp
+      cost=1400 use-bfd=no retransmit-interval=5s transmit-delay=1s hello-interval=1s
+      dead-interval=4s
 
-        1 D address=1.1.1.1%vlan10@vlan975@sfp-sfpplus1 area=MGMT-v2 state=ptp network-type=ptp
-        cost=10 use-bfd=no retransmit-interval=5s transmit-delay=1s hello-interval=10s
-        dead-interval=40s
+      1 D address=1.1.1.1%vlan10@vlan975@sfp-sfpplus1 area=MGMT-v2 state=ptp network-type=ptp
+      cost=10 use-bfd=no retransmit-interval=5s transmit-delay=1s hello-interval=10s
+      dead-interval=40s
 
-        2 D address=1.1.1.1%Lo0 area=MGMT-v2 state=passive network-type=broadcast
-        cost=1 priority=128 use-bfd=no retransmit-interval=5s transmit-delay=1s hello-interval=10s
-        dead-interval=40s
+      2 D address=1.1.1.1%Lo0 area=MGMT-v2 state=passive network-type=broadcast cost=1
+      priority=128 use-bfd=no retransmit-interval=5s transmit-delay=1s hello-interval=10s
+      dead-interval=40s
 
-        '
+      '
   routing ospf neighbor print:
     output: " 0 instance=default router-id=89.188.172.2 address=89.188.172.81 interface=vlan68\
       \ priority=128 dr-address=0.0.0.0 backup-dr-address=0.0.0.0 state=\"Full\" state-changes=5\
@@ -731,31 +729,31 @@ commands:
     help: execute the command "system resource print"
     prompt: '[admin@{base_prompt}] >'
     output_variants:
-      - "                   uptime: 1d6h22m\n                  version: 6.48.7 (long-term)\n\
-        \               build-time: May/23/2023 05:27:08\n         factory-software:\
-        \ 6.44.6\n              free-memory: 45.5MiB\n             total-memory: 64.0MiB\n\
-        \                      cpu: MIPS 24Kc V7.4\n                cpu-count: 1\n\
-        \            cpu-frequency: 650MHz\n                 cpu-load: 1%\n      \
-        \     free-hdd-space: 3428.0KiB\n          total-hdd-space: 16.0MiB\n  write-sect-since-reboot:\
-        \ 1970\n         write-sect-total: 77652\n               bad-blocks: 0%\n\
-        \        architecture-name: mipsbe\n               board-name: hEX PoE lite\n\
-        \                 platform: MikroTik\n"
-      - "\t\t\t\t   uptime: 5w3d20m51s\n                  version: 7.12.2 (stable)\n\
-        \               build-time: Dec/20/2023 08:41:00\n         factory-software:\
-        \ 7.1\n              free-memory: 36.7MiB\n             total-memory: 192.0MiB\n\
-        \                      cpu: Common\n                cpu-count: 2\n       \
-        \     cpu-frequency: 2294MHz\n                 cpu-load: 53%\n           free-hdd-space:\
-        \ 69.8MiB\n          total-hdd-space: 89.2MiB\n  write-sect-since-reboot:\
-        \ 213432\n         write-sect-total: 213432\n        architecture-name: x86_64\n\
-        \               board-name: CHR\n                 platform: MikroTik\n"
-      - "                   uptime: 10w2d6h21m59s\n                  version: 7.12.2\
-        \ (stable)\n               build-time: Dec/20/2023 08:41:00\n         factory-software:\
-        \ 7.6\n              free-memory: 3704.1MiB\n             total-memory: 4032.0MiB\n\
-        \                      cpu: ARM64\n                cpu-count: 4\n        \
-        \         cpu-load: 36%\n           free-hdd-space: 104.4MiB\n          total-hdd-space:\
-        \ 128.0MiB\n  write-sect-since-reboot: 54120\n         write-sect-total: 291965\n\
-        \               bad-blocks: 0%\n        architecture-name: arm64\n       \
-        \        board-name: CCR2004-1G-12S+2XS\n                 platform: MikroTik\n"
+    - "                   uptime: 1d6h22m\n                  version: 6.48.7 (long-term)\n\
+      \               build-time: May/23/2023 05:27:08\n         factory-software:\
+      \ 6.44.6\n              free-memory: 45.5MiB\n             total-memory: 64.0MiB\n\
+      \                      cpu: MIPS 24Kc V7.4\n                cpu-count: 1\n \
+      \           cpu-frequency: 650MHz\n                 cpu-load: 1%\n         \
+      \  free-hdd-space: 3428.0KiB\n          total-hdd-space: 16.0MiB\n  write-sect-since-reboot:\
+      \ 1970\n         write-sect-total: 77652\n               bad-blocks: 0%\n  \
+      \      architecture-name: mipsbe\n               board-name: hEX PoE lite\n\
+      \                 platform: MikroTik\n"
+    - "\t\t\t\t   uptime: 5w3d20m51s\n                  version: 7.12.2 (stable)\n\
+      \               build-time: Dec/20/2023 08:41:00\n         factory-software:\
+      \ 7.1\n              free-memory: 36.7MiB\n             total-memory: 192.0MiB\n\
+      \                      cpu: Common\n                cpu-count: 2\n         \
+      \   cpu-frequency: 2294MHz\n                 cpu-load: 53%\n           free-hdd-space:\
+      \ 69.8MiB\n          total-hdd-space: 89.2MiB\n  write-sect-since-reboot: 213432\n\
+      \         write-sect-total: 213432\n        architecture-name: x86_64\n    \
+      \           board-name: CHR\n                 platform: MikroTik\n"
+    - "                   uptime: 10w2d6h21m59s\n                  version: 7.12.2\
+      \ (stable)\n               build-time: Dec/20/2023 08:41:00\n         factory-software:\
+      \ 7.6\n              free-memory: 3704.1MiB\n             total-memory: 4032.0MiB\n\
+      \                      cpu: ARM64\n                cpu-count: 4\n          \
+      \       cpu-load: 36%\n           free-hdd-space: 104.4MiB\n          total-hdd-space:\
+      \ 128.0MiB\n  write-sect-since-reboot: 54120\n         write-sect-total: 291965\n\
+      \               bad-blocks: 0%\n        architecture-name: arm64\n         \
+      \      board-name: CCR2004-1G-12S+2XS\n                 platform: MikroTik\n"
   tool profile:
     output: 'NAME                    CPU        USAGE
 

--- a/simnos/plugins/nos/platforms_yaml/mikrotik_routeros.yaml
+++ b/simnos/plugins/nos/platforms_yaml/mikrotik_routeros.yaml
@@ -257,3 +257,540 @@ commands:
       avg-rtt=67ms max-rtt=157ms\n"
     help: execute the command "ping"
     prompt: "[admin@{base_prompt}] >"
+  interface bonding print detail:
+    output: "Flags: X - disabled, R - running\n 0  R ;;; To Cisco Te1/3 - Te1/4\n\
+      \      name=\"bond1\" mtu=9000 mac-address=4C:5E:0C:14:3F:9D arp=enabled arp-timeout=auto\
+      \ slaves=sfp-sfpplus7,sfp-sfpplus8 mode=802.3ad primary=none link-monitoring=mii\
+      \ arp-interval=100ms arp-ip-targets=\"\" mii-interval=100ms down-delay=0ms up-delay=0ms\
+      \ lacp-rate=1sec transmit-hash-policy=layer-3-and-4 min-links=0\n"
+    help: execute the command "interface bonding print detail"
+    prompt: '[admin@{base_prompt}] >'
+    output_variants:
+      - "Flags: X - disabled; R - running\n 0  R ;;; Link to Mikrotik\n      name=\"\
+        bond1\" mtu=1500 mac-address=48:A9:8A:5D:24:05 arp=enabled arp-timeout=auto\
+        \ slaves=sfp-sfpplus9,sfp-sfpplus10 mode=802.3ad primary=none link-monitoring=mii\
+        \ arp-interval=100ms arp-ip-targets=\"\" mii-interval=100ms down-delay=0ms\
+        \ up-delay=0ms lacp-rate=30secs transmit-hash-policy=layer-2 min-links=0\n"
+      - "Flags: X - disabled; R - running\n 0  R ;;; Link to Mikrotik\nand other things\n\
+        \      name=\"bond1\" mtu=1500 mac-address=48:A9:8A:5D:24:05 arp=enabled arp-timeout=auto\
+        \ slaves=sfp-sfpplus9,sfp-sfpplus10 mode=802.3ad primary=none link-monitoring=mii\
+        \ arp-interval=100ms arp-ip-targets=\"\" mii-interval=100ms down-delay=0ms\
+        \ up-delay=0ms lacp-rate=30secs transmit-hash-policy=layer-2 min-links=0\n"
+  interface bridge host print terse without-paging:
+    output: '0 D E  mac-address=11:22:33:44:55:01 interface=ether4 bridge=lan-bridge
+      on-interface=ether4
+
+      1 D E  mac-address=11:22:33:44:55:02 interface=ether3 bridge=lan-bridge on-interface=ether3
+
+      2 DLE  mac-address=11:22:33:44:55:03 interface=lan-bridge bridge=lan-bridge
+      on-interface=lan-bridge
+
+      3 DL   mac-address=11:22:33:44:55:04 interface=ether4 bridge=lan-bridge on-interface=ether4
+
+      4  I   mac-address=11:22:33:44:55:05 interface=lan-bridge bridge=lan-bridge
+
+      5  I   comment=test comment mac-address=11:22:33:44:55:06 interface=lan-bridge
+      bridge=lan-bridge
+
+      6 XI   mac-address=11:22:33:44:55:07 interface=lan-bridge bridge=lan-bridge
+
+      7 XI   mac-address=11:22:33:44:55:08 vid=123 interface=lan-bridge bridge=lan-bridge
+
+      '
+    help: execute the command "interface bridge host print terse without-paging"
+    prompt: '[admin@{base_prompt}] >'
+  interface print brief:
+    output: "Flags: D - dynamic, X - disabled, R - running, S - slave\n #     NAME\
+      \                                TYPE       ACTUAL-MTU L2MTU  MAX-L2MTU MAC-ADDRESS\n\
+      \ 0     ether1                              ether            1500  1598    \
+      \   2028 12:34:56:78:90:AA\n 1 D   ether2                              ether\
+      \            1500  1598            12:34:56:78:90:AB\n 2  R  ether3        \
+      \                      ether            1500                  12:34:56:78:90:AC\n\
+      \ 3   S ether4                              ether            1500  1598\n 4\
+      \ DR  ether5                              ether            1500\n 5  RS ether6\
+      \                              ether            1500  1598       2028 12:34:56:78:90:AD\n\
+      \ 6 D S lte1                                lte              1500  1598    \
+      \   2028 12:34:56:78:90:AE\n 7 DRS pptp-out1                           pptp-out\
+      \         1450  1598       2028\n"
+    help: execute the command "interface print brief"
+    prompt: '[admin@{base_prompt}] >'
+  interface print detail:
+    output: "Flags: D - dynamic, X - disabled, R - running, S - slave\n 0     name=\"\
+      ether1\" default-name=\"ether1\" type=\"ether\" mtu=1500 actual-mtu=1500 l2mtu=1598\
+      \ max-l2mtu=2028 mac-address=12:34:56:78:90:AA last-link-down-time=jul/09/2023\
+      \ 07:18:33 last-link-up-time=jul/09/2023 07:18:42 link-downs=20\n\n 1 D   name=\"\
+      ether2\" default-name=\"ether2\" type=\"ether\" mtu=1500 actual-mtu=1500 l2mtu=1598\
+      \ max-l2mtu=2028 mac-address=12:34:56:78:90:AB last-link-down-time=jul/09/2023\
+      \ 07:18:34 last-link-up-time=jul/09/2023 07:18:43 link-downs=20\n\n 2  R  name=\"\
+      ether3\" default-name=\"ether3\" type=\"ether\" mtu=1500 actual-mtu=1500 l2mtu=1598\
+      \ max-l2mtu=2028 mac-address=12:34:56:78:90:AC link-downs=0\n\n 3   S name=\"\
+      ether4\" default-name=\"ether4\" type=\"ether\" mtu=1500 actual-mtu=1500 l2mtu=1598\
+      \ max-l2mtu=2028 mac-address=12:34:56:78:90:AD link-downs=0\n\n 4 DR  name=\"\
+      ether5\" default-name=\"ether5\" type=\"ether\" mtu=1500 actual-mtu=1500 l2mtu=1598\
+      \ max-l2mtu=2028 mac-address=12:34:56:78:90:AE link-downs=0\n\n 5  RS name=\"\
+      ether6\" default-name=\"ether6\" type=\"ether\" mtu=1500 actual-mtu=1500 l2mtu=1598\
+      \ max-l2mtu=2028 mac-address=12:34:56:78:90:AF link-downs=0\n\n 6 D S name=\"\
+      lte1\" type=\"lte\" mtu=1500 actual-mtu=1500 mac-address=12:34:56:78:90:BA last-link-down-time=jul/21/2023\
+      \ 07:47:40 last-link-up-time=jul/21/2023 07:47:46 link-downs=114\n\n 7 DRS ;;;\
+      \ very very long\nmultiline description \n       name=\"pptp-out1\" type=\"\
+      pptp-out\" mtu=1450 actual-mtu=1450 last-link-down-time=jul/21/2023 07:47:03\
+      \ last-link-up-time=jul/21/2023 07:47:56 link-downs=304\n \n 8  RS ;;; Free\
+      \ Wi-Fi HTTPS\n       name=\"pptp-to-AH1100-HS\" type=\"pptp-out\" mtu=1596\
+      \ actual-mtu=1596 last-link-down-time=nov/03/1970 12:24:10 last-link-up-time=nov/03/1970\
+      \ 12:24:10 link-downs=38 \n"
+    help: execute the command "interface print detail"
+    prompt: '[admin@{base_prompt}] >'
+    output_variants:
+      - "Flags: D - dynamic; X - disabled, R - running; S - slave; P - passthrough\n\
+        \ 0  R   ;;; Management Port - 4G OOB\n        name=\"ether1\" default-name=\"\
+        ether1\" type=\"ether\" mtu=1500 actual-mtu=1500 l2mtu=1600 max-l2mtu=9586\
+        \ mac-address=AA:BB:CC:11:22:33 ifname=\"eth0\" ifindex=7 id=1 last-link-down-time=2024-10-08\
+        \ 11:14:27 last-link-up-time=2024-10-08 11:14:36 link-downs=166\n\n 1  R \
+        \  ;;; Uplink\n        name=\"sfp-sfpplus1\" default-name=\"sfp-sfpplus1\"\
+        \ type=\"ether\" mtu=9216 actual-mtu=9216 l2mtu=9216 max-l2mtu=9578 mac-address=AA:BB:CC:11:22:33\
+        \ ifname=\"eth1\" ifindex=9 id=2 last-link-up-time=2024-07-23 10:13:23 link-downs=0\n\
+        \n 2  X   ;;; Spare Optic\n        name=\"sfp-sfpplus2\" default-name=\"sfp-sfpplus2\"\
+        \ type=\"ether\" mtu=9216 actual-mtu=9216 l2mtu=9216 max-l2mtu=9578 mac-address=AA:BB:CC:11:22:33\
+        \ ifname=\"eth2\" ifindex=10 id=3 link-downs=0\n\n 3  X   name=\"sfp-sfpplus3\"\
+        \ default-name=\"sfp-sfpplus3\" type=\"ether\" mtu=9216 actual-mtu=9216 l2mtu=9216\
+        \ max-l2mtu=9578 mac-address=AA:BB:CC:11:22:33 ifname=\"eth3\" ifindex=11\
+        \ id=4 link-downs=0\n\n 4  X   name=\"sfp-sfpplus4\" default-name=\"sfp-sfpplus4\"\
+        \ type=\"ether\" mtu=9216 actual-mtu=9216 l2mtu=9216 max-l2mtu=9578 mac-address=AA:BB:CC:11:22:33\
+        \ ifname=\"eth4\" ifindex=12 id=5 link-downs=0\n\n 5  X   name=\"sfp-sfpplus5\"\
+        \ default-name=\"sfp-sfpplus5\" type=\"ether\" mtu=9216 actual-mtu=9216 l2mtu=9216\
+        \ max-l2mtu=9578 mac-address=AA:BB:CC:11:22:33 ifname=\"eth5\" ifindex=13\
+        \ id=6 link-downs=0\n\n 6  X   name=\"sfp-sfpplus6\" default-name=\"sfp-sfpplus6\"\
+        \ type=\"ether\" mtu=9216 actual-mtu=9216 l2mtu=9216 max-l2mtu=9578 mac-address=AA:BB:CC:11:22:33\
+        \ ifname=\"eth6\" ifindex=14 id=7 link-downs=0\n\n 7  X   name=\"sfp-sfpplus7\"\
+        \ default-name=\"sfp-sfpplus7\" type=\"ether\" mtu=9216 actual-mtu=9216 l2mtu=9216\
+        \ max-l2mtu=9578 mac-address=AA:BB:CC:11:22:33 ifname=\"eth7\" ifindex=15\
+        \ id=8 link-downs=0\n\n 8  X   name=\"sfp-sfpplus8\" default-name=\"sfp-sfpplus8\"\
+        \ type=\"ether\" mtu=9216 actual-mtu=9216 l2mtu=9216 max-l2mtu=9578 mac-address=AA:BB:CC:11:22:33\
+        \ ifname=\"eth8\" ifindex=16 id=9 link-downs=0\n\n 9  RS  ;;; Link to\n  \
+        \      name=\"sfp-sfpplus9\" default-name=\"sfp-sfpplus9\" type=\"ether\"\
+        \ mtu=9216 actual-mtu=9216 l2mtu=9216 max-l2mtu=9578 mac-address=AA:BB:CC:11:22:33\
+        \ ifname=\"eth9\" ifindex=17 id=10 last-link-down-time=2024-08-23 12:53:56\
+        \ last-link-up-time=2024-08-23 12:53:56 link-downs=4\n\n10  RS  ;;; Link to\n\
+        \        name=\"sfp-sfpplus10\" default-name=\"sfp-sfpplus10\" type=\"ether\"\
+        \ mtu=9216 actual-mtu=9216 l2mtu=9216 max-l2mtu=9578 mac-address=AA:BB:CC:11:22:33\
+        \ ifname=\"eth10\" ifindex=18 id=11 last-link-down-time=2024-08-23 12:53:27\
+        \ last-link-up-time=2024-08-23 12:53:55 link-downs=5\n\n11  R   ;;; Cust\n\
+        \        name=\"sfp-sfpplus11\" default-name=\"sfp-sfpplus11\" type=\"ether\"\
+        \ mtu=9216 actual-mtu=9216 l2mtu=9216 max-l2mtu=9578 mac-address=AA:BB:CC:11:22:33\
+        \ ifname=\"eth11\" ifindex=19 id=12 last-link-down-time=2024-08-29 20:57:53\
+        \ last-link-up-time=2024-09-19 23:00:35 link-downs=1\n\n12  X   ;;; Cust\n\
+        \        name=\"sfp-sfpplus12\" default-name=\"sfp-sfpplus12\" type=\"ether\"\
+        \ mtu=9216 actual-mtu=9216 l2mtu=9216 max-l2mtu=9578 mac-address=AA:BB:CC:11:22:33\
+        \ ifname=\"eth12\" ifindex=20 id=13 link-downs=0\n\n13  X   name=\"sfp28-1\"\
+        \ default-name=\"sfp28-1\" type=\"ether\" mtu=9216 actual-mtu=9216 l2mtu=9216\
+        \ max-l2mtu=9578 mac-address=AA:BB:CC:11:22:33 ifname=\"eth13\" ifindex=21\
+        \ id=14 link-downs=0\n\n14  X   name=\"sfp28-2\" default-name=\"sfp28-2\"\
+        \ type=\"ether\" mtu=9216 actual-mtu=9216 l2mtu=9216 max-l2mtu=9578 mac-address=AA:BB:CC:11:22:33\
+        \ ifname=\"eth14\" ifindex=22 id=15 link-downs=0\n\n15  R   ;;; Loopback\n\
+        \        name=\"Lo0\" type=\"bridge\" mtu=auto actual-mtu=1500 l2mtu=65535\
+        \ mac-address=AA:BB:CC:11:22:33 ifname=\"br0\" ifindex=24 id=23 last-link-up-time=2024-07-23\
+        \ 10:13:19 link-downs=0\n\n16  R   ;;; INET Loopback\n        name=\"Lo1\"\
+        \ type=\"bridge\" mtu=auto actual-mtu=1500 l2mtu=65535 vrf=INET mac-address=AA:BB:CC:11:22:33\
+        \ ifname=\"br1\" ifindex=36 id=27 last-link-up-time=2024-07-23 10:19:01 link-downs=0\n\
+        \n17  R   ;;; Link to\n        name=\"bond1\" type=\"bond\" mtu=1500 actual-mtu=1500\
+        \ l2mtu=9216 mac-address=AA:BB:CC:11:22:33 ifname=\"bond24\" ifindex=23 id=24\
+        \ last-link-down-time=2024-08-23 12:53:27 last-link-up-time=2024-08-23 12:53:55\
+        \ link-downs=3\n\n18  R   name=\"pppoe-out1\" type=\"pppoe-out\" mtu=1400\
+        \ actual-mtu=1400 ifname=\"ppp25889\" ifindex=25948 id=20 last-link-down-time=2024-10-08\
+        \ 12:36:57 last-link-up-time=2024-10-08 12:39:16 link-downs=7208\n\n19  R\
+        \   ;;; MGMT\n        name=\"vlan1@bond1\" type=\"vlan\" mtu=1574 actual-mtu=1574\
+        \ l2mtu=9212 mac-address=AA:BB:CC:11:22:33 ifname=\"vlan25\" ifindex=27 id=25\
+        \ last-link-down-time=2024-08-23 12:53:27 last-link-up-time=2024-08-23 12:53:55\
+        \ link-downs=3\n\n20  R   ;;; INET\n        name=\"vlan2@bond1\" type=\"vlan\"\
+        \ mtu=1574 actual-mtu=1574 l2mtu=9212 vrf=INET mac-address=AA:BB:CC:11:22:33\
+        \ ifname=\"vlan26\" ifindex=28 id=26 last-link-down-time=2024-08-23 12:53:27\
+        \ last-link-up-time=2024-08-23 12:53:55 link-downs=3\n\n21  R   ;;; MGMT Uplink\
+        \ YDCE-M1\n        name=\"vlan10@vlan975@sfp-sfpplus1\" type=\"vlan\" mtu=1574\
+        \ actual-mtu=1574 l2mtu=9208 mac-address=AA:BB:CC:11:22:33 ifname=\"vlan22\"\
+        \ ifindex=33 id=22 last-link-up-time=2024-07-23 10:13:23 link-downs=0\n\n\
+        22  R   ;;; INET: IX\n        name=\"vlan11@vlan975@sfp-sfpplus1\" type=\"\
+        vlan\" mtu=1500 actual-mtu=1500 l2mtu=9208 vrf=INET mac-address=AA:BB:CC:11:22:33\
+        \ ifname=\"vlan21\" ifindex=31 id=21 last-link-up-time=2024-07-23 10:13:23\
+        \ link-downs=0\n\n23  R   ;;; INET: IX\n        name=\"vlan12@vlan975@sfp-sfpplus1\"\
+        \ type=\"vlan\" mtu=1500 actual-mtu=1500 l2mtu=9208 vrf=INET mac-address=AA:BB:CC:11:22:33\
+        \ ifname=\"vlan29\" ifindex=38 id=29 last-link-up-time=2024-07-23 11:45:31\
+        \ link-downs=0\n\n24  R   ;;; INET: IX\n        name=\"vlan111@sfp-sfpplus1\"\
+        \ type=\"vlan\" mtu=1500 actual-mtu=1500 l2mtu=9212 vrf=INET mac-address=AA:BB:CC:11:22:33\
+        \ ifname=\"vlan18\" ifindex=26 id=18 last-link-up-time=2024-07-23 10:13:23\
+        \ link-downs=0\n\n25  R   ;;; Intercap\n        name=\"vlan975@sfp-sfpplus1\"\
+        \ type=\"vlan\" mtu=1500 actual-mtu=1500 l2mtu=9212 mac-address=AA:BB:CC:11:22:33\
+        \ ifname=\"vlan16\" ifindex=25 id=16 last-link-up-time=2024-07-23 10:13:23\
+        \ link-downs=0\n\n26  R   name=\"vlan4050@sfp-sfpplus11\" type=\"vlan\" mtu=9212\
+        \ actual-mtu=9212 l2mtu=9212 vrf=INET mac-address=AA:BB:CC:11:22:33 ifname=\"\
+        vlan30\" ifindex=239 id=30 last-link-down-time=2024-08-29 20:57:53 last-link-up-time=2024-09-19\
+        \ 23:00:35 link-downs=1"
+  interface vlan print detail:
+    output: "Flags: X - disabled, R - running\n 0 R ;;; MGMT\n     name=\"vlan1@bond1\"\
+      \ mtu=1574 l2mtu=9212 mac-address=AA:BB:CC:11:22:33 arp=enabled arp-timeout=auto\
+      \ loop-protect=default loop-protect-status=off loop-protect-send-interval=5s\
+      \ loop-protect-disable-time=5m vlan-id=1 interface=bond1 use-service-tag=no\n\
+      \n 1 R ;;; INET\n     name=\"vlan2@bond1\" mtu=1574 l2mtu=9212 mac-address=AA:BB:CC:11:22:33\
+      \ arp=enabled arp-timeout=auto loop-protect=default loop-protect-status=off\
+      \ loop-protect-send-interval=5s loop-protect-disable-time=5m vlan-id=2 interface=bond1\
+      \ use-service-tag=no\n\n 2 R ;;; MGMT\n     name=\"vlan10@vlan975@sfp-sfpplus1\"\
+      \ mtu=1574 l2mtu=9208 mac-address=AA:BB:CC:11:22:33 arp=enabled arp-timeout=auto\
+      \ loop-protect=default loop-protect-status=off loop-protect-send-interval=5s\
+      \ loop-protect-disable-time=5m vlan-id=10 interface=vlan975@sfp-sfpplus1 use-service-tag=no\n\
+      \n 3 R ;;; INET\n     name=\"vlan11@vlan975@sfp-sfpplus1\" mtu=1500 l2mtu=9208\
+      \ mac-address=AA:BB:CC:11:22:33 arp=enabled arp-timeout=auto loop-protect=default\
+      \ loop-protect-status=off loop-protect-send-interval=5s loop-protect-disable-time=5m\
+      \ vlan-id=11 interface=vlan975@sfp-sfpplus1 use-service-tag=no\n\n 4 R ;;; INET\n\
+      \     name=\"vlan12@vlan975@sfp-sfpplus1\" mtu=1500 l2mtu=9208 mac-address=AA:BB:CC:11:22:33\
+      \ arp=enabled arp-timeout=auto loop-protect=default loop-protect-status=off\
+      \ loop-protect-send-interval=5s loop-protect-disable-time=5m vlan-id=12 interface=vlan975@sfp-sfpplus1\
+      \ use-service-tag=no\n\n 5 R ;;; INET\n     name=\"vlan111@sfp-sfpplus1\" mtu=1500\
+      \ l2mtu=9212 mac-address=AA:BB:CC:11:22:33 arp=enabled arp-timeout=auto loop-protect=default\
+      \ loop-protect-status=off loop-protect-send-interval=5s loop-protect-disable-time=5m\
+      \ vlan-id=111 interface=sfp-sfpplus1 use-service-tag=no\n\n 6 R ;;; Intercap\n\
+      \     name=\"vlan975@sfp-sfpplus1\" mtu=1500 l2mtu=9212 mac-address=AA:BB:CC:11:22:33\
+      \ arp=enabled arp-timeout=auto loop-protect=default loop-protect-status=off\
+      \ loop-protect-send-interval=5s loop-protect-disable-time=5m vlan-id=975 interface=sfp-sfpplus1\
+      \ use-service-tag=no\n\n 7 R name=\"vlan4050@sfp-sfpplus11\" mtu=9212 l2mtu=9212\
+      \ mac-address=AA:BB:CC:11:22:33 arp=enabled arp-timeout=auto loop-protect=default\
+      \ loop-protect-status=off loop-protect-send-interval=5s loop-protect-disable-time=5m\
+      \ vlan-id=4050 interface=sfp-sfpplus11 use-service-tag=no\n"
+    help: execute the command "interface vlan print detail"
+    prompt: '[admin@{base_prompt}] >'
+    output_variants:
+      - "Flags: X - disabled, R - running\n 0 R ;;; CUST\n     name=\"vlan1@vlan602@interface\"\
+        \ mtu=1574 l2mtu=8992 mac-address=AA:BB:CC:11:22:33 arp=enabled arp-timeout=auto\
+        \ loop-protect=default loop-protect-status=off loop-protect-send-interval=5s\
+        \ loop-protect-disable-time=5m vlan-id=1 interface=vlan602@interface use-service-tag=no\n\
+        \n 1 R ;;; PPPoE Termination on BNGs\n     name=\"vlan6@bond1\" mtu=1508 l2mtu=8996\
+        \ mac-address=AA:BB:CC:11:22:33 arp=enabled arp-timeout=auto loop-protect=default\
+        \ loop-protect-status=off loop-protect-send-interval=5s loop-protect-disable-time=5m\
+        \ vlan-id=6 interface=bond1 use-service-tag=no\n\n 2 R ;;; Cust\n     name=\"\
+        vlan10@vlan975@interface\" mtu=1574 l2mtu=8992 mac-address=AA:BB:CC:11:22:33\
+        \ arp=enabled arp-timeout=auto loop-protect=default loop-protect-status=off\
+        \ loop-protect-send-interval=5s loop-protect-disable-time=5m vlan-id=10 interface=vlan975@interface\
+        \ use-service-tag=no\n\n 3 R ;;; test pppoe\n     name=\"vlan11@bond1\" mtu=1500\
+        \ l2mtu=8996 mac-address=AA:BB:CC:11:22:33 arp=enabled arp-timeout=auto loop-protect=default\
+        \ loop-protect-status=off loop-protect-send-interval=5s loop-protect-disable-time=5m\
+        \ vlan-id=11 interface=bond1 use-service-tag=no\n\n 4 R ;;; Intercap\n   \
+        \  name=\"vlan11@vlan975@interface\" mtu=1574 l2mtu=8992 mac-address=AA:BB:CC:11:22:33\
+        \ arp=enabled arp-timeout=auto loop-protect=default loop-protect-status=off\
+        \ loop-protect-send-interval=5s loop-protect-disable-time=5m vlan-id=11 interface=vlan975@interface\
+        \ use-service-tag=no\n\n 5 R ;;; Intercap\n     name=\"vlan12@vlan975@interface\"\
+        \ mtu=1574 l2mtu=8992 mac-address=AA:BB:CC:11:22:33 arp=enabled arp-timeout=auto\
+        \ loop-protect=default loop-protect-status=off loop-protect-send-interval=5s\
+        \ loop-protect-disable-time=5m vlan-id=12 interface=vlan975@interface use-service-tag=no\n\
+        \n 6 R ;;; Carrier\n     name=\"vlan60@interface\" mtu=1600 l2mtu=8996 mac-address=AA:BB:CC:11:22:33\
+        \ arp=enabled arp-timeout=auto loop-protect=default loop-protect-status=off\
+        \ loop-protect-send-interval=5s loop-protect-disable-time=5m vlan-id=60 interface=sfp-sfpplus1\
+        \ use-service-tag=no\n\n 7 R ;;; Carrier\n     name=\"vlan60@bond1\" mtu=1600\
+        \ l2mtu=8996 mac-address=AA:BB:CC:11:22:33 arp=enabled arp-timeout=auto loop-protect=default\
+        \ loop-protect-status=off loop-protect-send-interval=5s loop-protect-disable-time=5m\
+        \ vlan-id=60 interface=bond1 use-service-tag=no\n"
+      - "Flags: X - disabled, R - running\n 0 R ;;; CUST\nwho has a multiline comment\n\
+        \     name=\"vlan1@vlan602@interface\" mtu=1574 l2mtu=8992 mac-address=AA:BB:CC:11:22:33\
+        \ arp=enabled arp-timeout=auto loop-protect=default loop-protect-status=off\
+        \ loop-protect-send-interval=5s loop-protect-disable-time=5m vlan-id=1 interface=vlan602@interface\
+        \ use-service-tag=no\n"
+  interface wireguard peers print terse without-paging:
+    output: '0 interface=wg1 name=peer2 public-key=dcKiJ0TpLjtSWZh3G0ILJ9cL56fTIfHBAsZsXdDIlFM=
+      private-key= endpoint-address= endpoint-port=0 current-endpoint-address=192.168.93.254
+      current-endpoint-port=50610 allowed-address=192.168.100.0/24 preshared-key=
+      client-address=192.168.100.2/32 client-endpoint= rx=180 tx=92 last-handshake=20s
+
+      1 interface=wg1 name=peer2 public-key=dcKiJ0TpLjtSWZh3G0ILJ9cL56fTIfHBAsZsXdDIlFM=
+      private-key= endpoint-address= endpoint-port=0 current-endpoint-address=192.168.93.254
+      current-endpoint-port=50610 allowed-address=192.168.100.0/24 preshared-key=
+      client-address=192.168.100.2/32 client-endpoint= rx=5.3KiB tx=1472 last-handshake=1m45s'
+    help: execute the command "interface wireguard peers print terse without-paging"
+    prompt: '[admin@{base_prompt}] >'
+  interface wireguard print terse without-paging:
+    output: '0 R name=wg1 mtu=1420 listen-port=13231 private-key=+NLZfYaDm6qMfroVg6wf0pZ+0PyriGCd8oO/HkyQqFg=
+      public-key=oeyOeBGeRb8UfvpqFT8XkaG1euGU0viW7Ep4fZEQKyM=
+
+      1 R name=wg2 mtu=1420 listen-port=13232 private-key=YEvXxfzV5w8hiS4qZ4keoCe2gsYBJWuOxS3V38rpWH8=
+      public-key=LZoLYLOGTqe2p+S3jcdNAKABYEEFRChELB1p34H2STY='
+    help: execute the command "interface wireguard print terse without-paging"
+    prompt: '[admin@{base_prompt}] >'
+  ip arp print:
+    output: "Flags: X - disabled, I - invalid, H - DHCP, D - dynamic, P - published,\
+      \ C - complete\n #    ADDRESS         MAC-ADDRESS       INTERFACE\n 0 DC 10.160.1.230\
+      \    12:34:56:78:90:AA ether2\n 1    10.152.1.230    12:34:56:78:90:AB ether5\n\
+      \ 2    10.152.1.231    12:34:56:78:90:AC\n 3    10.152.1.232               \
+      \       ether4\n 4 DC 10.152.1.233\n"
+    help: execute the command "ip arp print"
+    prompt: '[admin@{base_prompt}] >'
+  ip arp print terse without-paging:
+    output: " 0 DC address=10.160.1.230 mac-address=12:34:56:78:90:AA interface=ether2_BOX\
+      \ published=no\n 1    address=10.152.1.230 mac-address=12:34:56:78:90:AB interface=ether5_KFCcisco\
+      \ published=no\n"
+    help: execute the command "ip arp print terse without-paging"
+    prompt: '[admin@{base_prompt}] >'
+  ip dhcp-server lease print:
+    output: "Flags: X - disabled, R - radius, D - dynamic, B - blocked\n #   ADDRESS\
+      \          MAC-ADDRESS        HOST-NAME  SERVER         RATE-LIMIT  STATUS \
+      \ LAST-SEEN\n 0   192.168.60.254                                 *1        \
+      \                 bound   35w13h13m15s\n 1 X 192.168.61.254                \
+      \      MikroTik   DHCPv4_Server              waiting never\n 1   192.168.62.254\
+      \   12:34:56:78:90:AA             DHCPv4_Server              waiting never\n\
+      \ 2 D 192.168.88.254   12:34:56:78:90:AB  MikroTik   DHCPv4_Server         \
+      \     waiting never\n"
+    help: execute the command "ip dhcp-server lease print"
+    prompt: '[admin@{base_prompt}] >'
+    output_variants:
+      - "Flags: D - DYNAMIC\nColumns: ADDRESS, MAC-ADDRESS, HOST-NAME, SERVER, STATUS,\
+        \ LAST-SEEN\n #   ADDRESS     MAC-ADDRESS        HOST-NAME    SERVER   STATUS\
+        \  LAST-SEEN\n0  D 10.0.1.94   BA:98:2C:BD:EA:47  raspberrypi  Clients  bound\
+        \   3m6s     \n1  D 10.0.1.99   DE:6E:70:C0:CC:B2  raspberrypi  Clients  bound\
+        \   2m48s    \n"
+  ip dhcp-server lease print terse without-paging:
+    output: " 0 D address=192.168.69.254 address-lists=\"\" server=*1 dhcp-option=\"\
+      \" status=conflict expires-after=6m59s last-seen=35w12h24m42s active-address=192.168.69.254\
+      \ active-server=*1 src-mac-address=12:34:56:78:90:AB\n 1   address=172.16.16.120\
+      \ mac-address=30:07:4D:F5:07:49 client-id=\"1:30:7:4d:f5:7:49\" address-lists=\"\
+      \" server=defconf dhcp-option=\"\" status=bound expires-after=8m55s last-seen=1m5s\
+      \ active-address=172.16.16.120 active-mac-address=30:07:4D:F5:07:49 active-client-id=\"\
+      1:30:7:4d:f5:7:49\" active-server=defconf host-name=\"Galaxy-S8\"\n"
+    help: execute the command "ip dhcp-server lease print terse without-paging"
+    prompt: '[admin@{base_prompt}] >'
+    output_variants:
+      - " 0   comment=UniFi1 address=10.124.3.199 mac-address=74:83:C2:36:5A:6E client-id=1:74:83:c2:36:5a:6e\
+        \ address-lists=\"\" server=dhcp1 dhcp-option=unifi status=bound expires-after=6m51s\
+        \ last-seen=3m9s active-address=10.164.1.199 active-mac-address=74:83:C2:36:5A:6E\
+        \ active-client-id=1:74:83:c2:36:5a:6e active-server=dhcp1 host-name=Unifi3B\
+        \ \n 1   comment=PC address=10.124.3.252 mac-address=00:50:56:88:80:EE client-id=1:0:50:56:88:80:ee\
+        \ address-lists=\"\" server=dhcp1 dhcp-option=\"\" status=bound expires-after=6m18s\
+        \ last-seen=3m42s active-address=10.164.1.252 active-mac-address=00:50:56:88:80:EE\
+        \ active-client-id=1:0:50:56:88:80:ee active-server=dhcp1 host-name=RSNC-CLIENT1-VM\
+        \ \n 2   comment=SPA address=10.124.3.222 mac-address=C4:0A:CB:BC:65:C8 address-lists=\"\
+        \" server=dhcp1 dhcp-option=\"\" status=bound expires-after=5m56s last-seen=4m4s\
+        \ active-address=10.164.1.222 active-mac-address=C4:0A:CB:BC:65:C8 active-client-id=1:c4:a:cb:bc:65:c8\
+        \ active-server=dhcp1 host-name=SPA122 \n 3 D address=10.0.1.56 mac-address=C2:39:B3:FA:81:D0\
+        \ client-id=1:c2:39:b3:fa:81:d0 address-lists= server=Clients dhcp-option=\
+        \ status=bound expires-after=2m38s last-seen=2m22s age=2h11m23s active-address=10.0.1.56\
+        \ active-mac-address=C2:39:B3:FA:81:D0 active-client-id=1:c2:39:b3:fa:81:d0\
+        \ active-server=Clients\n 4 D address=192.168.80.254 mac-address=AA:C1:AB:E3:F5:E8\
+        \ client-id=1:aa:c1:ab:e3:f5:e8 address-lists= server=dhcp1 dhcp-option= status=bound\
+        \ expires-after=16m59s last-seen=13m1s age=13m1s active-address=192.168.80.254\
+        \ active-mac-address=AA:C1:AB:E3:F5:E8 active-client-id=1:aa:c1:ab:e3:f5:e8\
+        \ active-server=dhcp1 class-id=udhcp 1.37.0"
+  ip dns cache print terse without-paging:
+    output: '0 type=A data=216.58.215.142 name=google.com ttl=1m44s
+
+      1 type=AAAA data=2a00:1450:4003:804::200e name=google.com ttl=1m24s'
+    help: execute the command "ip dns cache print terse without-paging"
+    prompt: '[admin@{base_prompt}] >'
+  ip firewall connection print terse without-paging:
+    output: '0 SAC protocol=tcp src-address=172.31.255.29 src-port=56454 dst-address=172.31.255.30
+      dst-port=22 reply-src-address=172.31.255.30 reply-src-port=22 reply-dst-address=172.31.255.29
+      reply-dst-port=56454 tcp-state=established timeout=23h59m52s orig-packets=520
+      orig-bytes=47 603 orig-fasttrack-packets=0 orig-fasttrack-bytes=0 repl-packets=363
+      repl-bytes=53 460 repl-fasttrack-packets=0 repl-fasttrack-bytes=0 orig-rate=1760bps
+      repl-rate=6.4kbps
+
+      1 S Cs protocol=icmp src-address=192.168.80.254 dst-address=216.58.215.142 reply-src-address=216.58.215.142
+      reply-dst-address=172.31.255.30 icmp-type=8 icmp-code=0 icmp-id=69 timeout=9s
+      orig-packets=7 269 orig-bytes=610 596 orig-fasttrack-packets=0 orig-fasttrack-bytes=0
+      repl-packets=7 269 repl-bytes=610 596 repl-fasttrack-packets=0 repl-fasttrack-bytes=0
+      orig-rate=1344bps repl-rate=1344bps
+
+      '
+    help: execute the command "ip firewall connection print terse without-paging"
+    prompt: '[admin@{base_prompt}] >'
+  ip hotspot ip-binding print terse without-paging:
+    output: '0 P comment=Sonda_Mantenimiento mac-address=D8:3A:DD:48:B6:1C server=server1
+      type=bypassed
+
+      1   mac-address=B0:4A:B4:76:A9:5D address=10.0.1.98 to-address=10.0.1.98 server=server1
+
+      '
+    help: execute the command "ip hotspot ip-binding print terse without-paging"
+    prompt: '[admin@{base_prompt}] >'
+  ip neighbor print detail:
+    output: ' 0 interface=ether1 address=10.159.1.159 address4=10.159.1.159 mac-address=12:34:56:78:90:AB
+      identity="MikroTik-Dev" platform="MikroTik" version="6.48.6 (long-term)" unpack=none
+      age=17s uptime=1w5d2h31m30s software-id="1234-ABCD" board="RB750UPr2" interface-name="ether2"
+      system-description="MikroTik RouterOS 6.48.6 (long-term) RB750UPr2" system-caps=bridge,router
+      system-caps-enabled=bridge,wlan-ap,router
+
+      '
+    help: execute the command "ip neighbor print detail"
+    prompt: '[admin@{base_prompt}] >'
+    output_variants:
+      - ' 0 interface=ether10,bridge_255_mgmt address=1.2.4.5 address4=1.2.4.5 address6=2001:0db8:11a3:09d7:1f34:8a2e:07a0:765d
+        mac-address=12:34:56:78:90:AB identity="CLEAR" platform="MikroTik" version="7.15.1
+        (stable) 2024-06-07 12:49:11" unpack=none age=7s uptime=1d8h37m20s software-id="AAAA-BBBB"
+        board="RB450Gx4" ipv6=yes interface-name="ether1" system-description="MikroTik
+        RouterOS 7.15.1 (stable) 2024-06-07 12:49:11 RB450Gx4" system-caps=bridge,router
+        system-caps-enabled=router
+
+        '
+      - " 0 interface=ether2,bridge_local mac-address=12:34:56:78:90:AB identity=\"\
+        CLEAR\" platform=\"MikroTik\" version=\"6.49.14 (stable)\" unpack=none age=37s\
+        \ uptime=1d8h37m17s software-id=\"AAAA-BBBB\" board=\"RB750UPr2\" interface-name=\"\
+        ether1\" system-description=\"MikroTik RouterOS 6.49.14 (stable) RB750UPr2\"\
+        \ system-caps=bridge,router system-caps-enabled=router\n\n 1 interface=ether10,bridge_255_mgmt\
+        \ address=1.2.4.5 address4=1.2.4.5 address6=2001:0db8:11a3:09d7:1f34:8a2e:07a0:765d\
+        \ mac-address=12:34:56:78:90:AC identity=\"Device_1\" platform=\"MikroTik\"\
+        \ version=\"7.15.1 (stable) 2024-06-07 12:49:11\" unpack=none age=7s uptime=1d8h37m20s\
+        \ software-id=\"CCCC-DDDD\" board=\"RB450Gx4\" ipv6=yes interface-name=\"\
+        ether1\" system-description=\"MikroTik RouterOS 7.15.1 (stable) 2024-06-07\
+        \ 12:49:11 RB450Gx4\" system-caps=bridge,router\n   system-caps-enabled=router\n\
+        \n 2 interface=eth1-vlan255,bridge_255_mgmt mac-address=12:34:56:78:90:AD\
+        \ identity=\"Device-2\" platform=\"MikroTik\" version=\"6.43.14 (long-term)\"\
+        \ unpack=none age=23s uptime=48w3d9h41m36s software-id=\"AAAA-ZZZZ\" board=\"\
+        RB1100x4\" ipv6=no interface-name=\"bridge_vlan255\" system-caps=\"\" system-caps-enabled=\"\
+        \"\n"
+  ip route print detail:
+    output: "Flags: X - disabled, A - active, D - dynamic, C - connect, S - static,\
+      \ r - rip, b - bgp, o - ospf, m - mme, B - blackhole, U - unreachable, P - prohibit\n\
+      \ 0 ADS  dst-address=0.0.0.0/0 gateway=192.168.8.1 gateway-status=192.168.8.1\
+      \ reachable via  lte1 distance=2 scope=30 target-scope=10 vrf-interface=lte1\n\
+      \n 1 ADC  dst-address=10.160.1.228/30 pref-src=10.160.1.230 gateway=ether1 gateway-status=ether1\
+      \ reachable distance=0 scope=10\n\n 2 A S  dst-address=10.213.20.64/32 gateway=10.160.1.229\
+      \ gateway-status=10.160.1.229 reachable via  ether1 distance=1 scope=30 target-scope=10\n\
+      \n 3 A S  ;;; to Internet\n        dst-address=0.0.0.0/0 gateway=10.160.1.230\
+      \ gateway-status=10.160.1.230 reachable via ether2 distance=1 scope=30 target-scope=10\
+      \ routing-mark=to-reserve\n\n 4 A S  dst-address=0.0.0.0/0 gateway=1.2.3.4 gateway-status=1.2.3.4\
+      \ recursive via 10.152.1.230 ether5 distance=1 scope=30 target-scope=10 routing-mark=Free_Wi-Fi\n\
+      \n 5 A SB dst-address=10.0.0.0/8 type=blackhole distance=100 routing-mark=Free_Wi-Fi\n\
+      \n 6 A S  dst-address=0.0.0.0/0 gateway=1.2.3.4 gateway-status=1.2.3.4 recursive\
+      \ via 10.152.1.230 ether5 check-gateway=ping distance=1 scope=30 target-scope=10\n"
+    help: execute the command "ip route print detail"
+    prompt: '[admin@{base_prompt}] >'
+  ip route print terse without-paging:
+    output: " 0 A S  dst-address=0.0.0.0/0 gateway=192.168.8.1 gateway-status=192.168.8.1\
+      \ reachable via  lte1 distance=2 scope=30 target-scope=10 vrf-interface=lte1\n\
+      \ 1 ADC  dst-address=10.160.1.228/30 pref-src=10.160.1.230 gateway=ether1 gateway-status=ether1\
+      \ reachable distance=0 scope=10\n 2 A S  comment=to Internet dst-address=134.0.0.0/8\
+      \ gateway=10.160.1.230 gateway-status=10.160.1.230 reachable via  ether2 distance=1\
+      \ scope=30 target-scope=10 routing-mark=reserve\n 3 A S  dst-address=172.0.0.0/8\
+      \ gateway=1.2.3.4 gateway-status=1.2.3.4 recursive via 10.152.1.230 ether5 distance=1\
+      \ scope=30 target-scope=10 routing-mark=Free_Wi-Fi\n 4 A SB dst-address=10.0.0.0/8\
+      \ type=blackhole distance=100 routing-mark=Free_Wi-Fi\n"
+    help: execute the command "ip route print terse without-paging"
+    prompt: '[admin@{base_prompt}] >'
+  routing bgp peer print status:
+    output: "Flags: X - disabled, E - established\n 0   name=\"peer1\" instance=default\
+      \ remote-address=192.168.1.134 remote-as=65001 tcp-md5-key=\"\" nexthop-choice=default\
+      \ multihop=no route-reflect=no hold-time=3m\n     ttl=255 in-filter=\"\" out-filter=\"\
+      \" address-families=ip,ipv6 default-originate=never remove-private-as=no as-override=no\
+      \ passive=no use-bfd=no state=opensent\n"
+    help: execute the command "routing bgp peer print status"
+    prompt: '[admin@{base_prompt}] >'
+  routing ospf interface print terse:
+    output: " 0  P interface=all cost=10 priority=1 authentication=none authentication-key=foo\
+      \ authentication-key-id=1 network-type=broadcast instance-id=0 retransmit-interval=5s\
+      \ transmit-delay=1s hello-interval=10s dead-interval=40s use-bfd=no\n 1    comment=ospf\
+      \ comment interface=vlan906@bond1 cost=10 priority=1 authentication=none authentication-key=\"\
+      bar\" authentication-key-id=1 network-type=broadcast instance-id=0 retransmit-interval=5s\
+      \ transmit-delay=1s hello-interval=10s dead-interval=40s use-bfd=no\n 2 DP interface=lo0\
+      \ cost=10 priority=1 authentication=none authentication-key=\"\" authentication-key-id=1\
+      \ network-type=broadcast instance-id=0 retransmit-interval=5s transmit-delay=1s\
+      \ hello-interval=10s dead-interval=40s use-bfd=no\n"
+    help: execute the command "routing ospf interface print terse"
+    prompt: '[admin@{base_prompt}] >'
+    output_variants:
+      - '0 D address=1.1.1.1%vlan11@vlan975@sfp-sfpplus1 area=INET-v2 state=ptp network-type=ptp
+        cost=1400 use-bfd=no retransmit-interval=5s transmit-delay=1s hello-interval=1s
+        dead-interval=4s
+
+        1 D address=1.1.1.1%vlan10@vlan975@sfp-sfpplus1 area=MGMT-v2 state=ptp network-type=ptp
+        cost=10 use-bfd=no retransmit-interval=5s transmit-delay=1s hello-interval=10s
+        dead-interval=40s
+
+        2 D address=1.1.1.1%Lo0 area=MGMT-v2 state=passive network-type=broadcast
+        cost=1 priority=128 use-bfd=no retransmit-interval=5s transmit-delay=1s hello-interval=10s
+        dead-interval=40s
+
+        '
+  routing ospf neighbor print:
+    output: " 0 instance=default router-id=89.188.172.2 address=89.188.172.81 interface=vlan68\
+      \ priority=128 dr-address=0.0.0.0 backup-dr-address=0.0.0.0 state=\"Full\" state-changes=5\
+      \ ls-retransmits=0 ls-requests=0 db-summaries=0 adjacency=7w5d8h40m21s\n\n 1\
+      \ instance=default router-id=89.188.172.3 address=89.188.172.93 interface=vlan71\
+      \ priority=128 dr-address=0.0.0.0 backup-dr-address=0.0.0.0 state=\"Full\" state-changes=5\
+      \ ls-retransmits=0 ls-requests=0 db-summaries=0 adjacency=7w5d8h40m21s\n"
+    help: execute the command "routing ospf neighbor print"
+    prompt: '[admin@{base_prompt}] >'
+  system identity print:
+    output: '  name: Mikrotik-Device_Name
+
+      '
+    help: execute the command "system identity print"
+    prompt: '[admin@{base_prompt}] >'
+  system resource print:
+    output: "                   uptime: 6w5d11h55m45s\n                  version:\
+      \ 6.48.6 (long-term)\n               build-time: Dec/03/2021 12:15:05\n    \
+      \          free-memory: 40.2MiB\n             total-memory: 64.0MiB\n      \
+      \                cpu: MIPS 24Kc V7.4\n                cpu-count: 1\n       \
+      \     cpu-frequency: 650MHz\n                 cpu-load: 1%\n           free-hdd-space:\
+      \ 1196.0KiB\n          total-hdd-space: 16.0MiB\n  write-sect-since-reboot:\
+      \ 44663\n         write-sect-total: 572180\n               bad-blocks: 0%\n\
+      \        architecture-name: mipsbe\n               board-name: hEX PoE lite\n\
+      \                 platform: MikroTik\n"
+    help: execute the command "system resource print"
+    prompt: '[admin@{base_prompt}] >'
+    output_variants:
+      - "                   uptime: 1d6h22m\n                  version: 6.48.7 (long-term)\n\
+        \               build-time: May/23/2023 05:27:08\n         factory-software:\
+        \ 6.44.6\n              free-memory: 45.5MiB\n             total-memory: 64.0MiB\n\
+        \                      cpu: MIPS 24Kc V7.4\n                cpu-count: 1\n\
+        \            cpu-frequency: 650MHz\n                 cpu-load: 1%\n      \
+        \     free-hdd-space: 3428.0KiB\n          total-hdd-space: 16.0MiB\n  write-sect-since-reboot:\
+        \ 1970\n         write-sect-total: 77652\n               bad-blocks: 0%\n\
+        \        architecture-name: mipsbe\n               board-name: hEX PoE lite\n\
+        \                 platform: MikroTik\n"
+      - "\t\t\t\t   uptime: 5w3d20m51s\n                  version: 7.12.2 (stable)\n\
+        \               build-time: Dec/20/2023 08:41:00\n         factory-software:\
+        \ 7.1\n              free-memory: 36.7MiB\n             total-memory: 192.0MiB\n\
+        \                      cpu: Common\n                cpu-count: 2\n       \
+        \     cpu-frequency: 2294MHz\n                 cpu-load: 53%\n           free-hdd-space:\
+        \ 69.8MiB\n          total-hdd-space: 89.2MiB\n  write-sect-since-reboot:\
+        \ 213432\n         write-sect-total: 213432\n        architecture-name: x86_64\n\
+        \               board-name: CHR\n                 platform: MikroTik\n"
+      - "                   uptime: 10w2d6h21m59s\n                  version: 7.12.2\
+        \ (stable)\n               build-time: Dec/20/2023 08:41:00\n         factory-software:\
+        \ 7.6\n              free-memory: 3704.1MiB\n             total-memory: 4032.0MiB\n\
+        \                      cpu: ARM64\n                cpu-count: 4\n        \
+        \         cpu-load: 36%\n           free-hdd-space: 104.4MiB\n          total-hdd-space:\
+        \ 128.0MiB\n  write-sect-since-reboot: 54120\n         write-sect-total: 291965\n\
+        \               bad-blocks: 0%\n        architecture-name: arm64\n       \
+        \        board-name: CCR2004-1G-12S+2XS\n                 platform: MikroTik\n"
+  tool profile:
+    output: 'NAME                    CPU        USAGE
+
+      spi                                   1%
+
+      console                               0%
+
+      firewall                            0.5%
+
+      networking                            0%
+
+      management                          0.5%
+
+      profiling                             0%
+
+      unclassified                        0.5%
+
+      total                               2.5%
+
+      '
+    help: execute the command "tool profile"
+    prompt: '[admin@{base_prompt}] >'
+  tool speed-test address:
+    output: "address: 192.168.88.1\n              status: tcp upload\n      time-remaining:\
+      \ 23s\n    ping-min-avg-max: 52.4ms / 86.1ms / 246ms\n  jitter-min-avg-max:\
+      \ 12us / 21.3ms / 158ms\n                loss: 0% (0/200)\n        tcp-download:\
+      \ 921Mbps local-cpu-load:30%\n          tcp-upload: 920Mbps local-cpu-load:30%\
+      \ remote-cpu-load:25%\n        udp-download: 917Mbps local-cpu-load:6% remote-cpu-load:21%\n\
+      \          udp-upload: 916Mbps local-cpu-load:20% remote-cpu-load:6%\n"
+    help: execute the command "tool speed-test address"
+    prompt: '[admin@{base_prompt}] >'
+  user print:
+    output: "Flags: X - disabled\n #   NAME                     GROUP  ADDRESS   \
+      \         LAST-LOGGED-IN\n 0   ;;; system default user\n     admin         \
+      \           full                      jun/30/2023 01:08:59\n 1   user1     \
+      \               full                      jul/18/2023 05:12:46\n"
+    help: execute the command "user print"
+    prompt: '[admin@{base_prompt}] >'

--- a/simnos/plugins/nos/platforms_yaml/paloalto_panos.yaml
+++ b/simnos/plugins/nos/platforms_yaml/paloalto_panos.yaml
@@ -423,3 +423,188 @@ commands:
       total routes shown: 98"
     help: execute the command "show routing route"
     prompt: '{base_prompt}>'
+  show interface all:
+    output: "total configured hardware interfaces: 12\nname                    id\
+      \    speed/duplex/state/fec        mac address\n--------------------------------------------------------------------------------\n\
+      ethernet1/8             23    1000/full/up/auto             00:1b:17:aa:bb:01\n\
+      ethernet1/13            28    1000/full/up/auto             00:1b:17:aa:bb:02\n\
+      ethernet1/14            29    1000/full/up/auto             00:1b:17:aa:bb:03\n\
+      ethernet1/19            34    10000/full/up/auto            00:1b:17:aa:bb:04\n\
+      ae1                     64    [n/a]/[n/a]/up/[n/a]          00:1b:17:aa:bb:40\n\
+      ae2                     65    [n/a]/[n/a]/up/[n/a]          00:1b:17:aa:bb:41\n\
+      ha1-a                   5     1000/full/up/ukn              8c:36:7a:aa:bb:b5\n\
+      ha1-b                   7     ukn/ukn/down((autoneg))/ukn   8c:36:7a:aa:bb:b4\n\
+      vlan                    1     [n/a]/[n/a]/up/[n/a]          00:1b:17:aa:bb:01\n\
+      loopback                3     [n/a]/[n/a]/up/[n/a]          00:1b:17:aa:bb:03\n\
+      tunnel                  4     [n/a]/[n/a]/up/[n/a]          00:1b:17:aa:bb:04\n\
+      hsci                    8     10000/full/up/ukn             64:7c:e8:aa:bb:08\n\
+      \naggregation groups: 2\nae1 members:\n  ethernet1/19 ethernet1/20\nae2 members:\n\
+      \  ethernet1/11\n\n\ntotal configured logical interfaces: 14\n\nname       \
+      \               id    vsys zone             forwarding               tag   \
+      \ address\n\n------------------- ----- ---- ---------------- ------------------------\
+      \ ------ ------------------\nethernet1/8               23    3    ZONE_TECH\
+      \        vr:vrf01                 0      192.0.2.1/28\nethernet1/8.81      \
+      \      300   3    ZONE_TECH        vr:vrf01                 81     192.0.2.17/27\n\
+      ethernet1/13              28    5    ZONE_INET        vr:vrf02             \
+      \    0      192.0.2.33/29\n                                                \
+      \                                10.10.10.1/29\nethernet1/13.388          298\
+      \   2    ZONE_SDWAN       vr:vrf03                 388    192.0.2.65/27\nethernet1/14\
+      \              29    5    ZONE_INET        vr:vrf02                 0      192.0.2.97/28\n\
+      ae1                       64    2                     N/A                  \
+      \    0      N/A\nae1.99                    267   2    ZONE_OTSC        vr:vrf03\
+      \                 99     192.0.2.113/28\nae5                       68    5 \
+      \                    vr:vrf02                 0      N/A\nha1-a            \
+      \         5     0                     ha                       0      198.51.100.1/30\n\
+      vlan                      1     1                     N/A                  \
+      \    0      N/A\nloopback                  3     1                     N/A \
+      \                     0      N/A\nloopback.99               297   2    ZONE_CORP\
+      \        vr:vrf03                 0      192.0.2.129/32\ntunnel            \
+      \        4     1                     N/A                      0      N/A\nhsci\
+      \                      8     0                     N/A                     \
+      \ 0      198.51.100.5/30\n"
+    help: execute the command "show interface all"
+    prompt: '{base_prompt}>'
+  show lacp aggregate-ethernet all:
+    output: "**********************************************************************************\n\
+      AE group: ae1\nMembers:                Bndl Rx state       Mux state  Sel state\n\
+      \  ethernet1/19          yes  Current        Tx_Rx      Selected\n  ethernet1/20\
+      \          yes  Current        Tx_Rx      Selected\nStatus:           Enabled\n\
+      Mode:             Active\nRate:             Slow\nMax-port:         8\nFast-failover:\
+      \    Disabled\nPre-negotiation:  Enabled\nLocal:            System Priority:\
+      \ 32768\n                  System MAC:      64:7c:e8:aa:bb:01\n            \
+      \      Key:             64\nPartner:          System Priority: 65534\n     \
+      \             System MAC:      0a:00:00:aa:bb:cc\n                  Key:   \
+      \          103\nPort State\n--------------------------------------------------------------------------------\n\
+      Interface                       Port\n                    Number Priority  Mode\
+      \    Rate  Key      State\n--------------------------------------------------------------------------------\n\
+      ethernet1/19         34     32768    Active  Slow  64       0x3D\nPartner  \
+      \            3      1        Active  Slow  103      0x3D\n\nethernet1/20   \
+      \      35     32768    Active  Slow  64       0x3D\nPartner              1003\
+      \   1        Active  Slow  103      0x3D\n\nPort Counters\n--------------------------------------------------------------------------------\n\
+      Interface               LACPDUs         Marker      Marker Response       Error\n\
+      \                    Sent     Recv     Sent Recv     Sent     Recv     Unknown\
+      \  Illegal\n--------------------------------------------------------------------------------\n\
+      ethernet1/19         100      100      0    0        0        0        0   \
+      \     0\nethernet1/20         100      100      0    0        0        0   \
+      \     0        0\n\n**********************************************************************************\n\
+      AE group: ae2\nMembers:                Bndl Rx state       Mux state  Sel state\n\
+      \  ethernet1/11          yes  Current        Tx_Rx      Selected\nStatus:  \
+      \         Enabled\nMode:             Active\nRate:             Slow\nMax-port:\
+      \         8\nFast-failover:    Disabled\nPre-negotiation:  Enabled\nLocal: \
+      \           System Priority: 32768\n                  System MAC:      64:7c:e8:aa:bb:01\n\
+      \                  Key:             65\nPartner:          System Priority: 32768\n\
+      \                  System MAC:      64:7c:e8:aa:bb:01\n                  Key:\
+      \             67\nPort State\n--------------------------------------------------------------------------------\n\
+      Interface                       Port\n                    Number Priority  Mode\
+      \    Rate  Key      State\n--------------------------------------------------------------------------------\n\
+      ethernet1/11         26     32768    Active  Slow  65       0x3D\nPartner  \
+      \            27     32768    Active  Slow  67       0x3D\n\nPort Counters\n\
+      --------------------------------------------------------------------------------\n\
+      Interface               LACPDUs         Marker      Marker Response       Error\n\
+      \                    Sent     Recv     Sent Recv     Sent     Recv     Unknown\
+      \  Illegal\n--------------------------------------------------------------------------------\n\
+      ethernet1/11         100      100      0    0        0        0        0   \
+      \     0\n"
+    help: execute the command "show lacp aggregate-ethernet all"
+    prompt: '{base_prompt}>'
+    output_variants:
+      - "LACP:\n\n**********************************************************************************\n\
+        AE group: ae1\nMembers:                Bndl Rx state       Mux state  Sel\
+        \ state\n  ethernet1/19          yes  Current        Tx_Rx      Selected\n\
+        \  ethernet1/20          yes  Current        Tx_Rx      Selected\nStatus:\
+        \           Enabled\nMode:             Active\nRate:             Slow\nMax-port:\
+        \         8\nFast-failover:    Disabled\nPre-negotiation:  Enabled\nLocal:\
+        \            System Priority: 32768\n                  System MAC:      64:7c:e8:aa:bb:01\n\
+        \                  Key:             64\nPartner:          System Priority:\
+        \ 65534\n                  System MAC:      0a:00:00:aa:bb:cc\n          \
+        \        Key:             103\nPort State\n--------------------------------------------------------------------------------\n\
+        Interface                       Port\n                    Number Priority\
+        \  Mode    Rate  Key      State\n--------------------------------------------------------------------------------\n\
+        ethernet1/19         34     32768    Active  Slow  64       0x3D\nPartner\
+        \              3      1        Active  Slow  103      0x3D\n\nethernet1/20\
+        \         35     32768    Active  Slow  64       0x3D\nPartner           \
+        \   1003   1        Active  Slow  103      0x3D\n\nPort Counters\n--------------------------------------------------------------------------------\n\
+        Interface               LACPDUs         Marker      Marker Response      \
+        \ Error\n                    Sent     Recv     Sent Recv     Sent     Recv\
+        \     Unknown  Illegal\n--------------------------------------------------------------------------------\n\
+        ethernet1/19         584295   584296   0    0        0        0        0 \
+        \       0\nethernet1/20         584295   584297   0    0        0        0\
+        \        0        0\n\n**********************************************************************************\n\
+        AE group: ae2\nMembers:                Bndl Rx state       Mux state  Sel\
+        \ state\n  ethernet1/11          yes  Current        Tx_Rx      Selected\n\
+        Status:           Enabled\nMode:             Active\nRate:             Slow\n\
+        Max-port:         8\nFast-failover:    Disabled\nPre-negotiation:  Enabled\n\
+        Local:            System Priority: 32768\n                  System MAC:  \
+        \    64:7c:e8:aa:bb:01\n                  Key:             65\nPartner:  \
+        \        System Priority: 32768\n                  System MAC:      64:7c:e8:aa:bb:01\n\
+        \                  Key:             67\nPort State\n--------------------------------------------------------------------------------\n\
+        Interface                       Port\n                    Number Priority\
+        \  Mode    Rate  Key      State\n--------------------------------------------------------------------------------\n\
+        ethernet1/11         26     32768    Active  Slow  65       0x3D\nPartner\
+        \              27     32768    Active  Slow  67       0x3D\n\nPort Counters\n\
+        --------------------------------------------------------------------------------\n\
+        Interface               LACPDUs         Marker      Marker Response      \
+        \ Error\n                    Sent     Recv     Sent Recv     Sent     Recv\
+        \     Unknown  Illegal\n--------------------------------------------------------------------------------\n\
+        ethernet1/11         584290   584286   0    0        0        0        0 \
+        \       0\n\n**********************************************************************************\n\
+        AE group: ae4\nMembers:                Bndl Rx state       Mux state  Sel\
+        \ state\n  ethernet1/12          yes  Current        Tx_Rx      Selected\n\
+        Status:           Enabled\nMode:             Active\nRate:             Slow\n\
+        Max-port:         8\nFast-failover:    Disabled\nPre-negotiation:  Enabled\n\
+        Local:            System Priority: 32768\n                  System MAC:  \
+        \    64:7c:e8:aa:bb:01\n                  Key:             67\nPartner:  \
+        \        System Priority: 32768\n                  System MAC:      64:7c:e8:aa:bb:01\n\
+        \                  Key:             65\nPort State\n--------------------------------------------------------------------------------\n\
+        Interface                       Port\n                    Number Priority\
+        \  Mode    Rate  Key      State\n--------------------------------------------------------------------------------\n\
+        ethernet1/12         27     32768    Active  Slow  67       0x3D\nPartner\
+        \              26     32768    Active  Slow  65       0x3D\n\nPort Counters\n\
+        --------------------------------------------------------------------------------\n\
+        Interface               LACPDUs         Marker      Marker Response      \
+        \ Error\n                    Sent     Recv     Sent Recv     Sent     Recv\
+        \     Unknown  Illegal\n--------------------------------------------------------------------------------\n\
+        ethernet1/12         584290   584286   0    0        0        0        0 \
+        \       0\n\n**********************************************************************************\n\
+        AE group: ae5\nMembers:                Bndl Rx state       Mux state  Sel\
+        \ state\n  ethernet1/15          yes  Current        Tx_Rx      Selected\n\
+        \  ethernet1/17          yes  Current        Tx_Rx      Selected\nStatus:\
+        \           Enabled\nMode:             Active\nRate:             Slow\nMax-port:\
+        \         8\nFast-failover:    Disabled\nPre-negotiation:  Enabled\nLocal:\
+        \            System Priority: 32768\n                  System MAC:      64:7c:e8:aa:bb:01\n\
+        \                  Key:             68\nPartner:          System Priority:\
+        \ 65534\n                  System MAC:      0a:00:00:aa:bb:cc\n          \
+        \        Key:             101\nPort State\n--------------------------------------------------------------------------------\n\
+        Interface                       Port\n                    Number Priority\
+        \  Mode    Rate  Key      State\n--------------------------------------------------------------------------------\n\
+        ethernet1/15         30     32768    Active  Slow  68       0x3D\nPartner\
+        \              1001   1        Active  Slow  101      0x3D\n\nethernet1/17\
+        \         32     32768    Active  Slow  68       0x3D\nPartner           \
+        \   1      1        Active  Slow  101      0x3D\n\nPort Counters\n--------------------------------------------------------------------------------\n\
+        Interface               LACPDUs         Marker      Marker Response      \
+        \ Error\n                    Sent     Recv     Sent Recv     Sent     Recv\
+        \     Unknown  Illegal\n--------------------------------------------------------------------------------\n\
+        ethernet1/15         584299   584270   0    0        0        0        0 \
+        \       0\nethernet1/17         584300   584271   0    0        0        0\
+        \        0        0\n\n**********************************************************************************\n\
+        AE group: ae6\nMembers:                Bndl Rx state       Mux state  Sel\
+        \ state\n  ethernet1/21          yes  Current        Tx_Rx      Selected\n\
+        \  ethernet1/22          yes  Current        Tx_Rx      Selected\nStatus:\
+        \           Enabled\nMode:             Active\nRate:             Slow\nMax-port:\
+        \         8\nFast-failover:    Disabled\nPre-negotiation:  Enabled\nLocal:\
+        \            System Priority: 32768\n                  System MAC:      64:7c:e8:aa:bb:01\n\
+        \                  Key:             69\nPartner:          System Priority:\
+        \ 65534\n                  System MAC:      0a:00:00:aa:bb:cc\n          \
+        \        Key:             102\nPort State\n--------------------------------------------------------------------------------\n\
+        Interface                       Port\n                    Number Priority\
+        \  Mode    Rate  Key      State\n--------------------------------------------------------------------------------\n\
+        ethernet1/21         36     32768    Active  Slow  69       0x3D\nPartner\
+        \              2      1        Active  Slow  102      0x3D\n\nethernet1/22\
+        \         37     32768    Active  Slow  69       0x3D\nPartner           \
+        \   1002   1        Active  Slow  102      0x3D\n\nPort Counters\n--------------------------------------------------------------------------------\n\
+        Interface               LACPDUs         Marker      Marker Response      \
+        \ Error\n                    Sent     Recv     Sent Recv     Sent     Recv\
+        \     Unknown  Illegal\n--------------------------------------------------------------------------------\n\
+        ethernet1/21         584296   584297   0    0        0        0        0 \
+        \       0\nethernet1/22         584296   584297   0    0        0        0\
+        \        0        0\n"

--- a/simnos/plugins/nos/platforms_yaml/paloalto_panos.yaml
+++ b/simnos/plugins/nos/platforms_yaml/paloalto_panos.yaml
@@ -508,103 +508,103 @@ commands:
     help: execute the command "show lacp aggregate-ethernet all"
     prompt: '{base_prompt}>'
     output_variants:
-      - "LACP:\n\n**********************************************************************************\n\
-        AE group: ae1\nMembers:                Bndl Rx state       Mux state  Sel\
-        \ state\n  ethernet1/19          yes  Current        Tx_Rx      Selected\n\
-        \  ethernet1/20          yes  Current        Tx_Rx      Selected\nStatus:\
-        \           Enabled\nMode:             Active\nRate:             Slow\nMax-port:\
-        \         8\nFast-failover:    Disabled\nPre-negotiation:  Enabled\nLocal:\
-        \            System Priority: 32768\n                  System MAC:      64:7c:e8:aa:bb:01\n\
-        \                  Key:             64\nPartner:          System Priority:\
-        \ 65534\n                  System MAC:      0a:00:00:aa:bb:cc\n          \
-        \        Key:             103\nPort State\n--------------------------------------------------------------------------------\n\
-        Interface                       Port\n                    Number Priority\
-        \  Mode    Rate  Key      State\n--------------------------------------------------------------------------------\n\
-        ethernet1/19         34     32768    Active  Slow  64       0x3D\nPartner\
-        \              3      1        Active  Slow  103      0x3D\n\nethernet1/20\
-        \         35     32768    Active  Slow  64       0x3D\nPartner           \
-        \   1003   1        Active  Slow  103      0x3D\n\nPort Counters\n--------------------------------------------------------------------------------\n\
-        Interface               LACPDUs         Marker      Marker Response      \
-        \ Error\n                    Sent     Recv     Sent Recv     Sent     Recv\
-        \     Unknown  Illegal\n--------------------------------------------------------------------------------\n\
-        ethernet1/19         584295   584296   0    0        0        0        0 \
-        \       0\nethernet1/20         584295   584297   0    0        0        0\
-        \        0        0\n\n**********************************************************************************\n\
-        AE group: ae2\nMembers:                Bndl Rx state       Mux state  Sel\
-        \ state\n  ethernet1/11          yes  Current        Tx_Rx      Selected\n\
-        Status:           Enabled\nMode:             Active\nRate:             Slow\n\
-        Max-port:         8\nFast-failover:    Disabled\nPre-negotiation:  Enabled\n\
-        Local:            System Priority: 32768\n                  System MAC:  \
-        \    64:7c:e8:aa:bb:01\n                  Key:             65\nPartner:  \
-        \        System Priority: 32768\n                  System MAC:      64:7c:e8:aa:bb:01\n\
-        \                  Key:             67\nPort State\n--------------------------------------------------------------------------------\n\
-        Interface                       Port\n                    Number Priority\
-        \  Mode    Rate  Key      State\n--------------------------------------------------------------------------------\n\
-        ethernet1/11         26     32768    Active  Slow  65       0x3D\nPartner\
-        \              27     32768    Active  Slow  67       0x3D\n\nPort Counters\n\
-        --------------------------------------------------------------------------------\n\
-        Interface               LACPDUs         Marker      Marker Response      \
-        \ Error\n                    Sent     Recv     Sent Recv     Sent     Recv\
-        \     Unknown  Illegal\n--------------------------------------------------------------------------------\n\
-        ethernet1/11         584290   584286   0    0        0        0        0 \
-        \       0\n\n**********************************************************************************\n\
-        AE group: ae4\nMembers:                Bndl Rx state       Mux state  Sel\
-        \ state\n  ethernet1/12          yes  Current        Tx_Rx      Selected\n\
-        Status:           Enabled\nMode:             Active\nRate:             Slow\n\
-        Max-port:         8\nFast-failover:    Disabled\nPre-negotiation:  Enabled\n\
-        Local:            System Priority: 32768\n                  System MAC:  \
-        \    64:7c:e8:aa:bb:01\n                  Key:             67\nPartner:  \
-        \        System Priority: 32768\n                  System MAC:      64:7c:e8:aa:bb:01\n\
-        \                  Key:             65\nPort State\n--------------------------------------------------------------------------------\n\
-        Interface                       Port\n                    Number Priority\
-        \  Mode    Rate  Key      State\n--------------------------------------------------------------------------------\n\
-        ethernet1/12         27     32768    Active  Slow  67       0x3D\nPartner\
-        \              26     32768    Active  Slow  65       0x3D\n\nPort Counters\n\
-        --------------------------------------------------------------------------------\n\
-        Interface               LACPDUs         Marker      Marker Response      \
-        \ Error\n                    Sent     Recv     Sent Recv     Sent     Recv\
-        \     Unknown  Illegal\n--------------------------------------------------------------------------------\n\
-        ethernet1/12         584290   584286   0    0        0        0        0 \
-        \       0\n\n**********************************************************************************\n\
-        AE group: ae5\nMembers:                Bndl Rx state       Mux state  Sel\
-        \ state\n  ethernet1/15          yes  Current        Tx_Rx      Selected\n\
-        \  ethernet1/17          yes  Current        Tx_Rx      Selected\nStatus:\
-        \           Enabled\nMode:             Active\nRate:             Slow\nMax-port:\
-        \         8\nFast-failover:    Disabled\nPre-negotiation:  Enabled\nLocal:\
-        \            System Priority: 32768\n                  System MAC:      64:7c:e8:aa:bb:01\n\
-        \                  Key:             68\nPartner:          System Priority:\
-        \ 65534\n                  System MAC:      0a:00:00:aa:bb:cc\n          \
-        \        Key:             101\nPort State\n--------------------------------------------------------------------------------\n\
-        Interface                       Port\n                    Number Priority\
-        \  Mode    Rate  Key      State\n--------------------------------------------------------------------------------\n\
-        ethernet1/15         30     32768    Active  Slow  68       0x3D\nPartner\
-        \              1001   1        Active  Slow  101      0x3D\n\nethernet1/17\
-        \         32     32768    Active  Slow  68       0x3D\nPartner           \
-        \   1      1        Active  Slow  101      0x3D\n\nPort Counters\n--------------------------------------------------------------------------------\n\
-        Interface               LACPDUs         Marker      Marker Response      \
-        \ Error\n                    Sent     Recv     Sent Recv     Sent     Recv\
-        \     Unknown  Illegal\n--------------------------------------------------------------------------------\n\
-        ethernet1/15         584299   584270   0    0        0        0        0 \
-        \       0\nethernet1/17         584300   584271   0    0        0        0\
-        \        0        0\n\n**********************************************************************************\n\
-        AE group: ae6\nMembers:                Bndl Rx state       Mux state  Sel\
-        \ state\n  ethernet1/21          yes  Current        Tx_Rx      Selected\n\
-        \  ethernet1/22          yes  Current        Tx_Rx      Selected\nStatus:\
-        \           Enabled\nMode:             Active\nRate:             Slow\nMax-port:\
-        \         8\nFast-failover:    Disabled\nPre-negotiation:  Enabled\nLocal:\
-        \            System Priority: 32768\n                  System MAC:      64:7c:e8:aa:bb:01\n\
-        \                  Key:             69\nPartner:          System Priority:\
-        \ 65534\n                  System MAC:      0a:00:00:aa:bb:cc\n          \
-        \        Key:             102\nPort State\n--------------------------------------------------------------------------------\n\
-        Interface                       Port\n                    Number Priority\
-        \  Mode    Rate  Key      State\n--------------------------------------------------------------------------------\n\
-        ethernet1/21         36     32768    Active  Slow  69       0x3D\nPartner\
-        \              2      1        Active  Slow  102      0x3D\n\nethernet1/22\
-        \         37     32768    Active  Slow  69       0x3D\nPartner           \
-        \   1002   1        Active  Slow  102      0x3D\n\nPort Counters\n--------------------------------------------------------------------------------\n\
-        Interface               LACPDUs         Marker      Marker Response      \
-        \ Error\n                    Sent     Recv     Sent Recv     Sent     Recv\
-        \     Unknown  Illegal\n--------------------------------------------------------------------------------\n\
-        ethernet1/21         584296   584297   0    0        0        0        0 \
-        \       0\nethernet1/22         584296   584297   0    0        0        0\
-        \        0        0\n"
+    - "LACP:\n\n**********************************************************************************\n\
+      AE group: ae1\nMembers:                Bndl Rx state       Mux state  Sel state\n\
+      \  ethernet1/19          yes  Current        Tx_Rx      Selected\n  ethernet1/20\
+      \          yes  Current        Tx_Rx      Selected\nStatus:           Enabled\n\
+      Mode:             Active\nRate:             Slow\nMax-port:         8\nFast-failover:\
+      \    Disabled\nPre-negotiation:  Enabled\nLocal:            System Priority:\
+      \ 32768\n                  System MAC:      64:7c:e8:aa:bb:01\n            \
+      \      Key:             64\nPartner:          System Priority: 65534\n     \
+      \             System MAC:      0a:00:00:aa:bb:cc\n                  Key:   \
+      \          103\nPort State\n--------------------------------------------------------------------------------\n\
+      Interface                       Port\n                    Number Priority  Mode\
+      \    Rate  Key      State\n--------------------------------------------------------------------------------\n\
+      ethernet1/19         34     32768    Active  Slow  64       0x3D\nPartner  \
+      \            3      1        Active  Slow  103      0x3D\n\nethernet1/20   \
+      \      35     32768    Active  Slow  64       0x3D\nPartner              1003\
+      \   1        Active  Slow  103      0x3D\n\nPort Counters\n--------------------------------------------------------------------------------\n\
+      Interface               LACPDUs         Marker      Marker Response       Error\n\
+      \                    Sent     Recv     Sent Recv     Sent     Recv     Unknown\
+      \  Illegal\n--------------------------------------------------------------------------------\n\
+      ethernet1/19         584295   584296   0    0        0        0        0   \
+      \     0\nethernet1/20         584295   584297   0    0        0        0   \
+      \     0        0\n\n**********************************************************************************\n\
+      AE group: ae2\nMembers:                Bndl Rx state       Mux state  Sel state\n\
+      \  ethernet1/11          yes  Current        Tx_Rx      Selected\nStatus:  \
+      \         Enabled\nMode:             Active\nRate:             Slow\nMax-port:\
+      \         8\nFast-failover:    Disabled\nPre-negotiation:  Enabled\nLocal: \
+      \           System Priority: 32768\n                  System MAC:      64:7c:e8:aa:bb:01\n\
+      \                  Key:             65\nPartner:          System Priority: 32768\n\
+      \                  System MAC:      64:7c:e8:aa:bb:01\n                  Key:\
+      \             67\nPort State\n--------------------------------------------------------------------------------\n\
+      Interface                       Port\n                    Number Priority  Mode\
+      \    Rate  Key      State\n--------------------------------------------------------------------------------\n\
+      ethernet1/11         26     32768    Active  Slow  65       0x3D\nPartner  \
+      \            27     32768    Active  Slow  67       0x3D\n\nPort Counters\n\
+      --------------------------------------------------------------------------------\n\
+      Interface               LACPDUs         Marker      Marker Response       Error\n\
+      \                    Sent     Recv     Sent Recv     Sent     Recv     Unknown\
+      \  Illegal\n--------------------------------------------------------------------------------\n\
+      ethernet1/11         584290   584286   0    0        0        0        0   \
+      \     0\n\n**********************************************************************************\n\
+      AE group: ae4\nMembers:                Bndl Rx state       Mux state  Sel state\n\
+      \  ethernet1/12          yes  Current        Tx_Rx      Selected\nStatus:  \
+      \         Enabled\nMode:             Active\nRate:             Slow\nMax-port:\
+      \         8\nFast-failover:    Disabled\nPre-negotiation:  Enabled\nLocal: \
+      \           System Priority: 32768\n                  System MAC:      64:7c:e8:aa:bb:01\n\
+      \                  Key:             67\nPartner:          System Priority: 32768\n\
+      \                  System MAC:      64:7c:e8:aa:bb:01\n                  Key:\
+      \             65\nPort State\n--------------------------------------------------------------------------------\n\
+      Interface                       Port\n                    Number Priority  Mode\
+      \    Rate  Key      State\n--------------------------------------------------------------------------------\n\
+      ethernet1/12         27     32768    Active  Slow  67       0x3D\nPartner  \
+      \            26     32768    Active  Slow  65       0x3D\n\nPort Counters\n\
+      --------------------------------------------------------------------------------\n\
+      Interface               LACPDUs         Marker      Marker Response       Error\n\
+      \                    Sent     Recv     Sent Recv     Sent     Recv     Unknown\
+      \  Illegal\n--------------------------------------------------------------------------------\n\
+      ethernet1/12         584290   584286   0    0        0        0        0   \
+      \     0\n\n**********************************************************************************\n\
+      AE group: ae5\nMembers:                Bndl Rx state       Mux state  Sel state\n\
+      \  ethernet1/15          yes  Current        Tx_Rx      Selected\n  ethernet1/17\
+      \          yes  Current        Tx_Rx      Selected\nStatus:           Enabled\n\
+      Mode:             Active\nRate:             Slow\nMax-port:         8\nFast-failover:\
+      \    Disabled\nPre-negotiation:  Enabled\nLocal:            System Priority:\
+      \ 32768\n                  System MAC:      64:7c:e8:aa:bb:01\n            \
+      \      Key:             68\nPartner:          System Priority: 65534\n     \
+      \             System MAC:      0a:00:00:aa:bb:cc\n                  Key:   \
+      \          101\nPort State\n--------------------------------------------------------------------------------\n\
+      Interface                       Port\n                    Number Priority  Mode\
+      \    Rate  Key      State\n--------------------------------------------------------------------------------\n\
+      ethernet1/15         30     32768    Active  Slow  68       0x3D\nPartner  \
+      \            1001   1        Active  Slow  101      0x3D\n\nethernet1/17   \
+      \      32     32768    Active  Slow  68       0x3D\nPartner              1 \
+      \     1        Active  Slow  101      0x3D\n\nPort Counters\n--------------------------------------------------------------------------------\n\
+      Interface               LACPDUs         Marker      Marker Response       Error\n\
+      \                    Sent     Recv     Sent Recv     Sent     Recv     Unknown\
+      \  Illegal\n--------------------------------------------------------------------------------\n\
+      ethernet1/15         584299   584270   0    0        0        0        0   \
+      \     0\nethernet1/17         584300   584271   0    0        0        0   \
+      \     0        0\n\n**********************************************************************************\n\
+      AE group: ae6\nMembers:                Bndl Rx state       Mux state  Sel state\n\
+      \  ethernet1/21          yes  Current        Tx_Rx      Selected\n  ethernet1/22\
+      \          yes  Current        Tx_Rx      Selected\nStatus:           Enabled\n\
+      Mode:             Active\nRate:             Slow\nMax-port:         8\nFast-failover:\
+      \    Disabled\nPre-negotiation:  Enabled\nLocal:            System Priority:\
+      \ 32768\n                  System MAC:      64:7c:e8:aa:bb:01\n            \
+      \      Key:             69\nPartner:          System Priority: 65534\n     \
+      \             System MAC:      0a:00:00:aa:bb:cc\n                  Key:   \
+      \          102\nPort State\n--------------------------------------------------------------------------------\n\
+      Interface                       Port\n                    Number Priority  Mode\
+      \    Rate  Key      State\n--------------------------------------------------------------------------------\n\
+      ethernet1/21         36     32768    Active  Slow  69       0x3D\nPartner  \
+      \            2      1        Active  Slow  102      0x3D\n\nethernet1/22   \
+      \      37     32768    Active  Slow  69       0x3D\nPartner              1002\
+      \   1        Active  Slow  102      0x3D\n\nPort Counters\n--------------------------------------------------------------------------------\n\
+      Interface               LACPDUs         Marker      Marker Response       Error\n\
+      \                    Sent     Recv     Sent Recv     Sent     Recv     Unknown\
+      \  Illegal\n--------------------------------------------------------------------------------\n\
+      ethernet1/21         584296   584297   0    0        0        0        0   \
+      \     0\nethernet1/22         584296   584297   0    0        0        0   \
+      \     0        0\n"


### PR DESCRIPTION
## Summary

#128 epic の最終 batch。NTC Templates v9.1 由来の新規コマンドを 10 platform に一括追加 (合計 75 commands、+5361 lines all-addition)。

| Platform | New commands |
|---|--:|
| mikrotik_routeros | 25 |
| linux | 15 |
| alcatel_aos | 12 |
| alcatel_sros | 7 |
| ciena_saos | 5 |
| aruba_os | 4 |
| extreme_exos | 2 |
| hp_procurve | 2 |
| paloalto_panos | 2 |
| aruba_aoscx | 1 |

## Excluded

- **hp_comware (2 cmds)** — #173 (open PR、HP 慣習書き換え) との conflict を避けるため除外。#173 マージ後に follow-up PR で対応。

## Out-of-table additions

`paloalto_panos` (2) と `aruba_aoscx` (1) は #128 table 上は完了扱い (✅) だったが、現 `sync_ntc_commands.py` 出力で新規 fixture が検出された。ntc-templates 側の更新で drift が出たため、epic を実質完了させる方向で本 PR に含めた。

## Approach

- `sync_ntc_commands.py` (`#123` 導入、`#147` 改善) で `/tmp/ntc-diff/{platform}.yaml` 生成
- Python merge script (`/tmp/merge_ntc.py`) で diff yaml の `commands:` セクションを既存 yaml 末尾に append (既存 entry は無変更)
- `invoke gen-docs-platform-commands` で docs 再生成

## Test plan

- [x] `yaml_has_correct_format` + `yaml_commands_has_correct_format`: 100 passed
- [x] 該当 10 platform `yaml_all_commands_are_running`: 全 PASS
- [x] `pytest tests/ -k "not docker" --timeout 600`: 749 passed, 7 skipped, 1 xfailed (huawei_smartax 既知)
- [x] `ruff check` + `ruff format --check`: クリーン
- [x] 衝突チェック: 既存コマンドキーとの重複なし

## Related

- 親: #128 (epic)
- 前例: #144 (cisco_ios, 28 cmds), #152 (Cisco family, 19 cmds), #155 (non-Cisco batch 1, 30 cmds)
- 依存: #123 / #147 (sync_ntc_commands.py)
- フォローアップ: #173 マージ後に hp_comware NTC commands を別 PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)