### PR TITLE
fix: ipinfusion_ocnos に netmiko 4.7.0 session_preparation handler を追加 (#195)

### DIFF
--- a/docs/platforms/ipinfusion_ocnos.md
+++ b/docs/platforms/ipinfusion_ocnos.md
@@ -51,6 +51,26 @@ Total entries displayed:  7
 - ipinfusion_ocnos>
 - ipinfusion_ocnos#
 
+### terminal length 0
+
+**Output:** None
+
+**Help:** disable pagination (netmiko session_preparation)
+
+**Prompt:**
+- ipinfusion_ocnos>
+- ipinfusion_ocnos#
+
+### terminal no monitor
+
+**Output:** None
+
+**Help:** disable monitor output (netmiko 4.7.0+ session_preparation)
+
+**Prompt:**
+- ipinfusion_ocnos>
+- ipinfusion_ocnos#
+
 ### show curpriv
 
 **Output:** None

--- a/simnos/plugins/nos/platforms_yaml/ipinfusion_ocnos.yaml
+++ b/simnos/plugins/nos/platforms_yaml/ipinfusion_ocnos.yaml
@@ -45,6 +45,18 @@ commands:
     prompt:
     - "{base_prompt}>"
     - "{base_prompt}#"
+  terminal length 0:
+    output: null
+    help: disable pagination (netmiko session_preparation)
+    prompt:
+    - "{base_prompt}>"
+    - "{base_prompt}#"
+  terminal no monitor:
+    output: null
+    help: disable monitor output (netmiko 4.7.0+ session_preparation)
+    prompt:
+    - "{base_prompt}>"
+    - "{base_prompt}#"
   show curpriv:
     output: null
     help: Execute the command show curpriv. This automatically generated. Feel free

--- a/tests/core/test_netmiko_init_compat.py
+++ b/tests/core/test_netmiko_init_compat.py
@@ -28,7 +28,6 @@ INIT_UNKNOWN_CMD_ALLOWED = {
     "brocade_fastiron",  # enable (repeated)
     "dlink_ds",  # disable clipaging
     "huawei_smartax",  # enable password (#70)
-    "ipinfusion_ocnos",  # terminal length 0
     "ruckus_fastiron",  # enable (repeated), skip-page-display
     "vyatta_vyos",  # set terminal width 512
 }


### PR DESCRIPTION
🐙claude:

Closes #195

## Summary

- netmiko 4.7.0 で `ipinfusion_ocnos` の `session_preparation()` に `terminal no monitor` が追加された (netmiko PR #3596 — OCNOS commit model 一環)。bundled yaml に handler が無く、netmiko 4.7.0 経由で接続した user が `Unknown command` を踏むのを修正
- 元々 netmiko 4.6.0 時点から `terminal length 0` も bundled に未定義で、test の `INIT_UNKNOWN_CMD_ALLOWED` に exclusion 入りで TODO 化されていた。2 handler を同 PR でまとめて追加し、TODO 解消も実施
- netmiko v4.6.0...v4.7.0 の 136 commits を全件 cross-check した結果、SimNOS bundled で session_preparation に新規 command が追加されたのは `ipinfusion_ocnos` の 1 件のみだった (詳細は Issue #195 参照)

## 変更内容

| ファイル | 内容 |
|---|---|
| `simnos/plugins/nos/platforms_yaml/ipinfusion_ocnos.yaml` | `terminal length 0` (netmiko session_preparation) + `terminal no monitor` (netmiko 4.7.0+ session_preparation) の 2 handler 追加 |
| `tests/core/test_netmiko_init_compat.py` | `INIT_UNKNOWN_CMD_ALLOWED` から `ipinfusion_ocnos` 削除 |
| `docs/platforms/ipinfusion_ocnos.md` | `invoke gen-docs-platform-commands` で自動再生成 |

## Test plan

- [x] `pytest tests/core/test_netmiko_init_compat.py` 全件 pass (146 passed / 6 skipped)
  - 元の `INIT_UNKNOWN_CMD_ALLOWED` 7 件 → 6 件に減少 (ipinfusion_ocnos が exclusion 解除されて enable)
  - `test_no_unknown_command_on_init[ipinfusion_ocnos]` PASSED
  - `test_unknown_command_graceful[ipinfusion_ocnos]` PASSED
  - `test_send_command_returns_defined_output[ipinfusion_ocnos]` PASSED
- [x] `invoke ruff` clean
- [x] `invoke yamllint` clean
- [x] `invoke gen-docs-platform-commands` で docs 再生成 → diff 確認 (cisco_ios.md の pre-existing drift は本 PR から除外して revert)
- [ ] CI 全件 green 確認 (本 PR 上で確認)

## 参照

- KeroRoute 側 fix (独自 plugin への同等 patch、外部 user の実例): https://github.com/Route-Reflector/KeroRoute/pull/774
- netmiko v4.6.0 → v4.7.0 比較: https://github.com/ktbyers/netmiko/compare/v4.6.0...v4.7.0
- netmiko PR #3596 (OCNOS commit model — terminal no monitor 追加元): https://github.com/ktbyers/netmiko/pull/3596

## 備考

本 PR では netmiko 自体の version bump は行っていません (yaml-only 修正で netmiko 4.6.0 / 4.7.0 両対応)。netmiko 4.7.0 への bump は別 PR (dependabot 等) で扱うことを想定。

🤖 Generated with [Claude Code](https://claude.com/claude-code)