### PR TITLE
chore: refactor inventory triage Bundle E — test 整理 4 件 (#199)

### DIFF
--- a/tests/core/test_netmiko.py
+++ b/tests/core/test_netmiko.py
@@ -122,9 +122,9 @@ class TestNetmiko:
             for router in inventory["hosts"]:
                 try:
                     with ConnectHandler(**credentials[router]):
-                        assert net.hosts[router].running is True
+                        assert net.hosts[router].running
                 except (NetMikoTimeoutException, NetMikoAuthenticationException):
-                    assert net.hosts[router].running is False
+                    assert not net.hosts[router].running
 
         net.stop()
 

--- a/tests/core/test_netmiko_init_compat.py
+++ b/tests/core/test_netmiko_init_compat.py
@@ -100,10 +100,10 @@ class TestNetmikoInitCompat:
                     "this_command_does_not_exist_12345",
                     read_timeout=10,
                 )
-                assert output is not None
+                assert isinstance(output, str)
                 # Verify session is still alive after unknown command
                 follow_up = conn.send_command_timing("?")
-                assert follow_up is not None
+                assert isinstance(follow_up, str)
         finally:
             net.stop()
 

--- a/tests/core/test_simnos.py
+++ b/tests/core/test_simnos.py
@@ -130,7 +130,7 @@ class TestSimNOS:
         """
         net = SimNOS()
         net.inventory = "tests/assets/inventory.yaml"
-        assert net._is_inventory_in_yaml() is True
+        assert net._is_inventory_in_yaml()
 
     def test_is_inventory_in_yaml_unit_false(self):
         """
@@ -139,7 +139,7 @@ class TestSimNOS:
         """
         net = SimNOS()
         net.inventory = "tests/assets/inventory.txt"
-        assert net._is_inventory_in_yaml() is False
+        assert not net._is_inventory_in_yaml()
 
     def test_load_inventory_yaml_unit_true(self):
         """
@@ -411,34 +411,34 @@ class TestSimNOS:
         net = SimNOS()
 
         net.start(hosts="router_cisco_ios")
-        assert net.hosts["router_cisco_ios"].running is True
-        assert net.hosts["router_huawei_smartax"].running is False
-        assert net.hosts["router_arista_eos"].running is False
+        assert net.hosts["router_cisco_ios"].running
+        assert not net.hosts["router_huawei_smartax"].running
+        assert not net.hosts["router_arista_eos"].running
 
         net.start(hosts="router_huawei_smartax")
-        assert net.hosts["router_cisco_ios"].running is True
-        assert net.hosts["router_huawei_smartax"].running is True
-        assert net.hosts["router_arista_eos"].running is False
+        assert net.hosts["router_cisco_ios"].running
+        assert net.hosts["router_huawei_smartax"].running
+        assert not net.hosts["router_arista_eos"].running
 
         net.start(hosts="router_arista_eos")
-        assert net.hosts["router_cisco_ios"].running is True
-        assert net.hosts["router_huawei_smartax"].running is True
-        assert net.hosts["router_arista_eos"].running is True
+        assert net.hosts["router_cisco_ios"].running
+        assert net.hosts["router_huawei_smartax"].running
+        assert net.hosts["router_arista_eos"].running
 
         net.stop(hosts="router_cisco_ios")
-        assert net.hosts["router_cisco_ios"].running is False
-        assert net.hosts["router_huawei_smartax"].running is True
-        assert net.hosts["router_arista_eos"].running is True
+        assert not net.hosts["router_cisco_ios"].running
+        assert net.hosts["router_huawei_smartax"].running
+        assert net.hosts["router_arista_eos"].running
 
         net.stop(hosts="router_huawei_smartax")
-        assert net.hosts["router_cisco_ios"].running is False
-        assert net.hosts["router_huawei_smartax"].running is False
-        assert net.hosts["router_arista_eos"].running is True
+        assert not net.hosts["router_cisco_ios"].running
+        assert not net.hosts["router_huawei_smartax"].running
+        assert net.hosts["router_arista_eos"].running
 
         net.stop(hosts="router_arista_eos")
