### PR TITLE
type-check: M-9 ty Phase 2 — production 0 件 + tests exclude + blocking 化 (#218)

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -34,17 +34,12 @@ jobs:
         run: "uv run invoke yamllint"
       - name: "Security: bandit"
         run: "uv run invoke bandit"
-      # Typecheck: ty is Phase 1 non-blocking (#216).
-      # First step prints "Found N diagnostics" to CI log for count trending;
-      # second step emits GitHub Actions annotations to PR review.
-      # Both wrapped with continue-on-error to avoid blocking the workflow
-      # while ~156 diagnostics still exist. Phase 2 will fix them and flip
-      # this to blocking by removing both --no-exit-zero and continue-on-error.
-      - name: "Typecheck: ty - count trend (Phase 1 non-blocking)"
-        continue-on-error: true
-        run: "uv run invoke ty --no-exit-zero"
-      - name: "Typecheck: ty - PR annotations (Phase 1 non-blocking)"
-        continue-on-error: true
+      # Typecheck: ty is blocking since Phase 2 (#218).
+      # Production code (simnos/) is ty-clean; tests/ excluded via
+      # pyproject.toml [tool.ty.src]. New type errors in production fail CI.
+      # GitHub Actions annotation format surfaces error locations directly in
+      # PR review's "Files changed" tab.
+      - name: "Typecheck: ty"
         run: "uv run ty check . --output-format=github"
 
   pytest:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -103,13 +103,18 @@ skips = ["B101", "B601"]
 
 
 [tool.ty.src]
-# Phase 1: non-blocking ty integration (#216).
-# Paramiko (untyped) generates ~67% of diagnostics (~318 of 474).
-# Excluding the two heaviest offenders drops total from 474 to ~156.
-# Phase 2 will reassess types-paramiko adoption and remove these exclusions.
+# Phase 2 (#218): production code (simnos/) is ty-clean (0 diagnostics).
+# tests/ is excluded because the test layer relies heavily on MagicMock dynamic
+# attributes and function-state fixture patterns that defeat static type
+# analysis. Phase 3 (TBD) will revisit tests with a type-aware testing approach
+# (e.g. create_autospec) if/when MagicMock alternatives mature.
+#
+# Phase 1 (#216) excluded ssh_server_paramiko separately because paramiko is
+# untyped and types-paramiko v4 was incompatible with paramiko 5.0. Keep that
+# entry until Phase 3 reassesses types-paramiko v5.x adoption.
 exclude = [
     "simnos/plugins/servers/ssh_server_paramiko.py",
-    "tests/plugins/test_ssh_server_paramiko.py",
+    "tests/",
 ]
 
 

--- a/simnos/core/servers.py
+++ b/simnos/core/servers.py
@@ -84,6 +84,8 @@ class TCPServerBase(ABC):
         self._is_running.set()
         try:
             self._bind_sockets()
+            # _bind_sockets() assigns self._socket; narrow for ty.
+            assert self._socket is not None  # noqa: S101 — post-condition of _bind_sockets
             self._socket.listen()
 
             self._wakeup_r, self._wakeup_w = socket.socketpair()
@@ -138,6 +140,9 @@ class TCPServerBase(ABC):
                 self._wakeup_w.send(b"\x00")
 
         # fail-safe join — wakeup socket may have failed; bound by SHUTDOWN_IO_TIMEOUT.
+        # _is_running.is_set() guard at the top of stop() returns early if start()
+        # hasn't been called, so self._listen_thread is set here; narrow for ty.
+        assert self._listen_thread is not None  # noqa: S101 — post-condition of start()
         self._listen_thread.join(timeout=SHUTDOWN_IO_TIMEOUT)
 
         try:
@@ -177,6 +182,10 @@ class TCPServerBase(ABC):
         A wakeup socketpair allows stop() to unblock select() instantly
         instead of waiting for the timeout to expire.
         """
+        # _listen only runs from the thread started by start(), where both
+        # self._socket and self._selector are non-None; narrow for ty.
+        assert self._selector is not None  # noqa: S101 — post-condition of start()
+        assert self._socket is not None  # noqa: S101 — post-condition of start()
         while self._is_running.is_set():
             try:
                 # select(timeout) is a safety net. Normal shutdown is

--- a/simnos/core/simnos.py
+++ b/simnos/core/simnos.py
@@ -219,7 +219,8 @@ class SimNOS:
 
         Pre-condition: ``_check_ports_and_replicas`` already validated that
         when ``replicas`` is truthy, ``port`` is a list[int] of length 2,
-        and otherwise ``port`` is an int. Cast assertions narrow for ty.
+        and otherwise ``port`` is an int. The ``isinstance`` assertions
+        below narrow ``port`` for ty without changing runtime behavior.
 
         :param host_name: string - name of the host
         :param port: integer or list of two integers - port to allocate

--- a/simnos/core/simnos.py
+++ b/simnos/core/simnos.py
@@ -130,6 +130,8 @@ class SimNOS:
 
     def _load_inventory_yaml(self) -> None:
         """Helper method to load SimNOS inventory if it is yaml."""
+        # narrow for ty; _is_inventory_in_yaml() guarantees self.inventory is a str.
+        assert isinstance(self.inventory, str)  # noqa: S101 — caller-side invariant
         with open(self.inventory, encoding="utf-8") as f:
             self.inventory = yaml.safe_load(f.read())
 
@@ -173,17 +175,22 @@ class SimNOS:
         :param port: integer or list of two integers - port to allocate
         :param replicas: integer - number of hosts to create
         """
-        if not replicas and isinstance(port, list):
-            raise ValueError("If replicas is not set, port must be an integer.")
-        if replicas and not isinstance(port, list):
+        # Structured as guard cascade so ty can narrow `port` to list[int] after the
+        # initial isinstance check; the original flat chain re-tested `isinstance`
+        # implicitly each line and lost type narrowing.
+        if not replicas:
+            if isinstance(port, list):
+                raise ValueError("If replicas is not set, port must be an integer.")
+            return  # port is int, no further check needed
+        if not isinstance(port, list):
             raise ValueError("If replicas is set, port must be a list of two integers.")
-        if replicas and len(port) != 2:
+        if len(port) != 2:
             raise ValueError("If replicas is set, port must be a list of two integers.")
-        if replicas and port[0] >= port[1]:
+        if port[0] >= port[1]:
             raise ValueError("If replicas is set, port[0] must be less than port[1].")
-        if replicas and replicas < 1:
+        if replicas < 1:
             raise ValueError("If replicas is set, replicas must be greater than 0.")
-        if replicas and port[1] - port[0] + 1 != replicas:
+        if port[1] - port[0] + 1 != replicas:
             raise ValueError("If replicas is set, port range must be equal to the number of replicas.")
 
     def _instantiate_host_object(
@@ -210,14 +217,20 @@ class SimNOS:
         Method to get hosts and ports correctly
         depending on the number of replicas (if exists).
 
+        Pre-condition: ``_check_ports_and_replicas`` already validated that
+        when ``replicas`` is truthy, ``port`` is a list[int] of length 2,
+        and otherwise ``port`` is an int. Cast assertions narrow for ty.
+
         :param host_name: string - name of the host
         :param port: integer or list of two integers - port to allocate
         :param replicas: integer - number of hosts to create
         """
         if replicas:
+            assert isinstance(port, list)  # noqa: S101 — caller-side invariant from _check_ports_and_replicas
             hosts_name = [f"{host_name}{i}" for i in range(replicas)]
             ports = list(range(port[0], port[1] + 1))
         else:
+            assert isinstance(port, int)  # noqa: S101 — caller-side invariant
             hosts_name = [host_name]
             ports = [port]
         return hosts_name, ports

--- a/simnos/plugins/nos/platforms_py/base_template.py
+++ b/simnos/plugins/nos/platforms_py/base_template.py
@@ -42,5 +42,5 @@ class BaseDevice:
 
     def render(self, template: str, **kwargs) -> str:
         """Render a template."""
-        template = self.env.get_template(template)
-        return template.render(**kwargs)
+        tmpl = self.env.get_template(template)
+        return tmpl.render(**kwargs)

--- a/simnos/plugins/servers/tap_io.py
+++ b/simnos/plugins/servers/tap_io.py
@@ -29,8 +29,14 @@ class TapIO(io.StringIO):
         self._cond: threading.Condition = threading.Condition()
         super().__init__(initial_value, newline)
 
-    def readline(self):
-        """Block until a line is available or the server shuts down."""
+    def readline(self, size: int | None = -1) -> str:
+        """Block until a line is available or the server shuts down.
+
+        The ``size`` argument is accepted for compatibility with
+        ``io.IOBase.readline`` but ignored; this stream returns complete
+        lines from the internal queue regardless of byte budget.
+        """
+        del size  # parent-class signature compatibility only
         with self._cond:
             while self.run_srv.is_set():
                 if self.lines:

--- a/simnos/plugins/shell/cmd_shell.py
+++ b/simnos/plugins/shell/cmd_shell.py
@@ -124,11 +124,11 @@ class CMDShell(Cmd):
             help_msg.append(f"{k}{padding}{v}")
         self.writeline(self.newline.join(help_msg))
 
-    def _check_prompt(self, prompt_: str | list[str]):
+    def _check_prompt(self, prompt_: str | list[str] | None):
         """
         Helper method to check if prompt_ matches current prompt
 
-        :param prompt_: (string or None)  prompt to check
+        :param prompt_: (string, list of strings, or None) prompt to check
         """
         # prompt_ is None if no 'prompt' key defined for command
         if prompt_ is None:

--- a/simnos/plugins/shell/utils.py
+++ b/simnos/plugins/shell/utils.py
@@ -50,14 +50,22 @@ def change_jinja_to_corresponding_py(files: list[str]):
     return list(files)
 
 
+# Module-level cache for get_files_changed. Previously stored as a
+# function attribute (get_files_changed.files_lasttime_changed_old),
+# which defeats static type analysis. Moved to module scope so ty can
+# track the type properly.
+_files_lasttime_changed_old: dict[str, float] = {}
+
+
 def get_files_changed(directory: str):
     """Method to get files changed under a directory"""
+    global _files_lasttime_changed_old
     files_changed: list[str] = []
     files_under_directory: list[str] = get_files_under_directory(directory)
-    if not hasattr(get_files_changed, "files_lasttime_changed_old"):
-        get_files_changed.files_lasttime_changed_old = get_files_lasttime_changed(files_under_directory)
-    files_changed += get_new_files(get_files_changed.files_lasttime_changed_old.keys(), files_under_directory)
-    files_changed += get_files_recently_modified(files_under_directory, get_files_changed.files_lasttime_changed_old)
+    if not _files_lasttime_changed_old:
+        _files_lasttime_changed_old = get_files_lasttime_changed(files_under_directory)
+    files_changed += get_new_files(list(_files_lasttime_changed_old.keys()), files_under_directory)
+    files_changed += get_files_recently_modified(files_under_directory, _files_lasttime_changed_old)
     files_changed = change_jinja_to_corresponding_py(files_changed)
-    get_files_changed.files_lasttime_changed_old = get_files_lasttime_changed(files_under_directory)
+    _files_lasttime_changed_old = get_files_lasttime_changed(files_under_directory)
     return files_changed

--- a/tasks.py
+++ b/tasks.py
@@ -40,23 +40,19 @@ def bandit(context):
 
 
 @task
-def ty(context, exit_zero=True):
-    """Run ty type-checker (Phase 1 non-blocking, see #216).
+def ty(context, exit_zero=False):
+    """Run ty type-checker (blocking since Phase 2, see #218).
 
-    Phase 1 ships ty in a non-blocking mode while the codebase still
-    has ~156 diagnostics (paramiko-heavy files are excluded via
-    pyproject.toml ``[tool.ty.src]``). Phase 2 will gradually fix the
-    remaining errors and flip this task to blocking by changing the
-    ``exit_zero`` default to ``False`` and dropping
-    ``continue-on-error: true`` from CI.
+    Phase 2 brought production code to 0 diagnostics; tests/ is excluded
+    via pyproject.toml ``[tool.ty.src]``. CI now treats ty as blocking
+    (exit_zero=False default + no continue-on-error). New type errors in
+    production code break the build.
 
     Args:
-        exit_zero: When True (default, for local invoke chains), pass
-            ``--exit-zero`` so ty never exits non-zero. CI runs
-            ``uv run invoke ty --no-exit-zero`` and relies on
-            ``continue-on-error: true`` for non-blocking — this lets the
-            step icon reflect ty's verdict so failing trends are visible
-            in GitHub Actions UI.
+        exit_zero: When True, pass ``--exit-zero`` so ty never exits
+            non-zero. Default is False (blocking) for CI. Set True only
+            for developer workflow chains where a transient typing error
+            should not abort the rest of the invoke pipeline.
     """
     flag = "--exit-zero " if exit_zero else ""
     run_cmd(context, f"uv run ty check . {flag}".rstrip())


### PR DESCRIPTION
## Summary

M-9 ty 採用 Phase 2 (#218) を **3 sub-step (2a/2b/2c) を 1 PR に統合** で実施。Phase 1 で paramiko exclude 後の 120 件を 0 件まで持っていき、CI を blocking に切り替え。

## 変更内容

### 2a — production 22 件 → 0 件 fix (6 file)

| File | 件数 | アプローチ |
|------|------|-----------|
| `simnos/core/simnos.py` | 9 | `_check_ports_and_replicas` を guard cascade 化して `port: list[int]` narrowing 確保 + `_get_hosts_and_ports` / `_load_inventory_yaml` に `isinstance` assertion |
| `simnos/core/servers.py` | 5 | `_socket` / `_listen_thread` / `_selector` の Optional narrowing (post-condition assertion 4 箇所) |
| `simnos/plugins/shell/utils.py` | 4 | function-state anti-pattern (`get_files_changed.files_lasttime_changed_old`) を module-level `_files_lasttime_changed_old` cache に置換 + `dict.keys()` → `list(...)` で型整合 |
| `simnos/plugins/nos/platforms_py/base_template.py` | 2 | `render` の local var rebind を `tmpl` 変数に分離 |
| `simnos/plugins/shell/cmd_shell.py` | 1 | `_check_prompt` の type annotation を `str \| list[str]` → `str \| list[str] \| None` (body は既に None 対応) |
| `simnos/plugins/servers/tap_io.py` | 1 | `readline` を parent `_TextIOBase.readline(size)` signature と整合 |

assert 7 箇所すべて `# noqa: S101 — <caller-side invariant / post-condition>` で bandit S101 を意図的 suppress (type narrowing 目的、user input validation ではない)。

### 2b — tests/ exclude

`pyproject.toml [tool.ty.src] exclude` に `tests/` 追加。
- tests は `MagicMock` の dynamic attribute と function-state fixture pattern が ty 不向き
- Phase 3 (TBD) で `create_autospec` 等の type-aware testing approach 採用検討予定

### 2c — blocking 化

- `tasks.py` の `invoke ty` task: `exit_zero=True` default → **`False`**
- `.github/workflows/main.yml`: ty step を 2 step (non-block + annotation) から **1 step (blocking + annotation)** に簡素化、`continue-on-error: true` 削除
- GitHub Actions annotation 形式で PR review の "Files changed" tab に error 直接表示

## Test plan

- [x] `uv run ty check .` → **0 diagnostics**
- [x] `uv run invoke ty` → exit 0 (blocking mode、All checks passed)
- [x] `uv run invoke ruff` / `yamllint` / `bandit` クリーン
- [x] `pytest -n auto` 全 **766 passed** / 7 skipped / 1 xfailed (G2 後と同 count、test 数不変)
- [x] final-refactor (Phase 1 + Phase 2) クリーン、1 件 fix (docstring wording cast → isinstance assertion)

## design + 経緯

- design doc (local-only): `design/20260521_194936_claude_m9-ty-adoption-phase2.md`
- Phase 1 の経験 (cross-review 2 round) で全体方針確定済 → Phase 2 は mini-design + cross-review skip 判断
- Phase 1 design doc 時点 156 件 → Phase 1 merge 後再計測 120 件 → Phase 2 で 0 件

## Phase 3 (defer、別 issue 候補)

- tests/ の type-safety 化 (`MagicMock` → `create_autospec` 等、structural typing 検討)
- types-paramiko v5.x 安定 release 後の再評価 (`ssh_server_paramiko.py` の exclude 解除)

## 関連

- Closes #218
- Phase 1: #216 (closed) via PR #217 (merged)
- 棚卸し doc: M-9 (L884-890)
- umbrella issue: #199 (close 済)

🤖 Generated with [Claude Code](https://claude.com/claude-code)