### PR TITLE
test: pytest.raises に match= を追加して regression pin を強化 (#210)

### DIFF
--- a/tests/core/test_host.py
+++ b/tests/core/test_host.py
@@ -76,7 +76,7 @@ class TestHost:
         """
         platform = "wrong_platform"
         host.simnos = SimNOS()
-        with pytest.raises(ValueError):
+        with pytest.raises(ValueError, match=r"Platform wrong_platform is not supported by SIMNOS"):
             # pylint: disable=protected-access
             host._check_if_platform_is_supported(platform)
 

--- a/tests/core/test_nos.py
+++ b/tests/core/test_nos.py
@@ -81,7 +81,7 @@ class NosTest(unittest.TestCase):
         Test that the validate raises a ValidationError
         when the NOS attributes are invalid.
         """
-        with pytest.raises(ValidationError):
+        with pytest.raises(ValidationError, match=r"commands"):
             nos = Nos(commands="invalid_commands")
             nos.validate()
 
@@ -103,33 +103,24 @@ class NosTest(unittest.TestCase):
 
     def test_from_dict_incorrect_name(self):
         """
-        Test that the from_dict method raises a
-        ValidationError when the name is incorrect.
+        Test that Nos raises a ValidationError when the name is incorrect.
         """
-        with pytest.raises(ValidationError):
-            Nos({"name": 123, "initial_prompt": "MySimNOS>", "commands": self.commands})
+        with pytest.raises(ValidationError, match=r"\bname\b"):
+            Nos(name=123, initial_prompt="MySimNOS>", commands=self.commands)
 
     def test_from_dict_incorrect_initial_prompt(self):
         """
-        Test that the from_dict method raises a
-        ValidationError when the initial_prompt is incorrect.
+        Test that Nos raises a ValidationError when the initial_prompt is incorrect.
         """
-        with pytest.raises(ValidationError):
-            Nos({"name": "MySimNOS", "initial_prompt": 123, "commands": self.commands})
+        with pytest.raises(ValidationError, match=r"initial_prompt"):
+            Nos(name="MySimNOS", initial_prompt=123, commands=self.commands)
 
     def test_from_dict_incorrect_commands(self):
         """
-        Test that the from_dict method raises a
-        ValidationError when the commands are incorrect.
+        Test that Nos raises a ValidationError when the commands are incorrect.
         """
-        with pytest.raises(ValidationError):
-            Nos(
-                {
-                    "name": "MySimNOS",
-                    "initial_prompt": "MySimNOS>",
-                    "commands": "invalid_commands",
-                }
-            )
+        with pytest.raises(ValidationError, match=r"commands"):
+            Nos(name="MySimNOS", initial_prompt="MySimNOS>", commands="invalid_commands")
 
     def test_from_dict_only_name(self):
         """
@@ -188,7 +179,7 @@ class NosTest(unittest.TestCase):
         Test that the from_file method raises a
         FileNotFoundError when the file is incorrect.
         """
-        with pytest.raises(FileNotFoundError):
+        with pytest.raises(FileNotFoundError, match=r"incorrect_file\.yaml"):
             nos = Nos()
             nos.from_file("tests/assets/incorrect_file.yaml")
 
@@ -210,7 +201,7 @@ class NosTest(unittest.TestCase):
         Test that the from_file method raises a
         FileNotFoundError when the file is incorrect.
         """
-        with pytest.raises(FileNotFoundError):
+        with pytest.raises(FileNotFoundError, match=r"incorrect_file\.py"):
             nos = Nos()
             nos.from_file("tests/assets/incorrect_file.py")
 
@@ -232,7 +223,7 @@ class NosTest(unittest.TestCase):
         Test that the from_module method raises a
         FileNotFoundError when the file is incorrect.
         """
-        with pytest.raises(FileNotFoundError):
+        with pytest.raises(FileNotFoundError, match=r"incorrect_file\.py"):
             nos = Nos()
             # pylint: disable=protected-access
             nos._from_module("tests/assets/incorrect_file.py")
@@ -293,7 +284,7 @@ class NosTest(unittest.TestCase):
         """
         Test that we can register a nos model from a dict.
         """
-        with pytest.raises(ValidationError):
+        with pytest.raises(ValidationError, match=r"output"):
             Nos(
                 name="MySimNOSPlugin",
                 initial_prompt="{base_prompt}>",
@@ -306,7 +297,7 @@ class NosTest(unittest.TestCase):
         """
         Test that we can register a nos model from a dict.
         """
-        with pytest.raises(ValidationError):
+        with pytest.raises(ValidationError, match=r"\bname\b"):
             Nos(
                 name=123,
                 initial_prompt="{base_prompt}>",
@@ -319,7 +310,7 @@ class NosTest(unittest.TestCase):
         """
         Test that we can register a nos model from a dict.
         """
-        with pytest.raises(ValidationError):
+        with pytest.raises(ValidationError, match=r"output"):
             Nos(commands={"show clock": {"output": 42}})
 
     def test_yaml_file_command_is_overwritten_by_corresponding_module(self):

--- a/tests/core/test_simnos.py
+++ b/tests/core/test_simnos.py
@@ -220,7 +220,7 @@ class TestSimNOS:
         """
         net = SimNOS()
         net.allocated_ports = [5000]
-        with pytest.raises(ValueError):
+        with pytest.raises(ValueError, match=r"already in use"):
             net._allocate_port(5000)
 
     def test_allocate_port(self):
@@ -264,16 +264,21 @@ class TestSimNOS:
         when replicas is not set.
         """
         inventory = {"default": {"port": [5000, 5001]}, "hosts": {"R1": {}}}
-        with pytest.raises(ValueError):
+        with pytest.raises(ValueError, match=r"replicas is not set, port must be an integer"):
             SimNOS(inventory=inventory)
 
     def test_replicas_set_and_port_int(self):
         """
         Test that the function _check_ports_and_replicas raises an exception
         when replicas is set and port is an int.
+
+        Note: ``replicas`` lives on each host (not in ``default``) because
+        ``InventoryDefaultSection`` uses ``extra="forbid"``. Keeping ``port`` in
+        ``default`` while moving ``replicas`` to the host lets the merged params
+        reach ``_check_ports_and_replicas`` without tripping pydantic first.
         """
-        inventory = {"default": {"port": 5000, "replicas": 2}, "hosts": {"R1": {}}}
-        with pytest.raises(ValueError):
+        inventory = {"default": {"port": 5000}, "hosts": {"R1": {"replicas": 2}}}
+        with pytest.raises(ValueError, match=r"port must be a list of two integers"):
             SimNOS(inventory=inventory)
 
     def test_replicas_set_and_port_list_not_enough_ports(self):
@@ -281,8 +286,8 @@ class TestSimNOS:
         Test that the function _check_ports_and_replicas raises an exception
         when replicas is set and there are not enough ports.
         """
-        inventory = {"default": {"port": [5000], "replicas": 2}, "hosts": {"R1": {}}}
-        with pytest.raises(ValueError):
+        inventory = {"default": {"port": [5000]}, "hosts": {"R1": {"replicas": 2}}}
+        with pytest.raises(ValueError, match=r"port must be a list of two integers"):
             SimNOS(inventory=inventory)
 
     def test_replicas_set_and_port_list_too_many_ports(self):
@@ -291,10 +296,10 @@ class TestSimNOS:
         when replicas is set and there are too many ports.
         """
         inventory = {
-            "default": {"port": [5000, 5001, 5002], "replicas": 2},
-            "hosts": {"R1": {}},
+            "default": {"port": [5000, 5001, 5002]},
+            "hosts": {"R1": {"replicas": 2}},
         }
-        with pytest.raises(ValueError):
+        with pytest.raises(ValueError, match=r"port must be a list of two integers"):
             SimNOS(inventory=inventory)
 
     def test_replicas_set_and_port_1_larger_than_port_2(self):
@@ -303,22 +308,28 @@ class TestSimNOS:
         when replicas is set and the first port is larger than the second port.
         """
         inventory = {
-            "default": {"port": [5001, 5000], "replicas": 2},
-            "hosts": {"R1": {}},
+            "default": {"port": [5001, 5000]},
+            "hosts": {"R1": {"replicas": 2}},
         }
-        with pytest.raises(ValueError):
+        with pytest.raises(ValueError, match=r"port\[0\] must be less than port\[1\]"):
             SimNOS(inventory=inventory)
 
     def test_replicas_set_and_replicas_less_than_1(self):
         """
         Test that the function _check_ports_and_replicas raises an exception
         when replicas is set and the replicas are less than 1.
+
+        Note: With ``replicas=0`` the guards in ``_check_ports_and_replicas`` short-circuit
+        on the first ``if not replicas and isinstance(port, list)`` branch (0 is falsy),
+        so the actual message is "replicas is not set, port must be an integer" — not
+        the "replicas must be greater than 0" branch the docstring would suggest. This is
+        a known quirk worth tracking in a follow-up issue.
         """
         inventory = {
-            "default": {"port": [5000, 5001], "replicas": 0},
-            "hosts": {"R1": {}},
+            "default": {"port": [5000, 5001]},
+            "hosts": {"R1": {"replicas": 0}},
         }
-        with pytest.raises(ValueError):
+        with pytest.raises(ValueError, match=r"replicas is not set, port must be an integer"):
             SimNOS(inventory=inventory)
 
     def test_replicas_set_and_ports_set_not_same_length(self):
@@ -327,10 +338,10 @@ class TestSimNOS:
         when replicas is set and the ports are not the same length.
         """
         inventory = {
-            "default": {"port": [5000, 5001], "replicas": 3},
-            "hosts": {"R1": {}},
+            "default": {"port": [5000, 5001]},
+            "hosts": {"R1": {"replicas": 3}},
         }
-        with pytest.raises(ValueError):
+        with pytest.raises(ValueError, match=r"port range must be equal to the number of replicas"):
             SimNOS(inventory=inventory)
 
     def test_wrong_plugin_name(self):
@@ -339,7 +350,7 @@ class TestSimNOS:
         when the plugin name is wrong.
         """
         inventory = {"hosts": {"R1": {"server": {"plugin": "wrong_plugin"}}}}
-        with pytest.raises(ValueError):
+        with pytest.raises(ValueError, match=r"wrong_plugin"):
             SimNOS(inventory=inventory)
 
     def test_wrong_platform(self):
@@ -348,7 +359,7 @@ class TestSimNOS:
         when the platform is wrong.
         """
         inventory = {"hosts": {"R1": {"platform": "wrong_platform"}}}
-        with pytest.raises(ValueError):
+        with pytest.raises(ValueError, match=r"Platform wrong_platform is not supported by SIMNOS"):
             SimNOS(inventory=inventory)
 
     def test_inventory_validation_cmdshell_plugin(self):
@@ -564,7 +575,7 @@ class TestPlatformsManifest:
 
     def test_decorator_raise_error_if_platform_and_inventory_provided(self):
         """Test that the decorator raises an exception if both platform and inventory are set."""
-        with pytest.raises(ValueError):
+        with pytest.raises(ValueError, match=r"platform and inventory cannot be used together"):
 
             @simnos(platform="cisco_ios", inventory="tests/assets/inventory.yaml")
             def dummy_function():
@@ -574,7 +585,7 @@ class TestPlatformsManifest:
 
     def test_decorator_raise_error_if_not_platform_or_inventory_provided(self):
         """Test that the decorator raises an exception if neither platform nor inventory are set."""
-        with pytest.raises(ValueError):
+        with pytest.raises(ValueError, match=r"platform or inventory must be set"):
 
             @simnos()
             def dummy_function():


### PR DESCRIPTION
## Summary

- `tests/core/` 配下の `pytest.raises(...)` 23 件すべてに `match=` regex を追加し、誤検知/見逃しリスクを構造的に解消
- T-12 (棚卸し doc、影響度大、S 規模) の対応
- 内訳: `test_nos.py` 10 件 / `test_simnos.py` 12 件 / `test_host.py` 1 件

## 露出した silent bug 2 件 (T-12 が想定した効果)

### 1. test_nos.py の `test_from_dict_incorrect_{name,initial_prompt,commands}`
positional dict 引数を `Nos.__init__` の `name` パラメータに渡しており、docstring が claim する path とは異なる validation 失敗 (name=dict) で test pass していた。
→ kwargs 形式 (`Nos(name=..., initial_prompt=..., commands=...)`) に修正、docstring も整合化。

### 2. test_simnos.py の `test_replicas_set_*` 6 件
`default` section に `replicas` を入れていたが、`InventoryDefaultSection` が `extra="forbid"` のため pydantic で reject され、`_check_ports_and_replicas` まで到達していなかった。意図した path とは別の "default.replicas: Extra inputs are not permitted" で test pass していた。
→ `replicas` を host に、`port` を default に置く構造に変更、merged params 経由で意図した check に到達するように修正。

## 既知の quirk (follow-up 候補)

`test_replicas_set_and_replicas_less_than_1` で `replicas=0` を渡すと、`_check_ports_and_replicas` の `if not replicas and isinstance(port, list)` guard が先に発火 (`0` は falsy) し、actual error が "replicas is not set, port must be an integer" になる。docstring 上の意図は "replicas must be greater than 0" path だが、現実装では到達不能。test docstring に Note を追加して、別 issue 候補として記録。

## Test plan

- [x] `pytest -n auto` 全 **761 passed** / 7 skipped / 1 xfailed (G1 後と同 count、test 削減なし)
- [x] `invoke ruff` / `invoke yamllint` / `invoke bandit` クリーン
- [x] 個別 test 確認: test_nos.py 29 passed / test_simnos.py 31 passed (関連) / test_host.py 5 passed

## 関連

- Closes #210
- 棚卸し doc: \`design/20260520_163932_claude_refactor-inventory-2026-05.md\` の T-12 (L645-650)
- umbrella issue: #199 (close 済、本件は defer 項目だった)

🤖 Generated with [Claude Code](https://claude.com/claude-code)