### PR TITLE
chore: G8 dep cleanup — detect 削除 + paramiko docs 整合 (#214)

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ SIMNOS is an independent project derived from [FakeNOS](https://github.com/faken
 - Python support: 3.13 / 3.14
 - CI: Modernized GitHub Actions workflow
 - NOS platforms: 5 additional platforms enabled (brocade_fastiron, ciena_saos, fortinet, juniper_screenos, ruckus_fastiron)
-- Paramiko: upgraded to 4.0 with DH Group Exchange server-mode workaround
+- Paramiko: 4.0+ (currently resolving to 5.0.0) with DH Group Exchange server-mode workaround
 
 ## Why?
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -39,7 +39,6 @@ dependencies = [
     "pyyaml<7.0",
     "pydantic<3.0",
     "jinja2>=3.1.6",
-    "detect==2020.12.*",
 ]
 
 

--- a/simnos/core/simnos.py
+++ b/simnos/core/simnos.py
@@ -12,7 +12,6 @@ import socket
 import threading
 import time
 
-import detect
 import yaml
 
 from simnos.core.host import Host
@@ -24,6 +23,7 @@ from simnos.core.timeouts import (
     SHUTDOWN_SAFETY_NET_DEADLINE,
     SHUTDOWN_SAFETY_NET_PER_THREAD,
 )
+from simnos.core.utils import _is_in_docker
 from simnos.plugins.nos import available_platforms, nos_plugins
 from simnos.plugins.servers import servers_plugins
 from simnos.plugins.shell import shell_plugins
@@ -56,7 +56,7 @@ default_inventory = {
 
 # If Windows or WSL, the configuration address is 0.0.0.0
 # WSL Bug: https://github.com/microsoft/WSL/issues/4983
-if detect.docker and "WSL2" in platform.release():
+if _is_in_docker() and "WSL2" in platform.release():
     server_config = default_inventory["default"]["server"]["configuration"]
     server_config["address"] = "0.0.0.0"  # noqa: S104
 

--- a/simnos/core/utils.py
+++ b/simnos/core/utils.py
@@ -1,0 +1,30 @@
+"""Utility helpers for SimNOS core."""
+
+from pathlib import Path
+
+
+def _is_in_docker() -> bool:
+    """Detect whether the current process is running inside a Docker container.
+
+    Replaces the previously-used ``detect.docker`` from the unmaintained
+    ``detect`` package (last release 2020-12-03). Uses two independent
+    heuristics; any positive match returns ``True``:
+
+    1. ``/.dockerenv`` exists. Docker creates this file at the container
+       root for every container it starts.
+    2. ``/proc/1/cgroup`` contains ``docker`` or ``containerd``. PID 1's
+       cgroup membership reveals the container runtime on Linux even when
+       ``/.dockerenv`` is missing (e.g. rootless or non-Docker runtimes
+       that still inherit the namespace).
+
+    Both checks degrade gracefully on platforms where the paths do not
+    exist (Windows host without WSL, plain macOS, BSD): the function
+    simply returns ``False``.
+    """
+    if Path("/.dockerenv").exists():
+        return True
+    try:
+        cgroup = Path("/proc/1/cgroup").read_text()
+    except OSError:
+        return False
+    return "docker" in cgroup or "containerd" in cgroup

--- a/tests/core/test_netmiko.py
+++ b/tests/core/test_netmiko.py
@@ -5,9 +5,9 @@ as a testing tool for Netmiko.
 
 import random
 import re
+import sys
 import threading
 
-import detect
 from netmiko import (
     ConnectHandler,
     NetMikoAuthenticationException,
@@ -71,7 +71,7 @@ class TestNetmiko:
                 if thread is not threading.main_thread() and "pytest_timeout" not in thread.name:
                     thread.join()
 
-        n_threads: int = 2 if detect.windows else 1
+        n_threads: int = 2 if sys.platform == "win32" else 1
         assert threading.active_count() == n_threads
 
     @pytest.mark.timeout(20 * 10)

--- a/tests/core/test_netmiko_init_compat.py
+++ b/tests/core/test_netmiko_init_compat.py
@@ -9,9 +9,9 @@ Verifies that:
 """
 
 import contextlib
+import sys
 import threading
 
-import detect
 from netmiko import ConnectHandler
 import pytest
 
@@ -237,7 +237,7 @@ class TestShutdownEOF:
             net.stop()
             self._join_all_threads()
 
-        n_threads = 2 if detect.windows else 1
+        n_threads = 2 if sys.platform == "win32" else 1
         assert threading.active_count() == n_threads
 
     @pytest.mark.timeout(30)
@@ -263,5 +263,5 @@ class TestShutdownEOF:
         finally:
             self._join_all_threads()
 
-        n_threads = 2 if detect.windows else 1
+        n_threads = 2 if sys.platform == "win32" else 1
         assert threading.active_count() == n_threads

--- a/tests/core/test_simnos.py
+++ b/tests/core/test_simnos.py
@@ -10,13 +10,13 @@ import platform
 import threading
 from unittest.mock import MagicMock, Mock, patch
 
-import detect
 import pytest
 import yaml
 
 from simnos.core.host import Host
 from simnos.core.nos import available_platforms
 from simnos.core.simnos import SimNOS, simnos
+from simnos.core.utils import _is_in_docker
 from simnos.plugins.nos import nos_plugins
 from tests.utils import get_platforms_from_md, get_running_hosts
 
@@ -53,7 +53,7 @@ class TestSimNOS:
             assert host.password in ["user"]
             assert host.port in {6000, 6001, 6002}
             assert host.server_inventory["plugin"] == "ParamikoSshServer"
-            if detect.docker and "WSL2" in platform.release():
+            if _is_in_docker() and "WSL2" in platform.release():
                 assert host.server_inventory["configuration"]["address"] == "0.0.0.0"
             else:
                 assert host.server_inventory["configuration"]["address"] == "127.0.0.1"

--- a/tests/core/test_utils.py
+++ b/tests/core/test_utils.py
@@ -1,0 +1,63 @@
+"""Tests for simnos.core.utils."""
+
+from unittest.mock import MagicMock, patch
+
+from simnos.core.utils import _is_in_docker
+
+
+class TestIsInDocker:
+    """Pin the two heuristics used by ``_is_in_docker``.
+
+    The function exists because the previously-used ``detect`` package was
+    unmaintained (last release 2020-12-03). These tests pin the contract so
+    that future refactors keep both detection paths intact.
+    """
+
+    def test_returns_true_when_dockerenv_file_exists(self):
+        """``/.dockerenv`` existence is the primary positive signal."""
+        with patch("simnos.core.utils.Path") as mock_path:
+            mock_path.return_value.exists.return_value = True
+            assert _is_in_docker() is True
+
+    def test_returns_true_when_cgroup_mentions_docker(self):
+        """If ``/.dockerenv`` is missing, ``/proc/1/cgroup`` containing
+        ``docker`` is the fallback positive signal."""
+        mock_dockerenv = MagicMock()
+        mock_dockerenv.exists.return_value = False
+        mock_cgroup = MagicMock()
+        mock_cgroup.read_text.return_value = "12:cpuset:/docker/abc123\n"
+        with patch("simnos.core.utils.Path") as mock_path:
+            mock_path.side_effect = [mock_dockerenv, mock_cgroup]
+            assert _is_in_docker() is True
+
+    def test_returns_true_when_cgroup_mentions_containerd(self):
+        """``containerd`` in cgroup also counts as a container runtime."""
+        mock_dockerenv = MagicMock()
+        mock_dockerenv.exists.return_value = False
+        mock_cgroup = MagicMock()
+        mock_cgroup.read_text.return_value = "0::/system.slice/containerd.service\n"
+        with patch("simnos.core.utils.Path") as mock_path:
+            mock_path.side_effect = [mock_dockerenv, mock_cgroup]
+            assert _is_in_docker() is True
+
+    def test_returns_false_when_neither_signal_present(self):
+        """Plain host (``/.dockerenv`` absent, cgroup mentions neither
+        ``docker`` nor ``containerd``) returns ``False``."""
+        mock_dockerenv = MagicMock()
+        mock_dockerenv.exists.return_value = False
+        mock_cgroup = MagicMock()
+        mock_cgroup.read_text.return_value = "0::/user.slice/user-1000.slice\n"
+        with patch("simnos.core.utils.Path") as mock_path:
+            mock_path.side_effect = [mock_dockerenv, mock_cgroup]
+            assert _is_in_docker() is False
+
+    def test_returns_false_when_cgroup_read_fails(self):
+        """On platforms without ``/proc/1/cgroup`` (Windows, macOS), the
+        ``OSError`` from ``read_text`` is swallowed and ``False`` returned."""
+        mock_dockerenv = MagicMock()
+        mock_dockerenv.exists.return_value = False
+        mock_cgroup = MagicMock()
+        mock_cgroup.read_text.side_effect = OSError("no such file")
+        with patch("simnos.core.utils.Path") as mock_path:
+            mock_path.side_effect = [mock_dockerenv, mock_cgroup]
+            assert _is_in_docker() is False

--- a/tests/plugins/test_cmd_shell.py
+++ b/tests/plugins/test_cmd_shell.py
@@ -5,13 +5,13 @@ Module to test the cmd_shell plugin.
 import importlib
 import os
 import shutil
+import sys
 import tempfile
 import threading
 import time
 from unittest import TestCase
 from unittest.mock import Mock, patch
 
-import detect
 from netmiko import ConnectHandler
 import pytest
 import yaml
@@ -428,7 +428,7 @@ class HotReloadTest(TestCase):
         mock_from_file.assert_called_once_with(module.__name__.replace(".", "/") + ".py")
         assert all(key in shell.commands for key in module.commands)
 
-    @pytest.mark.skipif(detect.windows, reason="Windows does not allow file movement on Github runners")
+    @pytest.mark.skipif(sys.platform == "win32", reason="Windows does not allow file movement on Github runners")
     @simnos(platform="cisco_ios", return_instance=True)
     def test_hot_reload_integration_yaml(self, net: SimNOS):
         """
@@ -482,7 +482,7 @@ class HotReloadTest(TestCase):
             finally:
                 undo_change_file()
 
-    @pytest.mark.skipif(detect.windows, reason="Windows does not allow file movement on Github runners")
+    @pytest.mark.skipif(sys.platform == "win32", reason="Windows does not allow file movement on Github runners")
     @simnos(platform="cisco_ios", return_instance=True)
     def test_hot_reload_integration_py_jinja(self, net: SimNOS):
         """

--- a/uv.lock
+++ b/uv.lock
@@ -395,12 +395,6 @@ wheels = [
 ]
 
 [[package]]
-name = "detect"
-version = "2020.12.3"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/a7/e4/50b692a4eb05580e7e081823e71c6b16cb6c506e766a2dfa5f9705f50c05/detect-2020.12.3.tar.gz", hash = "sha256:eecd6c41c17072b4db8dbfa850d979bda40b33b4f349ab4378205bceb74d712e", size = 1530, upload-time = "2020-12-03T20:18:30.881Z" }
-
-[[package]]
 name = "distlib"
 version = "0.4.0"
 source = { registry = "https://pypi.org/simple" }
@@ -1232,7 +1226,6 @@ name = "simnos"
 version = "2.3.1"
 source = { editable = "." }
 dependencies = [
-    { name = "detect" },
     { name = "jinja2" },
     { name = "paramiko" },
     { name = "pydantic" },
@@ -1267,7 +1260,6 @@ dev = [
 
 [package.metadata]
 requires-dist = [
-    { name = "detect", specifier = "==2020.12.*" },
     { name = "jinja2", specifier = ">=3.1.6" },
     { name = "paramiko", specifier = ">=4.0,<6.0" },
     { name = "pydantic", specifier = "<3.0" },


### PR DESCRIPTION
## Summary

棚卸し doc G8 group のうち M-8 + M-22 を 1 PR で対応。M-9 (ty 採用) は ty check で 474 件 error 出ることが判明、別 issue で Phase 1 + paramiko-stubs を統合的に設計するため scope 外。

### M-8: detect 削除 + 内製 _is_in_docker()

5 年放置の dead-end dep `detect==2020.12.*` を `pyproject.toml` から削除、`simnos/core/utils.py` に内製 `_is_in_docker()` helper を追加。

**Detection heuristics**:
1. `/.dockerenv` 存在 (Docker が container root に置くファイル)
2. `/proc/1/cgroup` 内 `docker` / `containerd` keyword (rootless / 非 Docker runtime も拾える)
3. 非 Linux (macOS / Windows) では `OSError` を swallow して `False` を返す

### M-22: paramiko docs version 整合

`README.md` の `Paramiko: upgraded to 4.0` を `4.0+ (currently resolving to 5.0.0)` に更新 (`pyproject.toml` 4.0-6.0 / `uv.lock` 5.0.0 / docs 4.x の drift を `4.0+` で統一)。

GEX workaround は memory `paramiko_gex_workaround` で確認済 (5.0 でも stale snapshot bug 残存、削除不可)。

## Test plan

- [x] `pytest -n auto` 全 **766 passed** / 7 skipped / 1 xfailed (G2 後 761 + utils test 5)
- [x] `invoke ruff` / `invoke yamllint` / `invoke bandit` クリーン
- [x] `uv lock` で transitive dep ツリーから detect 完全削除を確認 (\`Removed detect v2020.12.3\`)
- [x] 新 test `tests/core/test_utils.py::TestIsInDocker` で 5 件 (両 heuristic + 失敗 path 全 cover)

## scope 外 (M-9 defer 理由)

`uv run ty check .` で **474 件 diagnostic** 出ることが判明:
- 356 件 `invalid-argument-type` (75%、大半 paramiko untyped 由来)
- 44 件 `unresolved-attribute` (Optional unwrap narrowing 不足)
- 23 件 `invalid-assignment`
- file 別では `ssh_server_paramiko.py` + その test で 635 件 (75%) 集中

→ 一括 blocking 導入は scope 過大。別 issue で **Phase 1 (config + task + CI non-block)** + **Phase 2 (paramiko-stubs 試行 + 段階 fix)** を統合的に設計予定。

## 関連

- Closes #214
- 棚卸し doc: M-8 (L877-883) / M-22 (L975-982)
- M-9 (ty 採用) は別 issue 予定
- umbrella issue: #199 (close 済)

🤖 Generated with [Claude Code](https://claude.com/claude-code)