### PR TITLE
chore: refactor inventory triage Bundle D — 軽量 error handling 3 件 (#199)

### DIFF
--- a/simnos/core/nos.py
+++ b/simnos/core/nos.py
@@ -180,11 +180,26 @@ class Nos:
         :param filename: OS path string to Python .py file
         """
         spec = importlib.util.spec_from_file_location("module.name", filename)
+        if spec is None or spec.loader is None:
+            raise ValueError(f"Cannot load NOS module from '{filename}' (spec_from_file_location returned None)")
         module = importlib.util.module_from_spec(spec)
-        spec.loader.exec_module(module)
+        try:
+            spec.loader.exec_module(module)
+        except FileNotFoundError:
+            # Preserve FileNotFoundError as-is so callers can distinguish
+            # "path does not exist" from "plugin code itself failed".
+            raise
+        except Exception as e:
+            raise RuntimeError(f"Failed to load NOS plugin '{filename}': {e}") from e
         for module_attr, self_attr in self._MODULE_ATTR_MAP.items():
             setattr(self, self_attr, getattr(module, module_attr, getattr(self, self_attr)))
         self.commands.update(getattr(module, "commands", self.commands))
+        if self.name == "SimNOS":
+            log.warning(
+                "Module '%s' does not define NAME; falling back to default 'SimNOS' "
+                "(plugin will be registered under that key)",
+                filename,
+            )
         classname = getattr(module, "DEVICE_NAME", None)
         if classname is None:
             log.warning("Module '%s' does not define DEVICE_NAME; device will be None", filename)

--- a/simnos/core/simnos.py
+++ b/simnos/core/simnos.py
@@ -103,12 +103,21 @@ class SimNOS:
         self.start()
         return self
 
-    def __exit__(self, *args):
+    def __exit__(self, exc_type, exc_val, exc_tb):
         """
         Method to stop the SimNOS servers when exiting the context manager.
         It is meant to be used with the `with` statement.
+
+        If ``stop()`` itself raises, the traceback is logged via
+        ``log.exception`` (so it is not lost) and the exception is re-raised
+        to preserve normal context-manager semantics. This prevents
+        silent failures during shutdown.
         """
-        self.stop()
+        try:
+            self.stop()
+        except Exception:
+            log.exception("stop() failed during SimNOS context manager __exit__")
+            raise
 
     def _is_inventory_in_yaml(self) -> bool:
         """method that checks if the inventory is a yaml file."""


### PR DESCRIPTION
## Summary

- umbrella issue #199 (refactor inventory triage) の **Bundle D — 軽量 error handling 3 件** を取り込み
- Bundle A (PR #200) / B (PR #201) / C (PR #202) に続く 4 件目、scope は core/ の防御的 error handling
- 全 2 file / +27 / -3、件数最少の Bundle (3 件)
- cross-review は内容軽量のため skip

## 取り込んだ項目 (棚卸し doc の Bundle D 全件)

### C-5: `Nos._from_module` の spec/loader check + `exec_module` ラップ

- `spec_from_file_location` が `None` / `spec.loader is None` を返した場合に明示的に `ValueError` を raise (debug 困難な `AttributeError` を回避)
- `exec_module` を try/except でラップし、plugin code 起因の任意例外を `RuntimeError("Failed to load NOS plugin '...': ...")` で context 付きで再 raise
- ただし `FileNotFoundError` は as-is で通す (path 問題 vs plugin 問題を呼び出し側が区別できるように、`from_file` 経路の事前 `os.path.isfile` check 結果とも整合)

### C-11: `Nos._from_module` で `NAME` 未定義 silent fail 検知

- `_MODULE_ATTR_MAP` loop (Bundle C で導入) 後に `self.name` がデフォルト `"SimNOS"` のまま (= module に `NAME` 定数が未定義) であれば `log.warning` を emit
- 複数 plugin が `NAME` 未定義だと全部「SimNOS」key で同 namespace に衝突する silent fail を可視化

### C-23: `SimNOS.__exit__` の例外 logging + re-raise

- `__exit__` の signature を `*args` → `(exc_type, exc_val, exc_tb)` の正式 form に変更
- `self.stop()` の例外を `log.exception` で traceback 込みで log してから re-raise
- context manager の body 内で raise が起きた状態で `stop()` も raise した場合に **元の例外を silent に上書きしない** ように

## 設計判断: FileNotFoundError narrow

実装過程で `test_from_module_incorrect_file` (= `_from_module("incorrect.py")` で `FileNotFoundError` を期待する pre-existing test) が一度 fail した。解析の結果、本来の wrap 意図は **plugin code 内の予期しない例外** (`ImportError`, `SyntaxError`, plugin 内の任意 `raise` 等) を context 付きで捕まえることであり、「file path が無い」という user error を `RuntimeError` で覆い隠す意図ではなかった。よって `FileNotFoundError` のみ narrow exception で as-is pass-through する形に修正。

これは設計判断の補強として diff にも反映:
```python
except FileNotFoundError:
    # Preserve FileNotFoundError as-is so callers can distinguish
    # "path does not exist" from "plugin code itself failed".
    raise
except Exception as e:
    raise RuntimeError(f"Failed to load NOS plugin '{filename}': {e}") from e
```

## Test plan

- [x] `uv run invoke ruff` (check + format --check) — clean (51 files already formatted)
- [x] `uv run invoke yamllint` — clean
- [x] `uv run invoke bandit` — 0 issues
- [x] `uv run pytest tests/ -n auto --timeout=120 --ignore=tests/core/test_docker.py` — 756 passed / 7 skipped / 1 xfailed
- [x] pre-review-refactor + final-refactor 両方実施済

## defer (umbrella issue #199 のフォローアップ TODO 候補)

- C-5 で導入した RuntimeError wrap 経路の test 追加 (plugin module が exec_module 中に任意例外を投げるケース) は本 PR scope 外、Bundle E (test 整理) 系で扱う候補
- C-11 の `NAME` 未定義 warning emit 検知の test 追加も同様

## umbrella issue 進捗

merge 後、本 PR で +3 (C-5 / C-11 / C-23) → **18/30 checkbox ticked (60%)** になる見込み。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