-        assert net.hosts["router_cisco_ios"].running is False
-        assert net.hosts["router_huawei_smartax"].running is False
-        assert net.hosts["router_arista_eos"].running is False
+        assert not net.hosts["router_cisco_ios"].running
+        assert not net.hosts["router_huawei_smartax"].running
+        assert not net.hosts["router_arista_eos"].running
 
         net.stop()
 
@@ -450,17 +450,17 @@ class TestSimNOS:
         net = SimNOS()
         before_start = get_running_hosts(net.hosts)
         for running_state in before_start.values():
-            assert running_state is False
+            assert not running_state
 
         net.start()
         after_start = get_running_hosts(net.hosts)
         for running_state in after_start.values():
-            assert running_state is True
+            assert running_state
 
         net.stop()
         after_stop = get_running_hosts(net.hosts)
         for running_state in after_stop.values():
-            assert running_state is False
+            assert not running_state
 
         assert len(before_start) == len(after_start) == len(after_stop) == 3
 
@@ -501,10 +501,15 @@ class TestSimNOS:
         assert len(net.nos_plugins["cisco_ios"]) == 2, "Not all files detected"
 
 
-class TestPlatforms:
+class TestPlatformsManifest:
     """
     Tests directly related to the platforms like the ordering
     or if the platforms match the docs and the real in the code.
+
+    Renamed from ``TestPlatforms`` to disambiguate from
+    ``tests/plugins/test_platforms.py::TestPlatforms`` which covers
+    YAML format / runtime command execution; this class covers the
+    ``available_platforms`` manifest integrity (ordering, docs match).
     """
 
     def test_available_platforms_match_docs(self):

--- a/tests/plugins/test_platforms.py
+++ b/tests/plugins/test_platforms.py
@@ -103,11 +103,11 @@ class TestPlatforms:
             for values in data["commands"].values():
                 assert "output" in values or "exit" in values
                 if "output" in values:
-                    assert has_single_curly_brackets(values["output"], exceptions) is False
+                    assert not has_single_curly_brackets(values["output"], exceptions)
                 assert "help" in values
-                assert has_single_curly_brackets(values["help"], exceptions) is False
+                assert not has_single_curly_brackets(values["help"], exceptions)
                 assert "prompt" in values
-                assert has_single_curly_brackets(values["prompt"], exceptions) is False
+                assert not has_single_curly_brackets(values["prompt"], exceptions)
 
     @pytest.mark.parametrize("platform", get_py_nos_modules())
     def test_platforms_py_has_correct_format(self, platform: str):
@@ -155,9 +155,9 @@ class TestPlatforms:
                     assert isinstance(value["output"], types.FunctionType)
                     assert value["output"].__name__ in dir(module_class)
                 else:
-                    assert has_single_curly_brackets(value["output"], exceptions) is False
+                    assert not has_single_curly_brackets(value["output"], exceptions)
             assert "help" in value
-            assert has_single_curly_brackets(value["help"], exceptions) is False
+            assert not has_single_curly_brackets(value["help"], exceptions)
             assert "prompt" in value
 
     @pytest.mark.timeout(600)
@@ -202,17 +202,17 @@ class TestPlatforms:
             with ConnectHandler(**credentials) as conn:
                 for command in initial_commands:
                     output = conn.send_command(command)
-                    assert output or output == ""
+                    assert isinstance(output, str)
                 if enable_commands and platform not in skip_enable_platforms:
                     conn.enable()
                     for command in enable_commands:
                         output = conn.send_command(command)
-                        assert output or output == ""
+                        assert isinstance(output, str)
                 if config_commands and platform not in skip_enable_platforms:
                     conn.config_mode()
                     for command in config_commands:
                         output = conn.send_command(command)
-                        assert output or output == ""
+                        assert isinstance(output, str)
 
     @pytest.mark.timeout(600)
     @pytest.mark.parametrize("platform", get_py_nos_modules())
@@ -250,14 +250,14 @@ class TestPlatforms:
             with ConnectHandler(**credentials) as conn:
                 for command in initial_commands:
                     output = conn.send_command(command)
