### PR TITLE
refactor: shutdown timeout 定数を simnos/core/timeouts.py に集約 (G2 #212)

### DIFF
--- a/simnos/core/servers.py
+++ b/simnos/core/servers.py
@@ -12,12 +12,13 @@ import sys
 import threading
 import time
 
-log = logging.getLogger(__name__)
+from simnos.core.timeouts import (
+    SHUTDOWN_IO_TIMEOUT,
+    SHUTDOWN_SERVER_PER_THREAD_JOIN,
+    SHUTDOWN_SERVER_STOP_DEADLINE,
+)
 
-# Timeout constants for shutdown
-_SHUTDOWN_TIMEOUT = 2  # Bounded timeout (seconds) for shutdown-critical I/O paths
-_STOP_DEADLINE = 10  # Total wall-clock budget for joining connection threads
-_PER_THREAD_JOIN = 2  # Max join timeout per individual connection thread
+log = logging.getLogger(__name__)
 
 
 def join_threads_with_deadline(
@@ -136,16 +137,20 @@ class TCPServerBase(ABC):
             with contextlib.suppress(OSError):
                 self._wakeup_w.send(b"\x00")
 
-        # fail-safe join — wakeup socket may have failed; bound by _SHUTDOWN_TIMEOUT.
-        self._listen_thread.join(timeout=_SHUTDOWN_TIMEOUT)
+        # fail-safe join — wakeup socket may have failed; bound by SHUTDOWN_IO_TIMEOUT.
+        self._listen_thread.join(timeout=SHUTDOWN_IO_TIMEOUT)
 
         try:
-            alive = join_threads_with_deadline(self._connection_threads, _STOP_DEADLINE, _PER_THREAD_JOIN)
+            alive = join_threads_with_deadline(
+                self._connection_threads,
+                SHUTDOWN_SERVER_STOP_DEADLINE,
+                SHUTDOWN_SERVER_PER_THREAD_JOIN,
+            )
             if alive:
                 log.warning(
                     "%d connection thread(s) did not exit within %ds",
                     len(alive),
-                    _STOP_DEADLINE,
+                    SHUTDOWN_SERVER_STOP_DEADLINE,
                 )
         finally:
             self._cleanup_resources()

--- a/simnos/core/simnos.py
+++ b/simnos/core/simnos.py
@@ -19,6 +19,11 @@ from simnos.core.host import Host
 from simnos.core.nos import Nos
 from simnos.core.pydantic_models import ModelSimnosInventory
 from simnos.core.servers import join_threads_with_deadline
+from simnos.core.timeouts import (
+    SHUTDOWN_GLOBAL_DEADLINE,
+    SHUTDOWN_SAFETY_NET_DEADLINE,
+    SHUTDOWN_SAFETY_NET_PER_THREAD,
+)
 from simnos.plugins.nos import available_platforms, nos_plugins
 from simnos.plugins.servers import servers_plugins
 from simnos.plugins.shell import shell_plugins
@@ -295,10 +300,6 @@ class SimNOS:
             log.info("Device %s is running on port %s", host.name, host.port)
             self._warn_security(host)
 
-    # Global wall-clock budget for the entire stop() operation.
-    # Covers host.stop() calls + safety-net thread join.
-    _STOP_GLOBAL_DEADLINE = 60
-
     def stop(
         self,
         hosts: str | list[str] | None = None,
@@ -308,7 +309,7 @@ class SimNOS:
         """
         Function to stop NOS servers instances and join managed threads.
 
-        Uses a global deadline (_STOP_GLOBAL_DEADLINE seconds) to bound the
+        Uses a global deadline (SHUTDOWN_GLOBAL_DEADLINE seconds) to bound the
         total wall-clock time.  If the deadline is exceeded, remaining hosts
         may be left running and a warning is logged.
 
@@ -316,7 +317,7 @@ class SimNOS:
         :param parallel: if True, stop hosts in parallel using threads.
         :param workers: max number of worker threads (default: min(32, host_count)).
         """
-        deadline = time.monotonic() + self._STOP_GLOBAL_DEADLINE
+        deadline = time.monotonic() + SHUTDOWN_GLOBAL_DEADLINE
         hosts: list[Host] = self._get_hosts_as_list(hosts)
         # Collect managed threads before stopping (Host.stop sets server to None)
         managed_threads = self._collect_server_threads(hosts)
@@ -330,7 +331,7 @@ class SimNOS:
         )
         if managed_threads:
             remaining = max(0, deadline - time.monotonic())
-            self._join_threads(managed_threads, timeout=min(self._SAFETY_NET_DEADLINE, remaining))
+            self._join_threads(managed_threads, timeout=min(SHUTDOWN_SAFETY_NET_DEADLINE, remaining))
 
     def _collect_server_threads(self, hosts: list[Host]) -> list[threading.Thread]:
         """Collect all managed threads from host servers before stopping."""
@@ -339,11 +340,6 @@ class SimNOS:
             if host.server is not None:
                 threads.extend(host.server.managed_threads)
         return threads
-
-    # Safety-net join budget: longer than per-server budget because this
-    # covers ALL hosts after they have already been told to stop.
-    _SAFETY_NET_DEADLINE = 15
-    _SAFETY_NET_PER_THREAD = 5
 
     def _join_threads(
         self,
@@ -355,8 +351,8 @@ class SimNOS:
         Server threads are already joined by TCPServerBase.stop();
         this is a safety net for any stragglers.
         """
-        total = timeout if timeout is not None else self._SAFETY_NET_DEADLINE
-        alive = join_threads_with_deadline(threads, total, self._SAFETY_NET_PER_THREAD)
+        total = timeout if timeout is not None else SHUTDOWN_SAFETY_NET_DEADLINE
+        alive = join_threads_with_deadline(threads, total, SHUTDOWN_SAFETY_NET_PER_THREAD)
         if alive:
             log.warning("%d SimNOS thread(s) did not exit within timeout", len(alive))
 

--- a/simnos/core/timeouts.py
+++ b/simnos/core/timeouts.py
@@ -1,0 +1,39 @@
+"""Shutdown timeout constants for SimNOS.
+
+5-tier shutdown timeout hierarchy. Outer (SimNOS-global) deadlines bound
+the inner (per-server / per-thread) budgets, leaving headroom for sockets
+and event waits to complete.
+
+| Tier | Constant                            | Value | Owner / role                                      |
+|------|-------------------------------------|------:|---------------------------------------------------|
+| 1    | ``SHUTDOWN_GLOBAL_DEADLINE``        |  60s  | ``SimNOS.stop()`` total wall-clock budget.        |
+| 2    | ``SHUTDOWN_SAFETY_NET_DEADLINE``    |  15s  | ``SimNOS._join_threads`` safety-net join budget.  |
+| 3    | ``SHUTDOWN_SERVER_STOP_DEADLINE``   |  10s  | ``TCPServerBase.stop()`` connection-join budget.  |
+| 4    | ``SHUTDOWN_SAFETY_NET_PER_THREAD``  |   5s  | Per-thread cap inside SimNOS safety-net join.     |
+| 5    | ``SHUTDOWN_SERVER_PER_THREAD_JOIN`` |   2s  | Per-thread cap inside ``TCPServerBase`` join.     |
+| 5    | ``SHUTDOWN_IO_TIMEOUT``             |   2s  | Bounded I/O wait on shutdown paths (public API).  |
+
+Ordering: 60s >= 15s >= 10s >= 5s >= 2s.
+
+``SHUTDOWN_IO_TIMEOUT`` is the public API consumed by server plugins
+(``simnos.plugins.servers.ssh_server_paramiko``,
+``simnos.plugins.servers.telnet_server``). The other constants are used
+internally by ``simnos.core.servers`` / ``simnos.core.simnos`` but are
+re-exported here as the single source of truth.
+"""
+
+SHUTDOWN_GLOBAL_DEADLINE = 60
+SHUTDOWN_SAFETY_NET_DEADLINE = 15
+SHUTDOWN_SERVER_STOP_DEADLINE = 10
+SHUTDOWN_SAFETY_NET_PER_THREAD = 5
+SHUTDOWN_SERVER_PER_THREAD_JOIN = 2
+SHUTDOWN_IO_TIMEOUT = 2
+
+__all__ = [
+    "SHUTDOWN_GLOBAL_DEADLINE",
+    "SHUTDOWN_IO_TIMEOUT",
+    "SHUTDOWN_SAFETY_NET_DEADLINE",
+    "SHUTDOWN_SAFETY_NET_PER_THREAD",
+    "SHUTDOWN_SERVER_PER_THREAD_JOIN",
+    "SHUTDOWN_SERVER_STOP_DEADLINE",
+]

--- a/simnos/plugins/servers/ssh_server_paramiko.py
+++ b/simnos/plugins/servers/ssh_server_paramiko.py
@@ -15,7 +15,8 @@ import paramiko
 import paramiko.rsakey
 
 from simnos.core.nos import Nos
-from simnos.core.servers import _SHUTDOWN_TIMEOUT, TCPServerBase
+from simnos.core.servers import TCPServerBase
+from simnos.core.timeouts import SHUTDOWN_IO_TIMEOUT
 from simnos.plugins.servers.tap_io import TapIO, process_tap_line
 
 log = logging.getLogger(__name__)
@@ -205,7 +206,7 @@ def channel_to_shell_tap(
 
         # Wait for the shell to reply, but check run_srv periodically
         # so that shutdown is not blocked for the full wait duration.
-        while not shell_replied_event.wait(timeout=_SHUTDOWN_TIMEOUT):
+        while not shell_replied_event.wait(timeout=SHUTDOWN_IO_TIMEOUT):
             if not run_srv.is_set():
                 break
         if not run_srv.is_set():
@@ -466,7 +467,7 @@ class ParamikoSshServer(TCPServerBase):
             if not is_running.is_set():
                 break
 
-            time.sleep(min(self.watchdog_interval, _SHUTDOWN_TIMEOUT))
+            time.sleep(min(self.watchdog_interval, SHUTDOWN_IO_TIMEOUT))
 
         shell.stop()
 
@@ -549,8 +550,8 @@ class ParamikoSshServer(TCPServerBase):
         if not ParamikoSshServer._moduli_loaded:
             session.disabled_algorithms = _DISABLED_GEX_ALGORITHMS
         session.add_server_key(self._ssh_server_key)
-        session.banner_timeout = _SHUTDOWN_TIMEOUT
-        session.handshake_timeout = _SHUTDOWN_TIMEOUT
+        session.banner_timeout = SHUTDOWN_IO_TIMEOUT
+        session.handshake_timeout = SHUTDOWN_IO_TIMEOUT
 
         try:
             # create the server
@@ -573,7 +574,7 @@ class ParamikoSshServer(TCPServerBase):
             # wait for the client to open a channel
             channel = None
             while channel is None and is_running.is_set() and session.is_alive():
-                channel = session.accept(_SHUTDOWN_TIMEOUT)
+                channel = session.accept(SHUTDOWN_IO_TIMEOUT)
             if channel is None:
                 log.warning("session.accept() returned None or server stopping, closing transport")
                 return

--- a/simnos/plugins/servers/telnet_server.py
+++ b/simnos/plugins/servers/telnet_server.py
@@ -15,7 +15,8 @@ import time
 from typing import Any
 
 from simnos.core.nos import Nos
-from simnos.core.servers import _SHUTDOWN_TIMEOUT, TCPServerBase
+from simnos.core.servers import TCPServerBase
+from simnos.core.timeouts import SHUTDOWN_IO_TIMEOUT
 from simnos.plugins.servers.tap_io import TapIO, process_tap_line
 
 log = logging.getLogger(__name__)
@@ -252,7 +253,7 @@ class TelnetServer(TCPServerBase):
 
             # Wait for the shell to reply, but check run_srv periodically
             # so that shutdown is not blocked for the full wait duration.
-            while not shell_replied_event.wait(timeout=_SHUTDOWN_TIMEOUT):
+            while not shell_replied_event.wait(timeout=SHUTDOWN_IO_TIMEOUT):
                 if not run_srv.is_set():
                     break
             if not run_srv.is_set():
@@ -377,7 +378,7 @@ class TelnetServer(TCPServerBase):
         while run_srv.is_set():
             if not is_running.is_set():
                 break
-            time.sleep(min(self.watchdog_interval, _SHUTDOWN_TIMEOUT))
+            time.sleep(min(self.watchdog_interval, SHUTDOWN_IO_TIMEOUT))
         # Always stop the shell — whether run_srv or is_running caused the exit.
         shell.stop()
 

--- a/tests/plugins/test_ssh_server_paramiko.py
+++ b/tests/plugins/test_ssh_server_paramiko.py
@@ -15,9 +15,9 @@ from unittest.mock import MagicMock, Mock
 
 import paramiko
 
+from simnos.core.timeouts import SHUTDOWN_IO_TIMEOUT
 from simnos.plugins.servers.ssh_server_paramiko import (
     _BUNDLED_MODULI,
-    _SHUTDOWN_TIMEOUT,
     ParamikoSshServer,
     ParamikoSshServerInterface,
     channel_to_shell_tap,
@@ -307,7 +307,7 @@ class ChannelToShellTapTest(unittest.TestCase):
             shell_replied_event=self.mock_shell_replied_event,
             run_srv=self.mock_run_srv,
         )
-        self.mock_shell_replied_event.wait.assert_called_with(timeout=_SHUTDOWN_TIMEOUT)
+        self.mock_shell_replied_event.wait.assert_called_with(timeout=SHUTDOWN_IO_TIMEOUT)
 
     def test_channel_to_shell_tap_break_loop_when_channel_not_active(self):
         """Check that channel_to_shell_tap breaks the loop when the channel is not active."""
@@ -1833,7 +1833,7 @@ class TeardownFixTests(unittest.TestCase):
 
     @mock.patch("paramiko.Transport")
     def test_session_accept_bounded(self, mock_transport_cls: MagicMock):
-        """session.accept() should be called with _SHUTDOWN_TIMEOUT."""
+        """session.accept() should be called with SHUTDOWN_IO_TIMEOUT."""
         mock_session = MagicMock()
         mock_session.accept.return_value = None
         mock_transport_cls.return_value = mock_session
@@ -1843,7 +1843,7 @@ class TeardownFixTests(unittest.TestCase):
         server = ParamikoSshServer(**self.arguments)
         server.connection_function(MagicMock(), mock_is_running)
 
-        mock_session.accept.assert_called_with(_SHUTDOWN_TIMEOUT)
+        mock_session.accept.assert_called_with(SHUTDOWN_IO_TIMEOUT)
 
     @mock.patch("paramiko.Transport")
     def test_session_accept_returns_on_stop(self, mock_transport_cls: MagicMock):
@@ -1885,8 +1885,8 @@ class TeardownFixTests(unittest.TestCase):
         server = ParamikoSshServer(**self.arguments)
         server.connection_function(MagicMock(), mock_is_running)
 
-        assert mock_session.banner_timeout == _SHUTDOWN_TIMEOUT
-        assert mock_session.handshake_timeout == _SHUTDOWN_TIMEOUT
+        assert mock_session.banner_timeout == SHUTDOWN_IO_TIMEOUT
+        assert mock_session.handshake_timeout == SHUTDOWN_IO_TIMEOUT
 
     @mock.patch("simnos.plugins.servers.ssh_server_paramiko.channel_to_shell_tap")
     @mock.patch("simnos.plugins.servers.ssh_server_paramiko.shell_to_channel_tap")
@@ -2000,7 +2000,7 @@ class SshIntegrationTests(unittest.TestCase):
 
     def _assert_stop_time(self, elapsed):
         """Assert stop() completed within the expected time budget."""
-        budget = _SHUTDOWN_TIMEOUT * 3 + 2
+        budget = SHUTDOWN_IO_TIMEOUT * 3 + 2
         self.assertLess(elapsed, budget, f"stop() took {elapsed:.1f}s, expected < {budget}s")
 
     def test_ssh_stop_propagates_shell_stop_and_threads_converge(self):

--- a/tests/plugins/test_telnet_server.py
+++ b/tests/plugins/test_telnet_server.py
@@ -10,7 +10,7 @@ import unittest
 from unittest.mock import MagicMock
 
 from simnos.core.pydantic_models import ModelSimnosInventory
-from simnos.core.servers import _SHUTDOWN_TIMEOUT
+from simnos.core.timeouts import SHUTDOWN_IO_TIMEOUT
 from simnos.plugins.servers import servers_plugins
 from simnos.plugins.servers.telnet_server import (
     DO,
@@ -647,8 +647,8 @@ class SocketToShellTapTest(unittest.TestCase):
         self.server.socket_to_shell_tap(self.sock, self.shell_stdin, self.shell_replied_event, self.run_srv)
         # Should exit without processing the byte 'a' because the inner wait loop breaks
         self.sock.sendall.assert_not_called()
-        # Verify the interruptible wait uses _SHUTDOWN_TIMEOUT
-        self.shell_replied_event.wait.assert_called_with(timeout=_SHUTDOWN_TIMEOUT)
+        # Verify the interruptible wait uses SHUTDOWN_IO_TIMEOUT
+        self.shell_replied_event.wait.assert_called_with(timeout=SHUTDOWN_IO_TIMEOUT)
 
     @unittest.mock.patch("simnos.plugins.servers.telnet_server.time.sleep")
     @unittest.mock.patch.object(TelnetServer, "_recv_byte")
@@ -854,9 +854,9 @@ class WatchdogTest(unittest.TestCase):
 
     @unittest.mock.patch("simnos.plugins.servers.telnet_server.time.sleep")
     def test_sleep_interval_capped_by_shutdown_timeout(self, mock_sleep):
-        """Sleep interval is the minimum of watchdog_interval and _SHUTDOWN_TIMEOUT."""
-        self.server.watchdog_interval = 10.0  # Larger than _SHUTDOWN_TIMEOUT
+        """Sleep interval is the minimum of watchdog_interval and SHUTDOWN_IO_TIMEOUT."""
+        self.server.watchdog_interval = 10.0  # Larger than SHUTDOWN_IO_TIMEOUT
         self.run_srv.is_set.side_effect = [True, False]
         self.is_running.is_set.return_value = True
         self.server.watchdog(self.is_running, self.run_srv, self.shell)
-        mock_sleep.assert_called_once_with(_SHUTDOWN_TIMEOUT)
+        mock_sleep.assert_called_once_with(SHUTDOWN_IO_TIMEOUT)


### PR DESCRIPTION
## Summary

- 棚卸し doc G2 group の C-10 (shutdown timeout 6 定数の 2 file 散在) を `simnos/core/timeouts.py` への集約で解消
- 5 段階階層関係を docstring 表で明示、code から階層が読み取れる構造に
- `_SHUTDOWN_TIMEOUT` (private prefix + 外部 4 file から import の規約矛盾) を `SHUTDOWN_IO_TIMEOUT` に rename し public API 化
- 調査で C-12 (DEFAULT_PORT_START) / C-20 (servers.py:139 join timeout) は既に過去 Bundle で対応済を確認、本 PR scope は C-10 のみ

## Rename mapping

| 旧名                                | 新名                              |
|-------------------------------------|-----------------------------------|
| `SimNOS._STOP_GLOBAL_DEADLINE`      | `SHUTDOWN_GLOBAL_DEADLINE`        |
| `SimNOS._SAFETY_NET_DEADLINE`       | `SHUTDOWN_SAFETY_NET_DEADLINE`    |
| `SimNOS._SAFETY_NET_PER_THREAD`     | `SHUTDOWN_SAFETY_NET_PER_THREAD`  |
| `servers._STOP_DEADLINE`            | `SHUTDOWN_SERVER_STOP_DEADLINE`   |
| `servers._PER_THREAD_JOIN`          | `SHUTDOWN_SERVER_PER_THREAD_JOIN` |
| `servers._SHUTDOWN_TIMEOUT` (private) | `SHUTDOWN_IO_TIMEOUT` (public API)  |

## 5 段階階層

| Tier | Constant                            | Value | Owner / role                                      |
|------|-------------------------------------|------:|---------------------------------------------------|
| 1    | `SHUTDOWN_GLOBAL_DEADLINE`          |  60s  | `SimNOS.stop()` total wall-clock budget           |
| 2    | `SHUTDOWN_SAFETY_NET_DEADLINE`      |  15s  | `SimNOS._join_threads` safety-net join budget     |
| 3    | `SHUTDOWN_SERVER_STOP_DEADLINE`     |  10s  | `TCPServerBase.stop()` connection-join budget     |
| 4    | `SHUTDOWN_SAFETY_NET_PER_THREAD`    |   5s  | Per-thread cap inside SimNOS safety-net join      |
| 5    | `SHUTDOWN_SERVER_PER_THREAD_JOIN`   |   2s  | Per-thread cap inside TCPServerBase join          |
| 5    | `SHUTDOWN_IO_TIMEOUT`               |   2s  | Bounded I/O wait on shutdown paths (public API)   |

Ordering: `60s >= 15s >= 10s >= 5s >= 2s`

## Breaking change note

`_SHUTDOWN_TIMEOUT` → `SHUTDOWN_IO_TIMEOUT` rename は外部 import 影響あり (4 file、13 usages):
- `simnos/plugins/servers/ssh_server_paramiko.py` (5 usages)
- `simnos/plugins/servers/telnet_server.py` (3 usages)
- `tests/plugins/test_ssh_server_paramiko.py` (2 usages)
- `tests/plugins/test_telnet_server.py` (3 usages)

SimNOS external user は限定的 (KeroRoute / fork のみ) のため SemVer minor 内で OK と判断。

## Test plan

- [x] `pytest -n auto` 全 **761 passed** / 7 skipped / 1 xfailed (T-12 後と同 count、test 数不変)
- [x] `invoke ruff` / `invoke yamllint` / `invoke bandit` クリーン
- [x] 旧名 word-boundary grep 確認: `_SHUTDOWN_TIMEOUT` / `_STOP_GLOBAL_DEADLINE` / `_STOP_DEADLINE` / `_PER_THREAD_JOIN` / `_SAFETY_NET_DEADLINE` / `_SAFETY_NET_PER_THREAD` すべて消滅

## 関連

- Closes #212
- 棚卸し doc: \`design/20260520_163932_claude_refactor-inventory-2026-05.md\` の C-10 (L136-141)
- umbrella issue: #199 (close 済、本件は defer 項目だった)
- 関連 group: G2 (C-10 + C-12 + C-20)、C-12/C-20 は既解消

🤖 Generated with [Claude Code](https://claude.com/claude-code)