### PR TITLE
type-check: M-9 ty 採用 Phase 1 — non-block CI integration (#216)

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -34,6 +34,18 @@ jobs:
         run: "uv run invoke yamllint"
       - name: "Security: bandit"
         run: "uv run invoke bandit"
+      # Typecheck: ty is Phase 1 non-blocking (#216).
+      # First step prints "Found N diagnostics" to CI log for count trending;
+      # second step emits GitHub Actions annotations to PR review.
+      # Both wrapped with continue-on-error to avoid blocking the workflow
+      # while ~156 diagnostics still exist. Phase 2 will fix them and flip
+      # this to blocking by removing both --no-exit-zero and continue-on-error.
+      - name: "Typecheck: ty - count trend (Phase 1 non-blocking)"
+        continue-on-error: true
+        run: "uv run invoke ty --no-exit-zero"
+      - name: "Typecheck: ty - PR annotations (Phase 1 non-blocking)"
+        continue-on-error: true
+        run: "uv run ty check . --output-format=github"
 
   pytest:
     strategy:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -103,6 +103,17 @@ tests = ["B201", "B301"]
 skips = ["B101", "B601"]
 
 
+[tool.ty.src]
+# Phase 1: non-blocking ty integration (#216).
+# Paramiko (untyped) generates ~67% of diagnostics (~318 of 474).
+# Excluding the two heaviest offenders drops total from 474 to ~156.
+# Phase 2 will reassess types-paramiko adoption and remove these exclusions.
+exclude = [
+    "simnos/plugins/servers/ssh_server_paramiko.py",
+    "tests/plugins/test_ssh_server_paramiko.py",
+]
+
+
 [tool.coverage.run]
 branch = true
 omit = [".*", ".venv"]

--- a/tasks.py
+++ b/tasks.py
@@ -40,6 +40,29 @@ def bandit(context):
 
 
 @task
+def ty(context, exit_zero=True):
+    """Run ty type-checker (Phase 1 non-blocking, see #216).
+
+    Phase 1 ships ty in a non-blocking mode while the codebase still
+    has ~156 diagnostics (paramiko-heavy files are excluded via
+    pyproject.toml ``[tool.ty.src]``). Phase 2 will gradually fix the
+    remaining errors and flip this task to blocking by changing the
+    ``exit_zero`` default to ``False`` and dropping
+    ``continue-on-error: true`` from CI.
+
+    Args:
+        exit_zero: When True (default, for local invoke chains), pass
+            ``--exit-zero`` so ty never exits non-zero. CI runs
+            ``uv run invoke ty --no-exit-zero`` and relies on
+            ``continue-on-error: true`` for non-blocking — this lets the
+            step icon reflect ty's verdict so failing trends are visible
+            in GitHub Actions UI.
+    """
+    flag = "--exit-zero " if exit_zero else ""
+    run_cmd(context, f"uv run ty check . {flag}".rstrip())
+
+
+@task
 def docs(context):
     """Build and serve docs locally for development."""
     run_cmd(context, "mkdocs serve --dev-addr 0.0.0.0:8001")


### PR DESCRIPTION
## Summary

棚卸し doc M-9 group の「ty (astral-sh の Python type checker、alpha) を採用」を **段階導入の Phase 1** として実装。5 ヶ月放置されていた `ty>=0.0.1a26` dev dep に CI 実行経路を作り、156 件の type diagnostic を可視化。

### 変更

| ファイル | 内容 | 行数 |
|---------|-----|------|
| `pyproject.toml` | `[tool.ty.src] exclude` で paramiko 集中 2 file 除外 | +11 |
| `tasks.py` | `@task def ty(context, exit_zero=True)` 追加 | +23 |
| `.github/workflows/main.yml` | lint job に 2 step (件数 trend + PR annotation) 追加 | +12 |

合計: 3 files, +46/-0

### CI 設計の核心

**2 step 分離** (`set -e` skip 問題回避、cross-review 1st claude 反映):

```yaml
- name: "Typecheck: ty - count trend (Phase 1 non-blocking)"
  continue-on-error: true
  run: "uv run invoke ty --no-exit-zero"
- name: "Typecheck: ty - PR annotations (Phase 1 non-blocking)"
  continue-on-error: true
  run: "uv run ty check . --output-format=github"
```

- step 1: default format で `Found N diagnostics` を CI ログに残す (件数 trend)
- step 2: `--output-format=github` で PR review の "Files changed" tab に annotation
- 両 step 共 `continue-on-error: true` で workflow 全体を block しない

## Preliminary research + cross-review 1st 反映

### research 結果
- `uv run ty check .` で **474 件 diagnostics** (大半 paramiko untyped 由来)
- `types-paramiko` (v4.0.0) → 474 → 514 (+40) **逆に増加** (paramiko 5.0 と version drift)
- `[tool.ty.src] exclude` で `ssh_server_paramiko.py` 系 2 file 除外 → 474 → **156 件**まで減少

### cross-review 1st round 反映
- **codex (MUST FIX)**: `--statistics` flag が ty 0.0.23 に存在しないことを実機検証 → 削除し `Found N diagnostics` 末尾 + annotation の 2 step 体制に変更
- **gemini (SHOULD FIX)**: `[tool.ty.src] exclude` schema 実証 (474 → 120 件)、120 件 baseline で regression 見落とし risk → Phase 2 早期化 + step name `[Category]: [tool]` convention 整合
- **claude (MUST FIX)**: Decision 4 ⚠ vs ❌ wording 修正、CI から `invoke ty` 呼ぶ pattern に統一、`[tool.ty]` 親 section convention 明確化、PR annotation 取り込み

全 MUST FIX + SHOULD FIX 反映、2nd round skip 判断。

## Test plan

- [x] `uv run invoke ty` (default `--exit-zero`): exit 0、`Found 156 diagnostics`
- [x] `uv run invoke ty --no-exit-zero`: exit 1、`Found 156 diagnostics`
- [x] `uv run ty check . --output-format=github`: PR annotation 形式 出力確認
- [x] `pytest -n auto` 全 **761 passed** / 7 skipped / 1 xfailed (G2 後と同 count、test 数不変)
- [x] `invoke ruff` / `yamllint` / `bandit` クリーン
- [x] pre-review-refactor: pyproject.toml comment の "120" → "156" drift fix
- [x] final-refactor: 両 phase クリーン、追加変更なし

## Phase 2 (別 issue / 別 PR、time-based trigger)

**trigger anchor**: Phase 1 merge 後 **1-2 週間以内** に Phase 2 issue 起票、次回 棚卸し doc / 月次 refactor サイクルで進捗 review (5 ヶ月放置の再発防止)。

### Phase 2 作業項目
- **2a**: types-paramiko v5.x 安定 release 後に再評価 (category 別 diff で stub 壊れ vs 新 error 検出を判別)
- **2b**: 残 156 件の段階 fix (file 単位、`# ty: ignore` inline 戦略)
- **2c**: blocking 化 (`tasks.py` の `exit_zero` default を False、CI から `continue-on-error: true` 削除、2-3 行 diff)

## 関連

- Closes #216
- Design doc (local-only): `design/20260521_175607_claude_m9-ty-adoption-phase1.md` (cross-review 1st 反映 + final-refactor 済)
- 棚卸し doc M-9 (L884-890)
- 関連 PR: #214/#215 (G8 dep cleanup、M-9 分離決定)
- umbrella issue: #199 (close 済)

🤖 Generated with [Claude Code](https://claude.com/claude-code)