### PR TITLE
chore: refactor inventory triage Bundle B — docstring / type hint 追加 5 件 (#199)

### DIFF
--- a/simnos/core/__init__.py
+++ b/simnos/core/__init__.py
@@ -1,1 +1,3 @@
-"""SimNOS core: SSH server, host orchestration, validation models."""
+"""
+SimNOS core: SSH server, host orchestration, validation models.
+"""

--- a/simnos/core/__init__.py
+++ b/simnos/core/__init__.py
@@ -1,0 +1,1 @@
+"""SimNOS core: SSH server, host orchestration, validation models."""

--- a/simnos/core/host.py
+++ b/simnos/core/host.py
@@ -5,9 +5,13 @@ It also validates the host object using pydantic.
 """
 
 import logging
+from typing import TYPE_CHECKING
 
 from simnos.core.nos import Nos, available_platforms
 from simnos.core.pydantic_models import ModelHost
+
+if TYPE_CHECKING:
+    from simnos.core.simnos import SimNOS
 
 log = logging.getLogger(__name__)
 
@@ -26,7 +30,7 @@ class Host:
         server: dict,
         shell: dict,
         nos: dict,
-        simnos,
+        simnos: "SimNOS",
         platform: str | None = None,
         configuration_file: str | None = None,
     ) -> None:

--- a/simnos/core/nos.py
+++ b/simnos/core/nos.py
@@ -118,27 +118,16 @@ class Nos:
         """
         Method to build NOS from dictionary data.
 
-        Sample NOS dictionary::
+        The per-command schema follows :class:`simnos.core.pydantic_models.ModelNosCommand`;
+        a live Python plugin example is :mod:`simnos.plugins.nos.platforms_py.cisco_ios`.
+
+        Minimal sample::
 
             nos_plugin_dict = {
                 "name": "MySimNOSPlugin",
                 "initial_prompt": "{base_prompt}>",
                 "commands": {
-                    "terminal width 511": {
-                        "output": "",
-                        "help": "Set terminal width to 511",
-                        "prompt": "{base_prompt}>",
-                    },
-                    "terminal length 0": {
-                        "output": "",
-                        "help": "Set terminal length to 0",
-                        "prompt": "{base_prompt}>",
-                    },
-                    "show clock": {
-                        "output": "MySimNOSPlugin system time is 00:00:00",
-                        "help": "Show system time",
-                        "prompt": "{base_prompt}>",
-                    },
+                    "show clock": {"output": "12:00:00", "help": "Show clock"},
                 },
             }
 
@@ -155,26 +144,10 @@ class Nos:
         """
         Method to build NOS from YAML file.
 
-        Sample NOS YAML file content::
-
-            name: "MySimNOSPlugin"
-            initial_prompt: "{base_prompt}>"
-            commands:
-                terminal width 511: {
-                    "output": "",
-                    "help": "Set terminal width to 511",
-                    "prompt": "{base_prompt}>",
-                }
-                terminal length 0: {
-                    "output": "",
-                    "help": "Set terminal length to 0",
-                    "prompt": "{base_prompt}>",
-                }
-                show clock: {
-                    "output": "MySimNOSPlugin system time is 00:00:00",
-                    "help": "Show system time",
-                    "prompt": "{base_prompt}>",
-                }
+        The YAML mirrors the dict schema accepted by :meth:`from_dict`;
+        see :class:`simnos.core.pydantic_models.ModelNosCommand` for the
+        per-command schema and ``simnos/plugins/nos/platforms_yaml/cisco_ios.yaml``
+        for a live example.
 
         :param filepath: OS path to YAML file with NOS data
         """
@@ -188,29 +161,10 @@ class Nos:
         Loads from the .py file using the recipe:
         https://docs.python.org/3/library/importlib.html#importing-a-source-file-directly
 
-        Sample Python NOS plugin file::
-
-            name = "MySimNOSPlugin"
-
-            INITIAL_PROMPT = "{base_prompt}>"
-
-            commands = {
-                "terminal width 511": {
-                    "output": "",
-                    "help": "Set terminal width to 511",
-                    "prompt": "{base_prompt}>",
-                },
-                "terminal length 0": {
-                    "output": "",
-                    "help": "Set terminal length to 0",
-                    "prompt": "{base_prompt}>",
-                },
-                "show clock": {
-                    "output": "MySimNOSPlugin system time is 00:00:00",
-                    "help": "Show system time",
-                    "prompt": "{base_prompt}>",
-                },
-            }
+        The module is expected to define module-level constants (``NAME``,
+        ``INITIAL_PROMPT``, optional ``ENABLE_PROMPT`` / ``CONFIG_PROMPT`` /
+        ``DEVICE_NAME`` / ``DEFAULT_CONFIGURATION``) and a ``commands`` dict;
+        see :mod:`simnos.plugins.nos.platforms_py.cisco_ios` for a live example.
 
         :param filename: OS path string to Python .py file
         """

--- a/simnos/core/simnos.py
+++ b/simnos/core/simnos.py
@@ -150,7 +150,7 @@ class SimNOS:
             self._check_ports_and_replicas(port, replicas)
             self._instantiate_host_object(host_name, port, replicas, params)
 
-    def _check_ports_and_replicas(self, port, replicas):
+    def _check_ports_and_replicas(self, port: int | list[int], replicas: int | None) -> None:
         """
         Method to check if the port and replicas are valid
 
@@ -170,7 +170,9 @@ class SimNOS:
         if replicas and port[1] - port[0] + 1 != replicas:
             raise ValueError("If replicas is set, port range must be equal to the number of replicas.")
 
-    def _instantiate_host_object(self, host_name: str, port: int | list[int], replicas: int | None, params: dict):
+    def _instantiate_host_object(
+        self, host_name: str, port: int | list[int], replicas: int | None, params: dict
+    ) -> None:
         """
         Method that instantiate the host objects. It initializes the hosts
         with the corresponding name, port and network operating system
@@ -185,7 +187,9 @@ class SimNOS:
         for h_name, p in zip(hosts_name, ports, strict=True):
             self._instantiate_single_host_object(h_name, p, params)
 
-    def _get_hosts_and_ports(self, host_name: str, port: int | list[int], replicas: int | None = None):
+    def _get_hosts_and_ports(
+        self, host_name: str, port: int | list[int], replicas: int | None = None
+    ) -> tuple[list[str], list[int]]:
         """
         Method to get hosts and ports correctly
         depending on the number of replicas (if exists).
@@ -202,7 +206,7 @@ class SimNOS:
             ports = [port]
         return hosts_name, ports
 
-    def _instantiate_single_host_object(self, host: str, port: int, params: dict):
+    def _instantiate_single_host_object(self, host: str, port: int, params: dict) -> None:
         """
         Method that instantiates a single host object.
 
@@ -353,7 +357,7 @@ class SimNOS:
         parallel: bool = False,
         workers: int | None = None,
         deadline: float | None = None,
-    ):
+    ) -> None:
         """
         Function that executes a function like start or stop over
         the selected hosts.

--- a/simnos/plugins/__init__.py
+++ b/simnos/plugins/__init__.py
@@ -1,0 +1,1 @@
+"""SimNOS plugins: pluggable servers, shells, and NOS plugin modules."""

--- a/simnos/plugins/__init__.py
+++ b/simnos/plugins/__init__.py
@@ -1,1 +1,3 @@
-"""SimNOS plugins: pluggable servers, shells, and NOS plugin modules."""
+"""
+SimNOS plugins: pluggable servers, shells, and NOS plugin modules.
+"""

--- a/simnos/plugins/nos/platforms_py/__init__.py
+++ b/simnos/plugins/nos/platforms_py/__init__.py
@@ -1,0 +1,1 @@
+"""SimNOS NOS plugin modules implemented as Python files (callable command handlers)."""

--- a/simnos/plugins/nos/platforms_py/__init__.py
+++ b/simnos/plugins/nos/platforms_py/__init__.py
@@ -1,1 +1,3 @@
-"""SimNOS NOS plugin modules implemented as Python files (callable command handlers)."""
+"""
+SimNOS NOS plugin modules implemented as Python files (callable command handlers).
+"""

--- a/simnos/plugins/nos/platforms_py/base_template.py
+++ b/simnos/plugins/nos/platforms_py/base_template.py
@@ -12,14 +12,14 @@ import yaml
 class BaseDevice:
     """Interface for all devices."""
 
-    def __init__(self, configuration_file: str) -> None:
+    def __init__(self, configuration_file: str | None = None) -> None:
         self.configurations = self.load_configurations(configuration_file)
         self.env = Environment(
             loader=PackageLoader("simnos.plugins.nos.platforms_py", "templates"),
             autoescape=False,  # noqa: S701 — output is CLI text, not HTML
         )
 
-    def load_configurations(self, configuration_file: str) -> dict:
+    def load_configurations(self, configuration_file: str | None) -> dict:
         """
         Load configurations from a file.
         The file can be either a YAML file or a Jinja2 template.

--- a/simnos/plugins/utils/__init__.py
+++ b/simnos/plugins/utils/__init__.py
@@ -1,1 +1,3 @@
-"""Plugin utility helpers shared across SimNOS plugin packages."""
+"""
+Plugin utility helpers shared across SimNOS plugin packages.
+"""

--- a/simnos/plugins/utils/__init__.py
+++ b/simnos/plugins/utils/__init__.py
@@ -1,0 +1,1 @@
+"""Plugin utility helpers shared across SimNOS plugin packages."""


### PR DESCRIPTION
## Summary

- umbrella issue #199 (refactor inventory triage) の **Bundle B — docstring / type hint 追加 5 件** を取り込み
- Bundle A (PR #200 merge 済) に続く 2 件目、scope は internal API 表面の整理
- 全 8 file / +37 / -68、設計判断不要の docstring / 型注釈追加
- cross-review は内容軽量のため skip、final-refactor で `__init__.py` docstring style 統一 1 件取り込み

## 取り込んだ項目 (棚卸し doc の Bundle B 全件)

- **C-1**: `simnos/core/__init__.py` (0 byte) に module docstring 追加
- **C-16**: `SimNOS` private method (`_check_ports_and_replicas` / `_instantiate_host_object` / `_get_hosts_and_ports` / `_instantiate_single_host_object` / `_execute_function_over_hosts`) に type hint を追加 (戻り値型 `-> None` / `-> tuple[list[str], list[int]]`、欠けていた引数型注釈も追加)
- **C-29**: `Nos.from_dict` / `_from_yaml` / `_from_module` の docstring sample を縮小し、`pydantic_models.ModelNosCommand` および live plugin example (`simnos.plugins.nos.platforms_py.cisco_ios` / `cisco_ios.yaml`) への link 化。schema SSoT を pydantic に寄せる方針
- **C-33**: `Host.__init__` の `simnos` 引数に `TYPE_CHECKING` + forward reference (`simnos: "SimNOS"`) を入れ、循環 import を避けつつ型注釈
- **P-30**: `BaseDevice.__init__` の `configuration_file: str` → `str | None = None`、`load_configurations` も同様。Bundle A (PR #200) で `DEFAULT_CONFIGURATION` 削除後 `None` 経路が通常になった事実を型でも追認 (Bundle A cross-review の codex SUGGESTION への対応)

## pre-review-refactor / final-refactor で取り込んだ追加 cleanup

### pre-review-refactor Phase 2 (commit 568df56 内)

C-1 と同じ「empty `__init__.py`」が他 3 file (`simnos/plugins/__init__.py` / `simnos/plugins/utils/__init__.py` / `simnos/plugins/nos/platforms_py/__init__.py`) にも残っていたため、tailored docstring を追加。これで `simnos/` 配下の全 `__init__.py` が docstring 付きで揃う (Bundle A の precedent と同じ paradigm)。

### final-refactor Phase 2 (commit 0cf3664)

既存 `simnos/__init__.py` / `simnos/plugins/shell/__init__.py` / `simnos/plugins/servers/__init__.py` / `simnos/plugins/nos/__init__.py` の docstring が全て multi-line block style だったのに対し、本 branch で追加した 4 file (`simnos/core/__init__.py` / `simnos/plugins/__init__.py` / `simnos/plugins/utils/__init__.py` / `simnos/plugins/nos/platforms_py/__init__.py`) は single-line で書いてしまっていた。「1 箇所だけ別 style」を避けるため multi-line block に統一。

## Bundle A との関連

P-30 (BaseDevice の `str | None`) は **Bundle A の cross-review で codex が SUGGESTION として挙げていた item の解消**。Bundle A の P-2 で `DEFAULT_CONFIGURATION` を削除した結果 `configuration_file=None` 経路が通常になったが、型注釈は `str` のままだった。本 PR で型でも追認する形でクローズ。

## Test plan

- [x] `uv run invoke ruff` (check + format --check) — clean (51 files already formatted)
- [x] `uv run invoke yamllint` — clean
- [x] `uv run invoke bandit` — 0 issues
- [x] `uv run pytest tests/ -n auto --timeout=120 --ignore=tests/core/test_docker.py` — 756 passed / 7 skipped / 1 xfailed
- [x] pre-review-refactor + final-refactor 両方実施済

## defer (前 PR Bundle A から引き継ぎ、umbrella issue #199 のフォローアップ TODO 候補)

本 PR の scope 外。前 PR Bundle A の worklog Notes に詳細記録あり:

- `tests/` 配下の dead pylint disable — Bundle E 系で扱う候補
- C-15 で削除した pydantic v1 `conint` 制約 (port 1-65535 / unique_items) を v2 で復元するか判断 — 別 issue 候補
- 2 件の pre-existing flaky test (`test_docker` / `test_get_files_changed_null`) — 別途調査

## umbrella issue 進捗

merge 後、本 PR で +5 (C-1 / C-16 / C-29 / C-33 / P-30) → **10/30 checkbox ticked** になる見込み。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
