### PR TITLE
refactor: registry unification — available_platforms を nos_plugins.keys() から派生 (#206)

### DIFF
--- a/simnos/core/nos.py
+++ b/simnos/core/nos.py
@@ -12,59 +12,6 @@ from simnos.core.pydantic_models import ModelNosAttributes
 
 log = logging.getLogger(__name__)
 
-available_platforms: list[str] = [
-    "alcatel_aos",
-    "alcatel_sros",
-    "allied_telesis_awplus",
-    "arista_eos",
-    "aruba_aoscx",
-    "aruba_os",
-    "avaya_ers",
-    "avaya_vsp",
-    "broadcom_icos",
-    "brocade_fastiron",
-    "brocade_netiron",
-    "checkpoint_gaia",
-    "ciena_saos",
-    "cisco_apic",
-    "cisco_asa",
-    "cisco_ftd",
-    "cisco_ios",
-    "cisco_nxos",
-    "cisco_s300",
-    "cisco_viptela",
-    "cisco_wlc_ssh",
-    "cisco_xr",
-    "dell_force10",
-    "dell_powerconnect",
-    "dlink_ds",
-    "edgecore",
-    "eltex",
-    "ericsson_ipos",
-    "extreme_exos",
-    "extreme_slxos",
-    "fortinet",
-    "hp_comware",
-    "hp_procurve",
-    "huawei_smartax",
-    "huawei_vrp",
-    "ipinfusion_ocnos",
-    "juniper_junos",
-    "juniper_screenos",
-    "linux",
-    "mikrotik_routeros",
-    "oneaccess_oneos",
-    "paloalto_panos",
-    "ruckus_fastiron",
-    "ubiquiti_edgerouter",
-    "ubiquiti_edgeswitch",
-    "vyatta_vyos",
-    "watchguard_firebox",
-    "yamaha",
-    "zte_zxros",
-    "zyxel_os",
-]
-
 
 class Nos:
     """
@@ -233,3 +180,14 @@ class Nos:
         Supported types are: .yaml, .yml and .py
         """
         return filename.endswith((".yaml", ".yml", ".py"))
+
+
+# Re-export `available_platforms` from simnos.plugins.nos so existing callers
+# (e.g. `from simnos.core.nos import available_platforms`) keep working after
+# the source of truth was moved to the dynamically-derived registry. Placed
+# at file end to avoid circular import with simnos.plugins.nos.
+# `import X as X` + explicit `__all__` keeps mypy strict mode happy about
+# implicit re-export.
+from simnos.plugins.nos import available_platforms as available_platforms  # noqa: E402
+
+__all__ = ["Nos", "available_platforms"]

--- a/simnos/core/simnos.py
+++ b/simnos/core/simnos.py
@@ -19,7 +19,7 @@ from simnos.core.host import Host
 from simnos.core.nos import Nos
 from simnos.core.pydantic_models import ModelSimnosInventory
 from simnos.core.servers import join_threads_with_deadline
-from simnos.plugins.nos import nos_plugins
+from simnos.plugins.nos import available_platforms, nos_plugins
 from simnos.plugins.servers import servers_plugins
 from simnos.plugins.shell import shell_plugins
 
@@ -461,6 +461,10 @@ def simnos(platform: str | None = None, inventory: dict | None = None, return_in
         raise ValueError("platform and inventory cannot be used together")
     if not platform and not inventory:
         raise ValueError("platform or inventory must be set")
+    if platform and platform not in available_platforms:
+        raise ValueError(
+            f"Platform {platform} is not supported by SIMNOS. Supported platforms are: {available_platforms}"
+        )
     if platform:
         inventory = {
             "hosts": {

--- a/simnos/plugins/nos/__init__.py
+++ b/simnos/plugins/nos/__init__.py
@@ -3,11 +3,15 @@ This module is the point of entry for all NOS plugins.
 
 It gets the names and filenames to load the NOS plugins
 later whenever needed (lazy loading).
-The NOS plugins are loaded first, using the .py modules and
-then the .yaml files in the platforms directory for those which are left.
+The NOS plugins are loaded first from YAML files, then Python modules
+override or extend any existing entries.
 
 With .py modules we can have functionality, while using YAML is only
 intended for quick development of new NOS plugins.
+
+``available_platforms`` is the public derived view of this registry —
+``simnos.core.nos.available_platforms`` re-exports it for backward
+compatibility with callers that still import from the core module.
 """
 
 import glob

--- a/simnos/plugins/nos/__init__.py
+++ b/simnos/plugins/nos/__init__.py
@@ -25,13 +25,22 @@ for file in yaml_files:
     platform_name: str = os.path.basename(file).replace(".yaml", "")
     nos_plugins[platform_name] = [file]
 
-# load NOS from python modules updating the NOS
+# load NOS from python modules updating the NOS.
+# `base_template.py` is the plugin authoring template (BaseDevice example for
+# new NOS plugins to subclass), not a user-facing platform. Exclude it from
+# the registry so it does not surface in `available_platforms` / parametrized
+# tests.
 platforms_directory_py: str = os.path.join(current_directory, "platforms_py")
 py_files = glob.glob(os.path.join(platforms_directory_py, "*.py"))
-py_files = [file for file in py_files if not file.endswith("__init__.py")]
+py_files = [file for file in py_files if not file.endswith(("__init__.py", "base_template.py"))]
 for file in py_files:
     platform_name: str = os.path.basename(file).replace(".py", "")
     if platform_name in nos_plugins:
         nos_plugins[platform_name].append(file)
     else:
         nos_plugins[platform_name] = [file]
+
+# Single source of truth for "supported platform" — derived from `nos_plugins`
+# so that adding a yaml/py file under platforms_yaml/ or platforms_py/ is the
+# only step needed to extend the registry. Sorted for deterministic order.
+available_platforms: list[str] = sorted(nos_plugins.keys())

--- a/tests/core/test_simnos.py
+++ b/tests/core/test_simnos.py
@@ -5,6 +5,7 @@ The file can be found in simnos/core/simnos.py
 
 # pylint: disable=protected-access
 import logging
+import os
 import platform
 import threading
 from unittest.mock import MagicMock, Mock, patch
@@ -16,6 +17,7 @@ import yaml
 from simnos.core.host import Host
 from simnos.core.nos import available_platforms
 from simnos.core.simnos import SimNOS, simnos
+from simnos.plugins.nos import nos_plugins
 from tests.utils import get_platforms_from_md, get_running_hosts
 
 
@@ -579,6 +581,65 @@ class TestPlatformsManifest:
                 pass
 
             dummy_function()
+
+    def test_available_platforms_derived_from_nos_plugins(self):
+        """Pin that `available_platforms` is derived from `nos_plugins.keys()`.
+
+        Source of truth integrity guard: any drift between the registry
+        (`nos_plugins`) and the public symbol breaks this test immediately,
+        catching the failure mode that issue #206 (G1) eliminated.
+        """
+        assert available_platforms == sorted(nos_plugins.keys())
+
+    def test_available_platforms_excludes_base_template(self):
+        """Pin that `base_template` is filtered out of both registry and manifest.
+
+        `simnos/plugins/nos/platforms_py/base_template.py` is the plugin
+        authoring template (BaseDevice example), not a user-facing platform.
+        It must not appear in `available_platforms` or `nos_plugins`. This
+        test catches any future loosening of the py glob filter.
+        """
+        assert "base_template" not in available_platforms
+        assert "base_template" not in nos_plugins
+
+    def test_available_platforms_have_yaml_source(self):
+        """Pin that every supported platform has a backing yaml file.
+
+        Catches "dangling key" drift: if a yaml is deleted in a future PR
+        but `available_platforms` is not updated (e.g. via a stale registry
+        cache), this test fails. All current platforms ship at least a yaml
+        definition; py-only entries (BaseDevice subclasses) live alongside
+        yaml entries.
+        """
+        yaml_dir = "simnos/plugins/nos/platforms_yaml"
+        for platform_name in available_platforms:
+            yaml_path = f"{yaml_dir}/{platform_name}.yaml"
+            assert os.path.isfile(yaml_path), (
+                f"Platform '{platform_name}' is in available_platforms but its yaml file is missing: {yaml_path}"
+            )
+
+    def test_simnos_decorator_rejects_unknown_platform(self):
+        """Pin that `simnos(platform=...)` raises at decorator-factory evaluation time.
+
+        The validation lives in the decorator factory body (before the
+        inner `decorator(func)` is returned), so a typo like
+        `@simnos(platform="cisxo_ios")` raises at module load time rather
+        than waiting until the wrapped function is called. Catching this
+        early avoids paying test startup cost on a doomed run.
+        """
+        with pytest.raises(ValueError, match="not supported"):
+            simnos(platform="nonexistent_platform")
+
+    def test_simnos_decorator_accepts_known_platform(self):
+        """Pin that a known platform does not raise at decorator evaluation.
+
+        Negative-only tests (typo reject) would still pass if the new
+        validation incorrectly rejected every platform; this happy-path
+        test ensures the validation discriminates correctly.
+        """
+        # Should not raise — known platform from registry.
+        decorator = simnos(platform="cisco_ios")
+        assert callable(decorator)
 
 
 class TestWarnSecurity:

--- a/tests/plugins/test_platforms.py
+++ b/tests/plugins/test_platforms.py
@@ -23,7 +23,7 @@ from tests.utils import NETMIKO_DEVICE_TYPE_MAP, get_free_port, get_host_command
 def get_yaml_only_platforms() -> list[str]:
     """Return platforms that have YAML definitions but no Python module."""
     py_modules = set(get_py_nos_modules())
-    return [p for p in sorted(nos_plugins) if p not in py_modules and p != "base_template"]
+    return [p for p in sorted(nos_plugins) if p not in py_modules]
 
 
 def get_py_nos_modules() -> list[str]:


### PR DESCRIPTION
## Summary

棚卸し doc の **G1 group** (C-26 + P-6 前半 + C-38) を統合実装、`available_platforms` の source of truth を `nos_plugins.keys()` に集約。

`Closes #206`

### 対応項目

| ID | 内容 |
|---|---|
| **C-26** ★ | `simnos/core/nos.py:15-66` の 50 件 hardcoded `available_platforms` 削除、`nos_plugins.keys()` から動的派生 |
| **P-6** 前半 ★ | `simnos/plugins/nos/__init__.py` で `available_platforms = sorted(nos_plugins.keys())` を export、`simnos/core/nos.py` 末尾で re-export shim (後方互換) |
| **C-38** | `simnos/core/simnos.py:456` の `simnos()` decorator 入口で platform validation 追加 (typo は decorator factory 評価時 = module load 時に raise) |
| 隠れ drift 解消 | `simnos/plugins/nos/__init__.py` の py glob filter に `base_template.py` 追加。`base_template` は plugin 雛形で user-facing platform ではないが、現状 `nos_plugins` の 51 件目として混入していた (test parametrize / random.choice レイテント flaky 化リスク) |

### 設計判断 (詳細は local design doc)

- `simnos/core/nos.py` 末尾の re-export shim は `from ... import X as X` + 明示的 `__all__ = ["Nos", "available_platforms"]` で mypy strict mode の implicit re-export 警告を回避
- decorator validation は既存の `platform and inventory` / `not platform and not inventory` ValueError チェックの**後ろ**に配置 (input 妥当性 → platform 値 validation の優先順位維持)
- error message は `simnos/core/host.py:104` の既存 `_check_if_platform_is_supported` wording (`"Platform {platform} is not supported by SIMNOS. Supported platforms are: {available_platforms}"`) に意図的に揃え、Future helper 抽出 (別 PR) 時の diff を最小化
- 循環 import: `simnos.plugins.nos` は `glob` / `os` のみ使用で `simnos.core.*` を一切 import しないため構造的に発生せず、lazy import は撤廃して top-level に統一
- behavior 変化: `available_platforms` の値は 50 件で不変、`nos_plugins` のみ 51 → 50 件に縮小 (= `base_template` 除外、隠れ drift の解消)

### 新 test 5 件 (`tests/core/test_simnos.py::TestPlatformsManifest`)

- `test_available_platforms_derived_from_nos_plugins` — source of truth pin (`available_platforms == sorted(nos_plugins.keys())`)
- `test_available_platforms_excludes_base_template` — filter 除外 pin (`"base_template" not in available_platforms` / `nos_plugins`)
- `test_available_platforms_have_yaml_source` — dangling key catch (全 platform で yaml 存在確認)
- `test_simnos_decorator_rejects_unknown_platform` — decorator factory 評価時の `ValueError("not supported")` raise pin
- `test_simnos_decorator_accepts_known_platform` — happy path (known platform で raise しない)

### 既存 test 影響

- 値が 50 件で不変のため、`test_available_platforms_match_docs` / `test_platforms.py:69,87` (`parametrize`) / `test_netmiko.py:90,96` (`random.choice`) はすべて green 維持
- `tests/plugins/test_platforms.py:26` の `p != "base_template"` は filter 拡張で **dead branch 化** → 削除 (新 test `test_available_platforms_excludes_base_template` が一次 guard を引き継ぐ)

### scope 外 (Future 候補、別 PR)

- **DEVICE_NAME 廃止 (P-6 後半)**: M 規模、callable contract Protocol design doc と統合予定
- **base_template.py の `_templates/` 移動**: S 規模 chore、4 file の import 文書き換え伴う
- **error message helper 抽出** (`_assert_platform_supported`): M 規模、本 PR で文言寄せ済
- **`available_platforms` の読み取り専用化** (tuple / read-only accessor): public API 意味論変更要
- **`docs/platforms/index.md` 自動生成化** (M-1): 本 PR は code registry のみ

### Design 反復履歴

design は **cross-review 2 round** (codex + gemini + claude reviewer) を実施:
- 1st round: MUST FIX 2 件 (`base_template` 混入の事実誤認) + SHOULD FIX 1 件 (docs 整合矛盾) + SUGGESTION 6 件
- 2nd round: SHOULD FIX 1 件 (test 設計の不整合) + SUGGESTION 6 件 (型 checker 対応 / dead branch 言及 / etc.)
- final-refactor design で反復痕跡 + 最終整合性確認、すべて反映後の確定 design

詳細: local `design/20260521_101619_claude_g1-registry-unification.md`

## Test plan
- [x] `invoke ruff` (check + format --check) → clean
- [x] `invoke yamllint` → clean
- [x] `invoke bandit` → 0 issues
- [x] `pytest tests/core/test_simnos.py -v -k "Manifest"` → 13 passed (新 5 + 既存 8)
- [x] `pytest tests/ -n auto --timeout=120 --ignore=tests/core/test_docker.py` → **761 passed** / 7 skipped / 1 xfailed in 184.59s
- [x] pre-review-refactor (Phase 1 / Phase 2 ともクリーン)
- [x] final-refactor (Phase 2 で plugins/nos docstring drift 1 件発見、修正済)