### PR TITLE
chore: refactor inventory triage Bundle C — 機械的 fix 5 件 (#199)

### DIFF
--- a/simnos/core/host.py
+++ b/simnos/core/host.py
@@ -61,8 +61,6 @@ class Host:
         """Method to start server instance for this host."""
         self.server_plugin = self.simnos.servers_plugins[self.server_inventory["plugin"]]
         self.shell_plugin = self.simnos.shell_plugins[self.shell_inventory["plugin"]]
-        if self.platform:
-            self.nos_inventory["plugin"] = self.platform
         self.nos_plugin = self.simnos.nos_plugins.get(self.nos_inventory["plugin"], self.nos_inventory["plugin"])
         self.nos = (
             Nos(filename=self.nos_plugin, configuration_file=self.configuration_file)
@@ -83,7 +81,13 @@ class Host:
         self.running = True
 
     def stop(self):
-        """Method to stop server instance for this host."""
+        """Method to stop server instance for this host.
+
+        No-op if the server was never started or has already been stopped
+        (``self.server is None``); this guards against double-stop calls.
+        """
+        if self.server is None:
+            return
         self.server.stop()
         self.server = None
         self.running = False

--- a/simnos/core/nos.py
+++ b/simnos/core/nos.py
@@ -71,6 +71,17 @@ class Nos:
     Base class to build NOS plugins instances to use with SIMNOS.
     """
 
+    # Mapping of module-level UPPERCASE constants in a Python plugin file
+    # to the corresponding lowercase attribute on the Nos instance.
+    # Used by `_from_module` to sync module constants into self.
+    _MODULE_ATTR_MAP: dict[str, str] = {
+        "NAME": "name",
+        "INITIAL_PROMPT": "initial_prompt",
+        "AUTH": "auth",
+        "ENABLE_PROMPT": "enable_prompt",
+        "CONFIG_PROMPT": "config_prompt",
+    }
+
     def __init__(
         self,
         name: str = "SimNOS",
@@ -171,12 +182,9 @@ class Nos:
         spec = importlib.util.spec_from_file_location("module.name", filename)
         module = importlib.util.module_from_spec(spec)
         spec.loader.exec_module(module)
-        self.name = getattr(module, "NAME", self.name)
+        for module_attr, self_attr in self._MODULE_ATTR_MAP.items():
+            setattr(self, self_attr, getattr(module, module_attr, getattr(self, self_attr)))
         self.commands.update(getattr(module, "commands", self.commands))
-        self.initial_prompt = getattr(module, "INITIAL_PROMPT", self.initial_prompt)
-        self.auth = getattr(module, "AUTH", self.auth)
-        self.enable_prompt = getattr(module, "ENABLE_PROMPT", self.enable_prompt)
-        self.config_prompt = getattr(module, "CONFIG_PROMPT", self.config_prompt)
         classname = getattr(module, "DEVICE_NAME", None)
         if classname is None:
             log.warning("Module '%s' does not define DEVICE_NAME; device will be None", filename)

--- a/simnos/core/servers.py
+++ b/simnos/core/servers.py
@@ -136,7 +136,8 @@ class TCPServerBase(ABC):
             with contextlib.suppress(OSError):
                 self._wakeup_w.send(b"\x00")
 
-        self._listen_thread.join(timeout=2)
+        # fail-safe join — wakeup socket may have failed; bound by _SHUTDOWN_TIMEOUT.
+        self._listen_thread.join(timeout=_SHUTDOWN_TIMEOUT)
 
         try:
             alive = join_threads_with_deadline(self._connection_threads, _STOP_DEADLINE, _PER_THREAD_JOIN)

--- a/simnos/core/simnos.py
+++ b/simnos/core/simnos.py
@@ -25,11 +25,13 @@ from simnos.plugins.shell import shell_plugins
 
 log = logging.getLogger(__name__)
 
+DEFAULT_PORT_START = 6000
+
 default_inventory = {
     "default": {
         "username": "user",
         "password": "user",
-        "port": 6000,
+        "port": DEFAULT_PORT_START,
         "server": {
             "plugin": "ParamikoSshServer",
             "configuration": {
@@ -41,9 +43,9 @@ default_inventory = {
         "nos": {"plugin": "cisco_ios", "configuration": {}},
     },
     "hosts": {
-        "router_cisco_ios": {"port": 6000, "platform": "cisco_ios"},
-        "router_huawei_smartax": {"port": 6001, "platform": "huawei_smartax"},
-        "router_arista_eos": {"port": 6002, "platform": "arista_eos"},
+        "router_cisco_ios": {"port": DEFAULT_PORT_START, "platform": "cisco_ios"},
+        "router_huawei_smartax": {"port": DEFAULT_PORT_START + 1, "platform": "huawei_smartax"},
+        "router_arista_eos": {"port": DEFAULT_PORT_START + 2, "platform": "arista_eos"},
     },
 }
 


### PR DESCRIPTION
## Summary

- umbrella issue #199 (refactor inventory triage) の **Bundle C — 機械的 fix 5 件** を取り込み
- Bundle A (PR #200) / Bundle B (PR #201) に続く 3 件目、scope は core/ 内部の DRY / 定数化 / 防御的 cleanup
- 全 4 file / +28 / -13、設計判断不要の機械的整理 (Bundle A/B より小さい diff)
- cross-review は内容軽量のため skip

## 取り込んだ項目 (棚卸し doc の Bundle C 全件)

- **C-2**: `Host.start()` の `if self.platform: nos_inventory["plugin"] = ...` 2 行を削除 (`Host.__init__` 末尾で同じ代入を既に行っているため DRY)
- **C-12**: `simnos.py` の port 6000 リテラルを `DEFAULT_PORT_START = 6000` 定数化。残り 6001 / 6002 は `DEFAULT_PORT_START + 1 / + 2` で連番関係を明示
- **C-20**: `TCPServerBase.stop()` の `_listen_thread.join(timeout=2)` リテラルを `_SHUTDOWN_TIMEOUT` 参照に置換 + 意図コメント追記 (wakeup socket 失敗時の fail-safe であることを明示)
- **C-24**: `Host.stop()` に `if self.server is None: return` 早期 return 追加 + docstring に「double-stop は no-op」の旨を明記
- **C-30**: `Nos._from_module` の `getattr(module, "X", self.X)` 5 行 attribute sync を `_MODULE_ATTR_MAP` (class const) + loop に集約。新フィールド追加時の更新箇所が 1 箇所に減る

## pre-review-refactor で取り込んだ追加 cleanup

C-20 で追加した `servers.py` の fail-safe コメントで `SHUTDOWN_TIMEOUT` (private prefix 抜け) と書いてしまっていたが、実際の定数名は `_SHUTDOWN_TIMEOUT` であることに気づき修正。同 commit 内で解消。

## defer (umbrella issue #199 のフォローアップ TODO 候補)

final-refactor Phase 2 で `Host.stop()` の None guard (C-24) と対称的な `Host.start()` の **double-start guard** を再評価:

- 追加は 3 行で可能
- ただし現状の double-start 挙動 (silent re-init で新 server を上書き、旧 server は orphan thread 化) が意図的な可能性あり
- 「double-start を error にする」「no-op にする」「現状の re-init を維持」のいずれかは設計判断を要する
- 本 PR の scope (機械的 fix のみ) を超えるため deferred、umbrella issue #199 のフォローアップ TODO 候補とする

## Test plan

- [x] `uv run invoke ruff` (check + format --check) — clean (51 files already formatted)
- [x] `uv run invoke yamllint` — clean
- [x] `uv run invoke bandit` — 0 issues
- [x] `uv run pytest tests/ -n auto --timeout=120 --ignore=tests/core/test_docker.py` — 756 passed / 7 skipped / 1 xfailed
- [x] pre-review-refactor + final-refactor 両方実施済

## 関連定数の状態 (`DEFAULT_PORT_START` vs `_SHUTDOWN_TIMEOUT` 等)

本 PR で新規追加した `DEFAULT_PORT_START` は **prefix なし** の public 定数として宣言。一方、既存の `servers.py` の `_SHUTDOWN_TIMEOUT` / `_STOP_DEADLINE` / `_PER_THREAD_JOIN` は `_` prefix 付きで private 風だが、`ssh_server_paramiko.py` / `telnet_server.py` から実際は import されており、棚卸し doc の **C-10 (timeout 定数集約 + prefix 整理)** で「prefix 無しに rename して API として明示」が予定されている。本 PR の `DEFAULT_PORT_START` は C-10 の **未来の状態に整合する命名** を先取り。

## umbrella issue 進捗

merge 後、本 PR で +5 (C-2 / C-12 / C-20 / C-24 / C-30) → **15/30 checkbox ticked (50%)** になる見込み。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
