### PR TITLE
chore: refactor inventory triage Bundle F — 周辺機械的 8 件 (#199)

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -65,13 +65,18 @@ jobs:
           severity: "CRITICAL,HIGH"
       - name: "Trivy vulnerability scan (SARIF for Code Scanning)"
         if: always()
+        continue-on-error: true
         uses: "aquasecurity/trivy-action@v0.36.0"
         with:
           image-ref: "${{ env.IMAGE_NAME }}:scan"
           format: "sarif"
           output: "trivy-results.sarif"
       - name: "Upload Trivy SARIF to GitHub Code Scanning"
+        # SARIF upload is a security observability channel, not a release gate.
+        # `continue-on-error: true` keeps a transient Code Scanning outage from
+        # failing the scan job (which would block `publish` via `needs: scan`).
         if: always()
+        continue-on-error: true
         uses: "github/codeql-action/upload-sarif@v3"
         with:
           sarif_file: "trivy-results.sarif"

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -10,6 +10,8 @@ on:
 permissions:
   contents: read
   packages: write
+  # Trivy SARIF upload to GitHub Code Scanning (Security tab).
+  security-events: write
 
 env:
   REGISTRY: ghcr.io
@@ -54,13 +56,26 @@ jobs:
           tags: "${{ env.IMAGE_NAME }}:scan"
           cache-from: "type=gha,scope=docker-scan"
           cache-to: "type=gha,mode=max,scope=docker-scan"
-      - name: "Trivy vulnerability scan"
+      - name: "Trivy vulnerability scan (table, fail on CRITICAL/HIGH)"
         uses: "aquasecurity/trivy-action@v0.36.0"
         with:
           image-ref: "${{ env.IMAGE_NAME }}:scan"
           format: "table"
           exit-code: "1"
           severity: "CRITICAL,HIGH"
+      - name: "Trivy vulnerability scan (SARIF for Code Scanning)"
+        if: always()
+        uses: "aquasecurity/trivy-action@v0.36.0"
+        with:
+          image-ref: "${{ env.IMAGE_NAME }}:scan"
+          format: "sarif"
+          output: "trivy-results.sarif"
+      - name: "Upload Trivy SARIF to GitHub Code Scanning"
+        if: always()
+        uses: "github/codeql-action/upload-sarif@v3"
+        with:
+          sarif_file: "trivy-results.sarif"
+          category: "trivy-docker"
 
   publish:
     runs-on: "ubuntu-latest"
@@ -70,6 +85,12 @@ jobs:
     steps:
       - name: "Check out repository code"
         uses: "actions/checkout@v6"
+        with:
+          # metadata-action@v6 needs full history + tags so semver pattern
+          # extraction works on workflow_dispatch / manual re-runs (release
+          # published trigger alone is fine, but this guards against drift).
+          fetch-depth: 0
+          fetch-tags: true
       - name: "Lowercase image name"
         run: echo "IMAGE_NAME=${GITHUB_REPOSITORY,,}" >> "$GITHUB_ENV"
       - name: "Set up QEMU"

--- a/.github/workflows/pypi-publish.yml
+++ b/.github/workflows/pypi-publish.yml
@@ -47,20 +47,19 @@ jobs:
         run: "uv build"
       - name: "Verify bundled moduli is present in artifacts (issue #189)"
         run: |
-          echo "::group::wheel contents"
-          unzip -l dist/simnos-*.whl | grep -E 'simnos/plugins/servers/moduli$' || {
-            echo "::error::Bundled moduli file missing from wheel — packaging regression detected"
-            unzip -l dist/simnos-*.whl
-            exit 1
+          verify_moduli() {
+            local label="$1"
+            shift
+            echo "::group::${label} contents"
+            if ! "$@" | grep -E 'simnos/plugins/servers/moduli$'; then
+              echo "::error::Bundled moduli file missing from ${label} — packaging regression detected"
+              "$@"
+              exit 1
+            fi
+            echo "::endgroup::"
           }
-          echo "::endgroup::"
-          echo "::group::sdist contents"
-          tar tzf dist/simnos-*.tar.gz | grep -E 'simnos/plugins/servers/moduli$' || {
-            echo "::error::Bundled moduli file missing from sdist — packaging regression detected"
-            tar tzf dist/simnos-*.tar.gz
-            exit 1
-          }
-          echo "::endgroup::"
+          verify_moduli "wheel" unzip -l dist/simnos-*.whl
+          verify_moduli "sdist" tar tzf dist/simnos-*.tar.gz
       - name: "Upload distributions"
         uses: "actions/upload-artifact@v7"
         with:

--- a/.github/workflows/pypi-publish.yml
+++ b/.github/workflows/pypi-publish.yml
@@ -54,6 +54,7 @@ jobs:
             if ! "$@" | grep -E 'simnos/plugins/servers/moduli$'; then
               echo "::error::Bundled moduli file missing from ${label} — packaging regression detected"
               "$@"
+              echo "::endgroup::"
               exit 1
             fi
             echo "::endgroup::"

--- a/.gitignore
+++ b/.gitignore
@@ -145,6 +145,7 @@ inventory.yaml
 # local work artifacts
 design/
 workslog/
+worklogs/
 
 # Claude Code settings
 .claude/settings.json

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -10,7 +10,6 @@ repos:
     hooks:
       - id: check-ast
       - id: end-of-file-fixer
-      - id: requirements-txt-fixer
       - id: trailing-whitespace
       - id: check-added-large-files
         args: ['--maxkb=1000']

--- a/.yamllint.yml
+++ b/.yamllint.yml
@@ -32,10 +32,12 @@ rules:
     check-multi-line-strings: false
 
   # GitHub Actions workflows use `on:` as a top-level key, which YAML parses
-  # as boolean `True`. Disable truthy check on keys to allow this idiom.
+  # as boolean `True`. Allow `on`/`off` as truthy values (alongside `true`/`false`)
+  # so the workflow idiom passes while keeping key-level enforcement on (narrow
+  # to this set, instead of disabling key checks entirely).
   truthy:
-    allowed-values: ['true', 'false']
-    check-keys: false
+    allowed-values: ['true', 'false', 'on', 'off']
+    check-keys: true
 
   # Allow up to 3 consecutive blank lines (excluding platform YAMLs which
   # contain raw command outputs that may include multiple blank lines).

--- a/tasks.py
+++ b/tasks.py
@@ -6,14 +6,12 @@ local docs serving (`docs`), platform docs generation
 (`netmiko_check`).
 """
 
+from collections.abc import Iterable
 import os
 import time
 
 from invoke import task
-from netmiko import ConnectHandler
 import yaml
-
-from simnos import SimNOS
 
 
 def run_cmd(context, exec_cmd):
@@ -80,7 +78,7 @@ _PRESERVED_PLATFORM_DOCS: frozenset[str] = frozenset({"index.md", "index.ja.md"}
 
 def sweep_orphaned_platform_docs(
     docs_folder: str,
-    valid_platforms: set[str],
+    valid_platforms: Iterable[str],
     preserve: frozenset[str] = _PRESERVED_PLATFORM_DOCS,
 ) -> list[str]:
     """Remove ``docs/platforms/*.md`` entries whose backing yaml is gone.
@@ -141,7 +139,7 @@ def gen_docs_platform_commands(ctx):
                     platforms_file.write(f"- {rendered}\n")
                 platforms_file.write("\n")
 
-    for orphan in sweep_orphaned_platform_docs(docs_folder, set(platforms)):
+    for orphan in sweep_orphaned_platform_docs(docs_folder, platforms):
         print(f"Removed orphaned doc: {orphan}")
 
 
@@ -150,6 +148,12 @@ def netmiko_check(ctx, device_type: str):
     """
     This is a task for debugging possible problems with Netmiko logins.
     """
+    # Lazy import: keep `invoke --list` and lint-only tasks fast by avoiding
+    # the heavy netmiko / simnos import cost unless this task is actually run.
+    from netmiko import ConnectHandler
+
+    from simnos import SimNOS
+
     init_time = time.time()
     inventory = {
         "hosts": {


### PR DESCRIPTION
## Summary

Umbrella issue #199 の **Bundle F (周辺機械的 8 件)** — Bundle A-E (#200-#204) に続く **最終 Bundle**。merge で **30/30 = 100% 達成**、umbrella issue close 予定。

### 対応項目 (棚卸し doc 参照)

| ID | 内容 | scope |
|---|---|---|
| **M-7** | `tasks.py` top-level の netmiko / simnos import を `netmiko_check` 内 lazy import に | `tasks.py` |
| **M-11** | `.pre-commit-config.yaml` の `requirements-txt-fixer` hook 削除 (uv 移行済で stale) | pre-commit |
| **M-12** ★ | `.gitignore` に `worklogs/` 追加 (`workslog/` typo の隣) | .gitignore (**影響度大**、commit 事故防止) |
| **M-15** | `pypi-publish.yml` の moduli verify を `verify_moduli` shell 関数化 (wheel/sdist 2 ブロックを DRY) | pypi CI |
| **M-16** | `docker-publish.yml` publish job の checkout に `fetch-depth: 0` + `fetch-tags: true` 明示 | docker CI |
| **M-20** | `tasks.py` の `sweep_orphaned_platform_docs` signature `set[str]` → `Iterable[str]` 緩和 | `tasks.py` |
| **M-23** | `.yamllint.yml` の `truthy` を `allowed-values: [..., on, off]` + `check-keys: true` narrow 化 | yamllint |
| **M-24** | `docker-publish.yml` の Trivy step を table + SARIF dual run + `upload-sarif@v3` 連携 (GitHub Code Scanning) + `security-events: write` permission | docker CI |

### cross-review 1st round

3 reviewer (codex / gemini / claude reviewer) 全員 **SUGGESTION** 判定、MUST/SHOULD FIX 0 件。8 件すべて棚卸し doc の M-* と 1:1 対応、scope drift 無し。

取り込み済の SUGGESTION (commit `88595a1`):
- **A** (codex #2 + claude #1): Trivy SARIF scan + upload step に `continue-on-error: true` 追加。GitHub Code Scanning の transient service outage で release が止まる経路を防止 (security observability is not a release gate)
- **B** (codex #4 + gemini #6): `verify_moduli` の failure path で `echo "::endgroup::"` を `exit 1` の前に挿入。GHA log group の close 状態で fail させて debug 体験向上

defer (worklog Notes に記録):
- **C** (gemini #5): `.gitignore` の `workslog/` typo entry 削除 → claude reviewer は互換性 GOOD 判定、scope 外 design 判断要
- **D** (claude #2): Trivy DB 二重 download cost 軽減 → release path 1 回限り、future enhancement 候補

### 進捗 (本 PR merge 後)

| Bundle | PR | 状態 |
|---|---|---|
| A (dead code 削除) | #200 | ✅ |
| B (docstring / type hint) | #201 | ✅ |
| C (機械的 fix) | #202 | ✅ |
| D (軽量 error handling) | #203 | ✅ |
| E (test 整理) | #204 | ✅ |
| **F (周辺機械的) 本 PR** | — | ✅ (本 PR merge で) |
| **合計** | | **30/30 = 100%** |

## Test plan
- [x] `invoke ruff` (check + format --check) → clean
- [x] `invoke yamllint` → clean (truthy narrowing 後も既存 yaml 全 pass)
- [x] `invoke bandit` → 0 issues
- [x] `pytest tests/test_gen_docs_platform_commands.py` → 14 passed (M-20 signature 変更後の `sweep_orphaned_platform_docs` テスト互換性確認)
- [x] `pytest tests/ -n auto --timeout=120 --ignore=tests/core/test_docker.py` → 756 passed / 7 skipped / 1 xfailed in 172s
- [x] workflow yaml syntax 検証 (`yaml.safe_load` で docker/pypi publish 両方 OK)
- [x] pre-review-refactor (Phase 1 / Phase 2 ともクリーン)
- [x] cross-review 1st round (SUGGESTION 取り込み済)
- [x] final-refactor (Phase 1 / Phase 2 ともクリーン)