### PR TITLE
feat: add netmiko/scrapli/ansible compatibility CI workflow for cisco_ios (#125)

### DIFF
--- a/.github/workflows/compatibility.yml
+++ b/.github/workflows/compatibility.yml
@@ -1,0 +1,54 @@
+---
+name: SIMNOS Compatibility
+
+# Manually triggered. Verifies that simnos cisco_ios works with the major
+# network automation libraries (netmiko / scrapli / ansible). Tests live
+# under tests/compatibility/ and are gated by the `compatibility` marker
+# (excluded from the default suite).
+on:
+  workflow_dispatch: {}
+
+jobs:
+  netmiko:
+    runs-on: "ubuntu-latest"
+    steps:
+      - uses: "actions/checkout@v6"
+      - uses: "astral-sh/setup-uv@v7"
+        with:
+          version: "0.9.8"
+          activate-environment: true
+          enable-cache: true
+      - name: "Install compatibility dep group"
+        run: "uv sync --group compatibility"
+      - name: "Run netmiko compatibility tests"
+        run: "uv run pytest tests/compatibility/test_netmiko_cisco_ios.py -m compatibility"
+
+  scrapli:
+    runs-on: "ubuntu-latest"
+    steps:
+      - uses: "actions/checkout@v6"
+      - uses: "astral-sh/setup-uv@v7"
+        with:
+          version: "0.9.8"
+          activate-environment: true
+          enable-cache: true
+      - name: "Install compatibility dep group"
+        run: "uv sync --group compatibility"
+      - name: "Run scrapli compatibility tests"
+        run: "uv run pytest tests/compatibility/test_scrapli_cisco_ios.py -m compatibility"
+
+  ansible:
+    runs-on: "ubuntu-latest"
+    steps:
+      - uses: "actions/checkout@v6"
+      - uses: "astral-sh/setup-uv@v7"
+        with:
+          version: "0.9.8"
+          activate-environment: true
+          enable-cache: true
+      - name: "Install compatibility dep group"
+        run: "uv sync --group compatibility"
+      - name: "Install ansible collections"
+        run: "uv run ansible-galaxy collection install cisco.ios ansible.netcommon"
+      - name: "Run ansible compatibility tests"
+        run: "uv run pytest tests/compatibility/test_ansible_cisco_ios.py -m compatibility"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -151,7 +151,7 @@ dev = [
     "yamllint", # YAML linter
 ]
 compatibility = [
-    "netmiko",        # netmiko interop test
+    # netmiko is already in `dev` (default group), so not repeated here
     "scrapli",        # scrapli interop test
     "ansible-core",   # ansible interop test (cli_command / ios_facts)
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -117,7 +117,10 @@ directory = "coverage_html_report"
 
 [tool.pytest.ini_options]
 testpaths = ["tests"]
-addopts = "-vv -n auto"
+addopts = "-vv -n auto -m 'not compatibility'"
+markers = [
+    "compatibility: requires the `compatibility` dep group (netmiko/scrapli/ansible-core) and is run only via the compatibility CI workflow",
+]
 
 [tool.uv.build-backend]
 module-name = "simnos"
@@ -146,4 +149,9 @@ dev = [
     "mkdocs-static-i18n",
     "pymdown-extensions",
     "yamllint", # YAML linter
+]
+compatibility = [
+    "netmiko",        # netmiko interop test
+    "scrapli",        # scrapli interop test
+    "ansible-core",   # ansible interop test (cli_command / ios_facts)
 ]

--- a/simnos/plugins/nos/platforms_yaml/cisco_ios.yaml
+++ b/simnos/plugins/nos/platforms_yaml/cisco_ios.yaml
@@ -8,6 +8,16 @@ commands:
     new_prompt: "{base_prompt}#"
     help: enter enable mode
     prompt: "{base_prompt}>"
+  configure terminal:
+    output: null
+    new_prompt: "{base_prompt}(config)#"
+    help: enter global configuration mode
+    prompt: "{base_prompt}#"
+  end:
+    output: null
+    new_prompt: "{base_prompt}#"
+    help: exit configuration mode and return to enable mode
+    prompt: "{base_prompt}(config)#"
   show rep topology:
     output: 'REP Segment 1
 
@@ -4571,6 +4581,13 @@ commands:
     output: null
     help: Execute the command terminal width 511. This automatically generated. Feel
       free to change it!
+    prompt:
+    - "{base_prompt}>"
+    - "{base_prompt}#"
+  terminal width 512:
+    output: null
+    help: Execute the command terminal width 512. Used by scrapli for privilege escalation
+      preparation.
     prompt:
     - "{base_prompt}>"
     - "{base_prompt}#"

--- a/simnos/plugins/nos/platforms_yaml/cisco_ios.yaml
+++ b/simnos/plugins/nos/platforms_yaml/cisco_ios.yaml
@@ -18,6 +18,11 @@ commands:
     new_prompt: "{base_prompt}#"
     help: exit configuration mode and return to enable mode
     prompt: "{base_prompt}(config)#"
+  exit:
+    output: null
+    new_prompt: "{base_prompt}#"
+    help: exit current configuration sub-mode (from config mode returns to enable)
+    prompt: "{base_prompt}(config)#"
   show rep topology:
     output: 'REP Segment 1
 

--- a/tests/compatibility/conftest.py
+++ b/tests/compatibility/conftest.py
@@ -14,13 +14,12 @@ from tests.utils import get_free_port
 
 @pytest.fixture
 def cisco_ios_simnos():
-    """Start a simnos cisco_ios instance on a free port; yield (port, creds)."""
-    port = get_free_port()
+    """Start a simnos cisco_ios instance on a free port; yield connection creds."""
     creds = {
         "host": "localhost",
         "username": "test_user",
         "password": "test_pass",
-        "port": port,
+        "port": get_free_port(),
     }
     inventory = {
         "hosts": {
@@ -31,4 +30,4 @@ def cisco_ios_simnos():
         }
     }
     with SimNOS(inventory=inventory) as _net:
-        yield port, creds
+        yield creds

--- a/tests/compatibility/conftest.py
+++ b/tests/compatibility/conftest.py
@@ -1,0 +1,34 @@
+"""Shared fixtures for compatibility tests.
+
+These tests exercise simnos against external automation libraries
+(netmiko / scrapli / ansible) and are gated behind workflow_dispatch
+CI; they are skipped by default in the normal test suite via
+`pytest.mark.compatibility` (see pyproject `markers`).
+"""
+
+import pytest
+
+from simnos import SimNOS
+from tests.utils import get_free_port
+
+
+@pytest.fixture
+def cisco_ios_simnos():
+    """Start a simnos cisco_ios instance on a free port; yield (port, creds)."""
+    port = get_free_port()
+    creds = {
+        "host": "localhost",
+        "username": "test_user",
+        "password": "test_pass",
+        "port": port,
+    }
+    inventory = {
+        "hosts": {
+            "test_device": {
+                **{k: creds[k] for k in ("username", "password", "port")},
+                "platform": "cisco_ios",
+            }
+        }
+    }
+    with SimNOS(inventory=inventory) as _net:
+        yield port, creds

--- a/tests/compatibility/test_ansible_cisco_ios.py
+++ b/tests/compatibility/test_ansible_cisco_ios.py
@@ -49,7 +49,7 @@ def test_ansible_ios_facts(cisco_ios_simnos, tmp_path):
     if shutil.which("ansible-playbook") is None:
         pytest.skip("ansible-playbook not on PATH")
 
-    _port, creds = cisco_ios_simnos
+    creds = cisco_ios_simnos
     inventory = tmp_path / "inventory.yml"
     _write_inventory(inventory, creds)
     playbook = tmp_path / "play.yml"
@@ -74,7 +74,7 @@ def test_ansible_cli_command(cisco_ios_simnos, tmp_path):
     if shutil.which("ansible-playbook") is None:
         pytest.skip("ansible-playbook not on PATH")
 
-    _port, creds = cisco_ios_simnos
+    creds = cisco_ios_simnos
     inventory = tmp_path / "inventory.yml"
     _write_inventory(inventory, creds)
     playbook = tmp_path / "play.yml"

--- a/tests/compatibility/test_ansible_cisco_ios.py
+++ b/tests/compatibility/test_ansible_cisco_ios.py
@@ -1,0 +1,97 @@
+"""Compatibility check: ansible × cisco_ios.
+
+Uses ansible-playbook via subprocess against simnos. Requires
+`cisco.ios` + `ansible.netcommon` collections (installed in the
+compatibility CI job before running these tests).
+"""
+
+import os
+from pathlib import Path
+import shutil
+import subprocess
+import textwrap
+
+import pytest
+
+
+def _write_inventory(path: Path, creds: dict) -> None:
+    path.write_text(
+        textwrap.dedent(f"""\
+        all:
+          hosts:
+            test_device:
+              ansible_host: {creds["host"]}
+              ansible_port: {creds["port"]}
+              ansible_user: {creds["username"]}
+              ansible_password: {creds["password"]}
+              ansible_connection: ansible.netcommon.network_cli
+              ansible_network_os: cisco.ios.ios
+              ansible_become: true
+              ansible_become_method: enable
+    """)
+    )
+
+
+def _run_playbook(inventory: Path, playbook: Path) -> subprocess.CompletedProcess:
+    env = {**os.environ, "ANSIBLE_HOST_KEY_CHECKING": "False"}
+    return subprocess.run(
+        ["ansible-playbook", "-i", str(inventory), str(playbook)],
+        capture_output=True,
+        text=True,
+        timeout=120,
+        check=False,
+        env=env,
+    )
+
+
+@pytest.mark.compatibility
+def test_ansible_ios_facts(cisco_ios_simnos, tmp_path):
+    if shutil.which("ansible-playbook") is None:
+        pytest.skip("ansible-playbook not on PATH")
+
+    _port, creds = cisco_ios_simnos
+    inventory = tmp_path / "inventory.yml"
+    _write_inventory(inventory, creds)
+    playbook = tmp_path / "play.yml"
+    playbook.write_text(
+        textwrap.dedent("""\
+        - hosts: test_device
+          gather_facts: false
+          tasks:
+            - name: collect ios facts
+              cisco.ios.ios_facts:
+                gather_subset: min
+    """)
+    )
+
+    result = _run_playbook(inventory, playbook)
+    assert result.returncode == 0, f"ansible-playbook failed: stdout=\n{result.stdout}\nstderr=\n{result.stderr}"
+    assert "failed=0" in result.stdout
+
+
+@pytest.mark.compatibility
+def test_ansible_cli_command(cisco_ios_simnos, tmp_path):
+    if shutil.which("ansible-playbook") is None:
+        pytest.skip("ansible-playbook not on PATH")
+
+    _port, creds = cisco_ios_simnos
+    inventory = tmp_path / "inventory.yml"
+    _write_inventory(inventory, creds)
+    playbook = tmp_path / "play.yml"
+    playbook.write_text(
+        textwrap.dedent("""\
+        - hosts: test_device
+          gather_facts: false
+          tasks:
+            - name: show version via cli_command
+              ansible.netcommon.cli_command:
+                command: show version
+              register: result
+            - name: assert output contains Cisco IOS
+              ansible.builtin.assert:
+                that: "'Cisco IOS' in result.stdout"
+    """)
+    )
+
+    result = _run_playbook(inventory, playbook)
+    assert result.returncode == 0, f"ansible-playbook failed: stdout=\n{result.stdout}\nstderr=\n{result.stderr}"

--- a/tests/compatibility/test_netmiko_cisco_ios.py
+++ b/tests/compatibility/test_netmiko_cisco_ios.py
@@ -1,0 +1,26 @@
+"""Compatibility check: netmiko × cisco_ios."""
+
+from netmiko import ConnectHandler
+import pytest
+
+
+@pytest.mark.compatibility
+def test_netmiko_connect_and_show_version(cisco_ios_simnos):
+    _port, creds = cisco_ios_simnos
+    device = {**creds, "device_type": "cisco_ios"}
+    with ConnectHandler(**device) as conn:
+        conn.enable()
+        out = conn.send_command("show version")
+        assert "Cisco IOS" in out
+
+
+@pytest.mark.compatibility
+def test_netmiko_config_mode_round_trip(cisco_ios_simnos):
+    _port, creds = cisco_ios_simnos
+    device = {**creds, "device_type": "cisco_ios"}
+    with ConnectHandler(**device) as conn:
+        conn.enable()
+        conn.config_mode()
+        assert conn.check_config_mode()
+        conn.exit_config_mode()
+        assert not conn.check_config_mode()

--- a/tests/compatibility/test_netmiko_cisco_ios.py
+++ b/tests/compatibility/test_netmiko_cisco_ios.py
@@ -1,7 +1,9 @@
 """Compatibility check: netmiko × cisco_ios."""
 
-from netmiko import ConnectHandler
 import pytest
+
+pytest.importorskip("netmiko")
+from netmiko import ConnectHandler
 
 
 @pytest.mark.compatibility

--- a/tests/compatibility/test_netmiko_cisco_ios.py
+++ b/tests/compatibility/test_netmiko_cisco_ios.py
@@ -6,7 +6,7 @@ import pytest
 
 @pytest.mark.compatibility
 def test_netmiko_connect_and_show_version(cisco_ios_simnos):
-    _port, creds = cisco_ios_simnos
+    creds = cisco_ios_simnos
     device = {**creds, "device_type": "cisco_ios"}
     with ConnectHandler(**device) as conn:
         conn.enable()
@@ -16,7 +16,7 @@ def test_netmiko_connect_and_show_version(cisco_ios_simnos):
 
 @pytest.mark.compatibility
 def test_netmiko_config_mode_round_trip(cisco_ios_simnos):
-    _port, creds = cisco_ios_simnos
+    creds = cisco_ios_simnos
     device = {**creds, "device_type": "cisco_ios"}
     with ConnectHandler(**device) as conn:
         conn.enable()

--- a/tests/compatibility/test_scrapli_cisco_ios.py
+++ b/tests/compatibility/test_scrapli_cisco_ios.py
@@ -1,0 +1,33 @@
+"""Compatibility check: scrapli × cisco_ios."""
+
+import pytest
+from scrapli.driver.core import IOSXEDriver
+
+
+def _scrapli_creds(creds: dict) -> dict:
+    return {
+        "host": creds["host"],
+        "auth_username": creds["username"],
+        "auth_password": creds["password"],
+        "auth_strict_key": False,
+        "port": creds["port"],
+        "transport": "paramiko",
+    }
+
+
+@pytest.mark.compatibility
+def test_scrapli_connect_and_show_version(cisco_ios_simnos):
+    _port, creds = cisco_ios_simnos
+    with IOSXEDriver(**_scrapli_creds(creds)) as conn:
+        resp = conn.send_command("show version")
+        assert not resp.failed
+        assert "Cisco IOS" in resp.result
+
+
+@pytest.mark.compatibility
+def test_scrapli_show_running_config(cisco_ios_simnos):
+    _port, creds = cisco_ios_simnos
+    with IOSXEDriver(**_scrapli_creds(creds)) as conn:
+        resp = conn.send_command("show running-config")
+        assert not resp.failed
+        assert "hostname" in resp.result

--- a/tests/compatibility/test_scrapli_cisco_ios.py
+++ b/tests/compatibility/test_scrapli_cisco_ios.py
@@ -1,6 +1,8 @@
 """Compatibility check: scrapli × cisco_ios."""
 
 import pytest
+
+pytest.importorskip("scrapli")
 from scrapli.driver.core import IOSXEDriver
 
 

--- a/tests/compatibility/test_scrapli_cisco_ios.py
+++ b/tests/compatibility/test_scrapli_cisco_ios.py
@@ -17,7 +17,7 @@ def _scrapli_creds(creds: dict) -> dict:
 
 @pytest.mark.compatibility
 def test_scrapli_connect_and_show_version(cisco_ios_simnos):
-    _port, creds = cisco_ios_simnos
+    creds = cisco_ios_simnos
     with IOSXEDriver(**_scrapli_creds(creds)) as conn:
         resp = conn.send_command("show version")
         assert not resp.failed
@@ -26,7 +26,7 @@ def test_scrapli_connect_and_show_version(cisco_ios_simnos):
 
 @pytest.mark.compatibility
 def test_scrapli_show_running_config(cisco_ios_simnos):
-    _port, creds = cisco_ios_simnos
+    creds = cisco_ios_simnos
     with IOSXEDriver(**_scrapli_creds(creds)) as conn:
         resp = conn.send_command("show running-config")
         assert not resp.failed

--- a/uv.lock
+++ b/uv.lock
@@ -1229,7 +1229,6 @@ dependencies = [
 [package.dev-dependencies]
 compatibility = [
     { name = "ansible-core" },
-    { name = "netmiko" },
     { name = "scrapli" },
 ]
 dev = [
@@ -1264,7 +1263,6 @@ requires-dist = [
 [package.metadata.requires-dev]
 compatibility = [
     { name = "ansible-core" },
-    { name = "netmiko" },
     { name = "scrapli" },
 ]
 dev = [

--- a/uv.lock
+++ b/uv.lock
@@ -12,6 +12,22 @@ wheels = [
 ]
 
 [[package]]
+name = "ansible-core"
+version = "2.20.5"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "cryptography" },
+    { name = "jinja2" },
+    { name = "packaging" },
+    { name = "pyyaml" },
+    { name = "resolvelib" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/9d/ec/690cc73e38c3546eabc8ef4118e0d7be1758a598bc23eed3e24ca1f346a7/ansible_core-2.20.5.tar.gz", hash = "sha256:82e3049d95e6e02e5d20d4a5a8e10533a55e0cc52e878e4cf77166c45410f16f", size = 3339511, upload-time = "2026-04-21T00:48:27.175Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f9/e1/4454505e725b84ae670229565dfc20c4075480199647bf4874cf337c560e/ansible_core-2.20.5-py3-none-any.whl", hash = "sha256:ff6ff15c6a37fda07dc7400207e17e93727b24173ca48c068b3311a50d75ecc3", size = 2416843, upload-time = "2026-04-21T00:48:25.413Z" },
+]
+
+[[package]]
 name = "babel"
 version = "2.18.0"
 source = { registry = "https://pypi.org/simple" }
@@ -1122,6 +1138,15 @@ wheels = [
 ]
 
 [[package]]
+name = "resolvelib"
+version = "1.2.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/1d/14/4669927e06631070edb968c78fdb6ce8992e27c9ab2cde4b3993e22ac7af/resolvelib-1.2.1.tar.gz", hash = "sha256:7d08a2022f6e16ce405d60b68c390f054efcfd0477d4b9bd019cc941c28fad1c", size = 24575, upload-time = "2025-10-11T01:07:44.582Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e2/23/c941a0d0353681ca138489983c4309e0f5095dfd902e1357004f2357ddf2/resolvelib-1.2.1-py3-none-any.whl", hash = "sha256:fb06b66c8da04172d9e72a21d7d06186d8919e32ae5ab5cdf5b9d920be805ac2", size = 18737, upload-time = "2025-10-11T01:07:43.081Z" },
+]
+
+[[package]]
 name = "rich"
 version = "14.3.3"
 source = { registry = "https://pypi.org/simple" }
@@ -1181,6 +1206,15 @@ wheels = [
 ]
 
 [[package]]
+name = "scrapli"
+version = "2026.2.20"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/cc/20/5a16997013f9aca4100e41493a93af774b1e73ef2c0fafc312a250b7425a/scrapli-2026.2.20.tar.gz", hash = "sha256:b6f8492110601c11ca8394d8540814464bb97681b87e92b30bb6853b5213558a", size = 104525, upload-time = "2026-02-20T23:42:57.414Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/2f/bd/4297e274df5cb43d0e3a85d9a30e7298daa13185f26442ef3f142a047105/scrapli-2026.2.20-py3-none-any.whl", hash = "sha256:abbe6f0d70e9b59166e590a74335781e4b5987a488403e08110ce75321a255af", size = 145891, upload-time = "2026-02-20T23:42:56.113Z" },
+]
+
+[[package]]
 name = "simnos"
 version = "2.2.1"
 source = { editable = "." }
@@ -1193,6 +1227,11 @@ dependencies = [
 ]
 
 [package.dev-dependencies]
+compatibility = [
+    { name = "ansible-core" },
+    { name = "netmiko" },
+    { name = "scrapli" },
+]
 dev = [
     { name = "bandit" },
     { name = "coverage" },
@@ -1223,6 +1262,11 @@ requires-dist = [
 ]
 
 [package.metadata.requires-dev]
+compatibility = [
+    { name = "ansible-core" },
+    { name = "netmiko" },
+    { name = "scrapli" },
+]
 dev = [
     { name = "bandit" },
     { name = "coverage" },


### PR DESCRIPTION
## Summary

#125 epic の Phase 1+2+3 を cisco_ios だけで先行実装。netmiko / scrapli / ansible の 3 ライブラリが simnos cisco_ios と動作することを workflow_dispatch CI で常時検証可能にする。Phase 4 (他 OS 拡大) は別 PR。

## Changes

- \`tests/compatibility/\` 配下に 3 lib × cisco_ios の動作確認 pytest:
  - netmiko: connect + show_version + config_mode round-trip
  - scrapli: connect + show_version + show running-config
  - ansible: ios_facts + cli_command (subprocess + ansible-playbook)
- \`pyproject.toml\` に \`compatibility\` dep group (\`scrapli\` + \`ansible-core\`、\`netmiko\` は \`dev\` 既存) + \`compatibility\` pytest marker + addopts で default suite から除外
- \`.github/workflows/compatibility.yml\` を workflow_dispatch で新設、3 ライブラリそれぞれ独立 job (\`ansible\` job のみ \`ansible-galaxy collection install\` step 含む)
- \`simnos/plugins/nos/platforms_yaml/cisco_ios.yaml\` に不足コマンド追加:
  - \`terminal width 512\` (scrapli on_open privilege escalation 準備)
  - \`configure terminal\` + \`end\` + \`exit\` (netmiko \`config_mode()\` 経路 + gemini SUGGESTION の real Cisco IOS 挙動再現)

## Test plan

- [x] \`pytest tests/compatibility/ -m compatibility --timeout 120\`: 6/6 PASS (netmiko 2 + scrapli 2 + ansible 2)
- [x] \`pytest tests/ -k \"not docker\" --timeout 600\`: 749 passed, 7 skipped, 1 xfailed (huawei_smartax 既知)
- [x] \`ruff check\` / \`ruff format --check\`: クリーン
- [x] scrapli 一時 uninstall + \`pytest --collect-only\`: \`pytest.importorskip\` で module 単位 skip 確認 (codex 1st review MUST FIX への対応)

## Review iterations

- pre-review-refactor (commit \`8efa8f7\`): fixture が yield する不要な port unpacking を削除
- 1st cross-review (gemini LGTM / claude MUST FIX (false positive 判定) / codex MUST FIX (real bug))
- codex MUST FIX 対応 (commit \`2b8ce55\`): \`pytest.importorskip\` を module-top に追加 (collection isolation)
- claude S-7 対応: \`compatibility\` group から \`netmiko\` を削除 (\`dev\` に既存で重複)
- gemini SUGGESTION 対応: \`cisco_ios.yaml\` に \`exit\` コマンド追加
- final-refactor: クリーン

## Defer items

worklog \`20260515_052817_claude_issue-125-compatibility-workflow.md\` に記録:

- ansible collection install cache (claude S-1) — CI 効率改善、別 chore
- 3 job DRY 化 (matrix or composite action、claude S-2) — 明示性 trade-off
- SimNOS startup TOCTOU race (claude S-3) — 既存 pattern 踏襲
- ansible env vars (NOCOLOR / json callback、claude S-4) — functional
- \`terminal width 512\` future risk note (claude S-5) — memo level
- dep version pin (claude S-6) — 全 dep pin で別 PR 検討
- \`shutil.which\` skip 冗長 (claude S-8) — local 防御
- ansible \`requirements.yml\` 化 (gemini SUGGESTION) — Phase 4 で OS 拡大時

## Related

- 親: #125 (compatibility workflow epic)
- 依存: #124 (ansible-required commands、closed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)