-                    assert output or output == ""
+                    assert isinstance(output, str)
                 if enable_commands:
                     conn.enable()
                     for command in enable_commands:
                         output = conn.send_command(command)
-                        assert output or output == ""
+                        assert isinstance(output, str)
                 if config_commands:
                     conn.config_mode()
                     for command in config_commands:
                         output = conn.send_command(command)
-                        assert output or output == ""
+                        assert isinstance(output, str)

--- a/tests/plugins/test_ssh_server_paramiko.py
+++ b/tests/plugins/test_ssh_server_paramiko.py
@@ -226,10 +226,11 @@ class TapIOTest(unittest.TestCase):
         mock_run_srv: Mock = Mock()
         mock_run_srv.is_set.side_effect = [True] * 10 + [False]
         tap_io: TapIO = TapIO(run_srv=mock_run_srv)
-        tap_io.lines = ["line1", "line2"]
+        tap_io.write("line1")
+        tap_io.write("line2")
 
-        self.assertEqual(tap_io.readline(), "line2")
         self.assertEqual(tap_io.readline(), "line1")
+        self.assertEqual(tap_io.readline(), "line2")
         self.assertEqual(tap_io.readline(), "")
 
         self.assertEqual(mock_run_srv.is_set.call_count, 11)
@@ -1917,7 +1918,7 @@ class TeardownFixTests(unittest.TestCase):
         # 3 threads: channel_to_shell_tapper, shell_to_channel_tapper, watchdog
         assert len(threads_created) == 3
         for t in threads_created:
-            assert t.daemon is True, f"Thread {t.name} should be daemon"
+            assert t.daemon, f"Thread {t.name} should be daemon"
 
     @mock.patch("paramiko.Transport")
     def test_start_server_exception_triggers_cleanup(self, mock_transport_cls: MagicMock):


### PR DESCRIPTION
## Summary

Umbrella issue #199 の **Bundle E (test 整理 4 件)** を取り込み。前 PR は #203 (Bundle D)。

### 対応項目 (棚卸し doc 参照)

- **T-11** [pin 強度]: `is True` / `is False` → 直接 boolean assertion
  - `tests/core/test_simnos.py` 23 件 + `test_netmiko.py` 2 件 + `tests/plugins/test_platforms.py` 5 件
  - 近隣 extension で `tests/plugins/test_ssh_server_paramiko.py:1921` の `t.daemon is True` 1 件も同 pattern として併せて修正
- **T-13** [pin 強度]: vacuous assertion (`output is not None` / `output or output == ""`) を `isinstance(output, str)` に置換
  - `tests/core/test_netmiko_init_compat.py` 2 件 + `tests/plugins/test_platforms.py` 6 件
  - netmiko の `send_command` 戻り値は `str | list | dict` の Union 型 → `isinstance(output, str)` で意味のある regression pin になる
- **T-20** [test 配置]: `tests/core/test_simnos.py` の `TestPlatforms` → `TestPlatformsManifest` rename
  - `tests/plugins/test_platforms.py::TestPlatforms` (YAML / runtime 検査) との責務分離を disambiguation docstring で明示
- **T-30** [pin]: `TapIOTest.test_readline` の `tap_io.lines` 内部 deque 直書きを `write()` 経由に置換
  - 期待値順序を TapIO の FIFO 仕様 (`appendleft` + `pop()` = oldest first) に合わせて正しく更新
  - 同 class の `test_drain_*` 系 test と同じスタイルに統一

### 進捗

Bundle A (#200) / B (#201) / C (#202) / D (#203) / **E (本 PR)** で **22/30 = 73%** 到達。残は Bundle F (周辺機械的 8 件) のみ。

## Test plan
- [x] `invoke ruff` (check + format --check) → clean
- [x] `invoke yamllint` → clean
- [x] `invoke bandit` → 0 issues
- [x] `pytest tests/ -n auto --timeout=120 --ignore=tests/core/test_docker.py` → 756 passed / 7 skipped / 1 xfailed in 179.41s
- [x] pre-review-refactor (Phase 1 / Phase 2 ともクリーン)
- [x] final-refactor (Phase 1 / Phase 2 ともクリーン、追加変更なし)