### PR TITLE
fix: _check_ports_and_replicas の replicas=0 quirk を解消 (T-12 follow-up #220)

### DIFF
--- a/simnos/core/simnos.py
+++ b/simnos/core/simnos.py
@@ -175,21 +175,23 @@ class SimNOS:
         :param port: integer or list of two integers - port to allocate
         :param replicas: integer - number of hosts to create
         """
-        # Structured as guard cascade so ty can narrow `port` to list[int] after the
-        # initial isinstance check; the original flat chain re-tested `isinstance`
-        # implicitly each line and lost type narrowing.
-        if not replicas:
+        # `is None` (not `not replicas`) so that replicas=0 is treated as "set
+        # with invalid value" and reaches the `replicas < 1` check below. T-12
+        # PR #211 recorded this as a known quirk; #220 promotes the check.
+        # Guard cascade also lets ty narrow `port` to list[int] after the
+        # initial isinstance check.
+        if replicas is None:
             if isinstance(port, list):
                 raise ValueError("If replicas is not set, port must be an integer.")
             return  # port is int, no further check needed
+        if replicas < 1:
+            raise ValueError("If replicas is set, replicas must be greater than 0.")
         if not isinstance(port, list):
             raise ValueError("If replicas is set, port must be a list of two integers.")
         if len(port) != 2:
             raise ValueError("If replicas is set, port must be a list of two integers.")
         if port[0] >= port[1]:
             raise ValueError("If replicas is set, port[0] must be less than port[1].")
-        if replicas < 1:
-            raise ValueError("If replicas is set, replicas must be greater than 0.")
         if port[1] - port[0] + 1 != replicas:
             raise ValueError("If replicas is set, port range must be equal to the number of replicas.")
 

--- a/tests/core/test_simnos.py
+++ b/tests/core/test_simnos.py
@@ -319,17 +319,17 @@ class TestSimNOS:
         Test that the function _check_ports_and_replicas raises an exception
         when replicas is set and the replicas are less than 1.
 
-        Note: With ``replicas=0`` the guards in ``_check_ports_and_replicas`` short-circuit
-        on the first ``if not replicas and isinstance(port, list)`` branch (0 is falsy),
-        so the actual message is "replicas is not set, port must be an integer" — not
-        the "replicas must be greater than 0" branch the docstring would suggest. This is
-        a known quirk worth tracking in a follow-up issue.
+        Fix in #220 promoted the ``replicas < 1`` check above the ``port`` type
+        checks and switched the entry guard from ``if not replicas`` to
+        ``if replicas is None``, so ``replicas=0`` now reaches the intended
+        "replicas must be greater than 0" branch instead of short-circuiting
+        on the falsy-replicas path.
         """
         inventory = {
             "default": {"port": [5000, 5001]},
             "hosts": {"R1": {"replicas": 0}},
         }
-        with pytest.raises(ValueError, match=r"replicas is not set, port must be an integer"):
+        with pytest.raises(ValueError, match=r"replicas must be greater than 0"):
             SimNOS(inventory=inventory)
 
     def test_replicas_set_and_ports_set_not_same_length(self):


### PR DESCRIPTION
## Summary

T-12 (PR #211 / closed #210) で記録した known quirk の production fix。`replicas=0` を渡したとき、`_check_ports_and_replicas` の `replicas must be greater than 0` branch が **到達不能** だった問題を guard 順序調整で解消。

## Problem

```python
if not replicas:  # replicas=0 と replicas=None 両方 falsy で同 branch
    if isinstance(port, list):
        raise ValueError("If replicas is not set, port must be an integer.")
    return  # port=int は副作用なしで return
...
if replicas < 1:  # unreachable for replicas=0
    raise ValueError("If replicas is set, replicas must be greater than 0.")
```

docstring 意図と挙動が乖離していた。

## Fix

- entry guard を `if not replicas:` → `if replicas is None:` (replicas=0 を「set with invalid value」扱い)
- `replicas < 1` check を guard cascade の上位に移動 (replicas=0 で early raise)

```python
if replicas is None:
    if isinstance(port, list):
        raise ValueError("If replicas is not set, port must be an integer.")
    return
if replicas < 1:
    raise ValueError("If replicas is set, replicas must be greater than 0.")
# replicas >= 1 確定、以下従来通り
```

## Behavior 変更

| Input | 元 | 新 |
|-------|----|----|
| `replicas=0 + port=int` | 副作用なし return | raise "replicas must be greater than 0" |
| `replicas=0 + port=list` | raise "replicas is not set, port must be an integer" | raise "replicas must be greater than 0" |
| `replicas=None + ...` | 変わらず | 変わらず |
| `replicas>=1 + ...` | 変わらず | 変わらず |

`replicas=0` を渡す legitimate use case 無し (host を 0 個複製は無意味)、breaking change の影響軽微想定。

## Test plan

- [x] `test_replicas_set_and_replicas_less_than_1` の docstring quirk Note 削除 + match regex を `replicas must be greater than 0` に更新 (docstring intent と一致)
- [x] `invoke ruff` / `yamllint` / `bandit` / `ty` 全 green
- [x] `pytest -n auto` 全 **766 passed** / 7 skipped / 1 xfailed (test 数不変)

## 関連

- Closes #220
- T-12 PR #211 (closed #210): quirk 記録元
- M-9 Phase 2 PR #219 (closed #218): `_check_ports_and_replicas` を guard cascade refactor 済、本 fix は guard 順序の調整のみ

🤖 Generated with [Claude Code](https://claude.com/claude-code)