### PR TITLE
refactor: G3 PR1 — SSH/Telnet tap 対を tap_bridge (TransportAdapter) に統合 (#225)

### DIFF
--- a/simnos/plugins/servers/ssh_server_paramiko.py
+++ b/simnos/plugins/servers/ssh_server_paramiko.py
@@ -387,7 +387,7 @@ class ParamikoSshServer(TCPServerBase):
 
         :param channel: paramiko Channel
         :return: (authenticated, skip_lf) — skip_lf should be forwarded to
-                 channel_to_shell_tap so it can consume a trailing LF after
+                 client_to_shell_tap so it can consume a trailing LF after
                  the final CR of the password line.
         """
         channel.sendall(b"\r\nUser Name:")

--- a/simnos/plugins/servers/ssh_server_paramiko.py
+++ b/simnos/plugins/servers/ssh_server_paramiko.py
@@ -3,7 +3,6 @@ This module implements an SSH server done using
 paramiko as the SSH connection library.
 """
 
-import io
 import logging
 from pathlib import Path
 import socket
@@ -17,7 +16,8 @@ import paramiko.rsakey
 from simnos.core.nos import Nos
 from simnos.core.servers import TCPServerBase
 from simnos.core.timeouts import SHUTDOWN_IO_TIMEOUT
-from simnos.plugins.servers.tap_io import TapIO, process_tap_line
+from simnos.plugins.servers.tap_bridge import client_to_shell_tap, shell_to_client_tap
+from simnos.plugins.servers.tap_io import TapIO
 
 log = logging.getLogger(__name__)
 
@@ -158,166 +158,32 @@ class ParamikoSshServerInterface(paramiko.ServerInterface):
         return (self.ssh_banner + "\r\n", "en-US")
 
 
-def channel_to_shell_tap(
-    channel: paramiko.Channel,
-    shell_stdin: TapIO,
-    shell_replied_event: threading.Event,
-    run_srv: threading.Event,
-    *,
-    initial_skip_lf: bool = False,
-    shell_stdout: TapIO | None = None,
-) -> None:
-    """Read bytes from SSH channel and forward complete lines to shell stdin.
+class ParamikoChannelAdapter:
+    """TransportAdapter implementation wrapping a paramiko Channel (G3 / #225).
 
-    When *shell_stdout* is provided, the newline echo (``\\r\\n``) for
-    line-ending bytes is written to *shell_stdout* instead of being sent
-    directly to the channel.  ``shell_to_channel_tap`` then batches the
-    echo together with the shell's response into a single ``sendall()``,
-    preventing a GIL-scheduling race where the client reads the echo and
-    the prompt as separate SSH packets (#87).
+    Used by the shared tap functions in tap_bridge; keeps all paramiko
+    specifics (exception types, channel liveness flags) in this module.
     """
-    buffer: io.BytesIO = io.BytesIO()
-    skip_lf = initial_skip_lf
-    while run_srv.is_set():
-        try:
-            byte: bytes = channel.recv(1)
-        except TimeoutError:
-            continue
-        except (OSError, EOFError, paramiko.SSHException):
-            log.debug("ssh_server.channel_to_shell_tap channel read closed")
-            break
-        log.debug("ssh_server.channel_to_shell_tap received from channel: %s", [byte])
 
-        # EOF / channel closed
-        if byte in (b"", None):
-            break
+    io_errors = (OSError, EOFError, paramiko.SSHException)
+    nul_resets_skip_lf = False  # SSH has no CR NUL convention (RFC 854 is Telnet-only)
+    name = "ssh"
 
-        # Drop NUL bytes completely (don't echo, don't buffer).
-        # Unlike Telnet (RFC 854), SSH has no CR NUL convention,
-        # so skip_lf is intentionally preserved across NUL bytes.
-        if byte == b"\x00":
-            continue
+    def __init__(self, channel: paramiko.Channel):
+        self._channel = channel
 
-        # Consume the LF half of a CR LF pair.
-        if skip_lf:
-            skip_lf = False
-            if byte == b"\n":
-                continue
+    def recv_byte(self) -> bytes | None:
+        byte = self._channel.recv(1)
+        return byte if byte else None  # normalize b"" (EOF) to None
 
-        # Wait for the shell to reply, but check run_srv periodically
-        # so that shutdown is not blocked for the full wait duration.
-        while not shell_replied_event.wait(timeout=SHUTDOWN_IO_TIMEOUT):
-            if not run_srv.is_set():
-                break
-        if not run_srv.is_set():
-            break
-        if not channel.active:
-            log.error("SSH channel is not active. Exiting.")
-            break
-        try:
-            if byte in (b"\r", b"\n"):
-                skip_lf = byte == b"\r"
-                if shell_stdout is not None:
-                    shell_stdout.write("\r\n")
-                else:
-                    channel.sendall(b"\r\n")
-                log.debug(
-                    "ssh_server.channel_to_shell_tap echoing new line to channel: %s",
-                    [b"\r\n"],
-                )
-                buffer.write(byte)
-                buffer.seek(0)
-                line = buffer.read().decode(encoding="utf-8")
-                buffer.seek(0)
-                buffer.truncate()
-                log.debug("ssh_server.channel_to_shell_tap sending line to shell: %s", [line])
-                shell_stdin.write(line)
-                shell_replied_event.clear()
-            else:
-                channel.sendall(byte)
-                log.debug(
-                    "ssh_server.channel_to_shell_tap echoing byte to channel: %s",
-                    [byte],
-                )
-                buffer.write(byte)
-        except (OSError, EOFError, paramiko.SSHException) as e:
-            log.error("ssh_server.channel_to_shell_tap channel write error: %s", e)
-            break
+    def sendall(self, data: bytes) -> None:
+        self._channel.sendall(data)
 
-    run_srv.clear()
-
-
-def shell_to_channel_tap(
-    channel: paramiko.Channel,
-    shell_stdout: TapIO,
-    shell_replied_event: threading.Event,
-    run_srv: threading.Event,
-) -> None:
-    """Read lines from shell stdout and send them to the SSH channel.
-
-    After reading the first available line, a brief coalescing pause
-    (1 ms) allows the shell to enqueue additional output (e.g. a prompt
-    following a newline echo).  All available lines are then sent in a
-    single ``sendall()`` call so the client receives them in one SSH
-    packet, avoiding a GIL-scheduling race in paramiko (#87).
-
-    When the first line is whitespace-only (a newline echo from
-    ``channel_to_shell_tap``), the function blocks on a second
-    ``readline()`` instead of sending the echo alone.  This guarantees
-    the echo and the prompt that follows it are always delivered in the
-    same ``sendall()`` call, even when the shell is slow (e.g. hot
-    reload YAML re-parse in ``precmd()``).
-    """
-    while run_srv.is_set():
-        if channel.closed:
-            break
-        line = shell_stdout.readline()
-        if not line:
-            break
-
-        # Coalesce: brief pause lets the shell enqueue the prompt
-        # after the newline echo, so both are sent in one packet.
-        time.sleep(0.001)
-
-        batch = process_tap_line(line)
-        drained = shell_stdout.drain()
-
-        if not drained and batch.strip() == "":
-            # Echo-only batch (e.g. "\r\n") with nothing else queued.
-            # The shell hasn't produced the prompt yet — block until it
-            # does so we never send a bare echo as a separate packet.
-            next_line = shell_stdout.readline()
-            if next_line:
-                batch += process_tap_line(next_line)
-                # Drain any extra items that arrived alongside the prompt.
-                time.sleep(0.001)
-                drained = shell_stdout.drain()
-
-        for extra in drained:
-            # Separate consecutive lines that don't end with a newline
-            # (e.g. prompts: "SimNOS>") so they aren't concatenated into
-            # "SimNOS>SimNOS>..." which breaks netmiko's find_prompt().
-            if batch and not batch.endswith("\n"):
-                batch += "\r\n"
-            batch += process_tap_line(extra)
-
-        log.debug("ssh_server.shell_to_channel_tap sending batch to channel %s", [batch])
-        written = False
-        while run_srv.is_set() and not written:
-            try:
-                channel.sendall(batch.encode(encoding="utf-8"))
-                written = True
-            except TimeoutError:
-                log.debug("ssh_server.shell_to_channel_tap write timeout, retrying")
-                continue
-            except (OSError, EOFError, paramiko.SSHException) as e:
-                log.error("ssh_server.shell_to_channel_tap channel write error: %s", e)
-                break
-        if not written:
-            break
-        shell_replied_event.set()
-
-    run_srv.clear()
+    def is_closed(self) -> bool:
+        # Known-dead early check: closed channel or dead transport.
+        # channel.active also reflects peer-side EOF paramiko already knows;
+        # authoritative peer-disconnect detection stays recv/send based.
+        return self._channel.closed or not self._channel.active
 
 
 class ParamikoSshServer(TCPServerBase):
@@ -595,24 +461,27 @@ class ParamikoSshServer(TCPServerBase):
             # create stdio for the shell
             shell_stdin, shell_stdout = TapIO(run_srv), TapIO(run_srv)
 
+            # bridge the channel and the shell through the shared tap pair
+            transport_adapter = ParamikoChannelAdapter(channel)
+
             # start intermediate thread to tap into
-            # the channel->shell_stdin bytes stream
-            channel_to_shell_tapper = threading.Thread(
-                target=channel_to_shell_tap,
-                args=(channel, shell_stdin, shell_replied_event, run_srv),
+            # the client->shell_stdin bytes stream
+            client_to_shell_tapper = threading.Thread(
+                target=client_to_shell_tap,
+                args=(transport_adapter, shell_stdin, shell_replied_event, run_srv),
                 kwargs={"initial_skip_lf": skip_lf, "shell_stdout": shell_stdout},
                 daemon=True,
             )
-            channel_to_shell_tapper.start()
+            client_to_shell_tapper.start()
 
             # start intermediate thread to tap into
-            # the shell_stdout->channel bytes stream
-            shell_to_channel_tapper = threading.Thread(
-                target=shell_to_channel_tap,
-                args=(channel, shell_stdout, shell_replied_event, run_srv),
+            # the shell_stdout->client bytes stream
+            shell_to_client_tapper = threading.Thread(
+                target=shell_to_client_tap,
+                args=(transport_adapter, shell_stdout, shell_replied_event, run_srv),
                 daemon=True,
             )
-            shell_to_channel_tapper.start()
+            shell_to_client_tapper.start()
 
             # create the client shell
             client_shell = self.shell(

--- a/simnos/plugins/servers/tap_bridge.py
+++ b/simnos/plugins/servers/tap_bridge.py
@@ -29,6 +29,11 @@ class TransportAdapter(Protocol):
 
     Implementations: ParamikoChannelAdapter (ssh_server_paramiko),
     TelnetSocketAdapter (telnet_server).
+
+    Timeout responsibility: adapters do NOT manage I/O timeouts. The caller
+    (connection_function) configures them on the underlying channel/socket
+    before the taps start; recv_byte()/sendall() simply let the resulting
+    TimeoutError propagate. New transports must follow the same split.
     """
 
     #: Exceptions that mean "I/O failed / peer gone" for this transport.
@@ -247,7 +252,13 @@ def shell_to_client_tap(
                 transport.sendall(batch.encode(encoding="utf-8"))
                 written = True
             except TimeoutError:
-                log.debug("tap_bridge.shell_to_client_tap [%s] write timeout, retrying", transport.name)
+                # Batch size aids debugging the partial-send duplicate risk
+                # accepted in the G3 design (resend may duplicate echoed chars).
+                log.debug(
+                    "tap_bridge.shell_to_client_tap [%s] write timeout (batch %d chars), retrying",
+                    transport.name,
+                    len(batch),
+                )
                 continue
             except transport.io_errors as e:
                 log.error("tap_bridge.shell_to_client_tap [%s] client write error: %s", transport.name, e)

--- a/simnos/plugins/servers/tap_bridge.py
+++ b/simnos/plugins/servers/tap_bridge.py
@@ -1,0 +1,259 @@
+"""Transport-agnostic tap functions bridging a network client and a TapIO shell.
+
+Shared by SSH (paramiko channel) and Telnet (raw socket) servers. The
+transport differences are absorbed by TransportAdapter implementations
+that live in the respective server modules (G3 / #225). The loop logic is
+ported verbatim from the former SSH tap pair in ssh_server_paramiko.py so
+that the #87 echo-coalescing behaviour is preserved byte for byte.
+"""
+
+import io
+import logging
+import threading
+import time
+from typing import Protocol
+
+from simnos.core.timeouts import SHUTDOWN_IO_TIMEOUT
+from simnos.plugins.servers.tap_io import TapIO, process_tap_line
+
+log = logging.getLogger(__name__)
+
+# Echo coalescing delay for the GIL-scheduling race workaround (#87 SSH /
+# #94 Telnet). A 1 ms pause lets the shell enqueue the prompt after a
+# newline echo so both are sent in a single sendall().
+_COALESCE_DELAY = 0.001
+
+
+class TransportAdapter(Protocol):
+    """Minimal transport surface required by the tap functions.
+
+    Implementations: ParamikoChannelAdapter (ssh_server_paramiko),
+    TelnetSocketAdapter (telnet_server).
+    """
+
+    #: Exceptions that mean "I/O failed / peer gone" for this transport.
+    #: NOTE: TimeoutError is a subclass of OSError (Py3.10+), so it is
+    #: unavoidably *matched* by this tuple. The tap functions therefore
+    #: catch TimeoutError in a dedicated ``except TimeoutError:`` clause
+    #: placed BEFORE ``except transport.io_errors:`` — exception-clause
+    #: order is the contract, not tuple membership.
+    io_errors: tuple[type[Exception], ...]
+
+    #: RFC 854 quirk switch: True (Telnet) = CR NUL is a complete sequence,
+    #: NUL resets the pending-LF state. False (SSH) = no CR NUL convention,
+    #: pending-LF state is preserved across NUL bytes.
+    nul_resets_skip_lf: bool
+
+    #: Short name for log messages ("ssh" / "telnet").
+    name: str
+
+    def recv_byte(self) -> bytes | None:
+        """Read one data byte. Returns None on EOF (b"" must be normalized).
+
+        MUST let TimeoutError propagate to the caller (do NOT swallow it
+        inside the adapter) — the tap functions turn recv timeout into a
+        ``continue`` so that run_srv shutdown checks keep cycling.
+        """
+        ...
+
+    def sendall(self, data: bytes) -> None:
+        """Send *data* to the client. TimeoutError must propagate."""
+        ...
+
+    def is_closed(self) -> bool:
+        """Best-effort early check for known-dead transport state.
+
+        Minimum guarantee: returns True once the transport is closed on our
+        side (e.g. socket fd already closed). A transport MAY additionally
+        report peer-side closure it already knows about (e.g. paramiko's
+        channel.closed / not channel.active reflect peer EOF) — callers must
+        NOT rely on that: authoritative peer-disconnect detection is
+        recv_byte() -> None or an io_errors exception on send.
+        """
+        ...
+
+
+def client_to_shell_tap(
+    transport: TransportAdapter,
+    shell_stdin: TapIO,
+    shell_replied_event: threading.Event,
+    run_srv: threading.Event,
+    *,
+    initial_skip_lf: bool = False,
+    shell_stdout: TapIO | None = None,
+) -> None:
+    """Read bytes from the client transport and forward complete lines to shell stdin.
+
+    When *shell_stdout* is provided, the newline echo (``\\r\\n``) for
+    line-ending bytes is written to *shell_stdout* instead of being sent
+    directly to the transport.  ``shell_to_client_tap`` then batches the
+    echo together with the shell's response into a single ``sendall()``,
+    preventing a race where the client reads the echo and the prompt as
+    separate packets (#87 SSH / #94 Telnet).
+    """
+    buffer: io.BytesIO = io.BytesIO()
+    skip_lf = initial_skip_lf
+    while run_srv.is_set():
+        try:
+            byte = transport.recv_byte()
+        except TimeoutError:
+            continue
+        except transport.io_errors:
+            log.debug("tap_bridge.client_to_shell_tap [%s] read closed", transport.name)
+            break
+        log.debug(
+            "tap_bridge.client_to_shell_tap [%s] received from client: %s",
+            transport.name,
+            [byte],
+        )
+
+        # EOF / connection closed (adapters normalize b"" to None)
+        if byte is None:
+            break
+
+        # Drop NUL bytes completely (don't echo, don't buffer).
+        # Telnet (RFC 854): CR NUL is a complete sequence, so reset skip_lf.
+        # SSH: no CR NUL convention, skip_lf is intentionally preserved.
+        if byte == b"\x00":
+            if transport.nul_resets_skip_lf:
+                skip_lf = False
+            continue
+
+        # Consume the LF half of a CR LF pair.
+        if skip_lf:
+            skip_lf = False
+            if byte == b"\n":
+                continue
+
+        # Wait for the shell to reply, but check run_srv periodically
+        # so that shutdown is not blocked for the full wait duration.
+        while not shell_replied_event.wait(timeout=SHUTDOWN_IO_TIMEOUT):
+            if not run_srv.is_set():
+                break
+        if not run_srv.is_set():
+            break
+        if transport.is_closed():
+            log.error("tap_bridge.client_to_shell_tap [%s] transport closed. Exiting.", transport.name)
+            break
+        try:
+            if byte in (b"\r", b"\n"):
+                skip_lf = byte == b"\r"
+                if shell_stdout is not None:
+                    shell_stdout.write("\r\n")
+                else:
+                    transport.sendall(b"\r\n")
+                log.debug(
+                    "tap_bridge.client_to_shell_tap [%s] echoing new line to client: %s",
+                    transport.name,
+                    [b"\r\n"],
+                )
+                buffer.write(byte)
+                buffer.seek(0)
+                line = buffer.read().decode(encoding="utf-8")
+                buffer.seek(0)
+                buffer.truncate()
+                log.debug(
+                    "tap_bridge.client_to_shell_tap [%s] sending line to shell: %s",
+                    transport.name,
+                    [line],
+                )
+                shell_stdin.write(line)
+                shell_replied_event.clear()
+            else:
+                transport.sendall(byte)
+                log.debug(
+                    "tap_bridge.client_to_shell_tap [%s] echoing byte to client: %s",
+                    transport.name,
+                    [byte],
+                )
+                buffer.write(byte)
+        except TimeoutError as e:
+            # Echo-send timeout is treated as a disconnect, matching the
+            # pre-G3 behaviour of both transports (policy table in the G3
+            # design doc; deliberately NOT unified with the batch-send
+            # retry in shell_to_client_tap).
+            log.error("tap_bridge.client_to_shell_tap [%s] echo write timeout: %s", transport.name, e)
+            break
+        except transport.io_errors as e:
+            log.error("tap_bridge.client_to_shell_tap [%s] client write error: %s", transport.name, e)
+            break
+
+    run_srv.clear()
+
+
+def shell_to_client_tap(
+    transport: TransportAdapter,
+    shell_stdout: TapIO,
+    shell_replied_event: threading.Event,
+    run_srv: threading.Event,
+) -> None:
+    """Read lines from shell stdout and send them to the client transport.
+
+    After reading the first available line, a brief coalescing pause
+    (``_COALESCE_DELAY``) allows the shell to enqueue additional output
+    (e.g. a prompt following a newline echo).  All available lines are then
+    sent in a single ``sendall()`` call so the client receives them in one
+    packet, avoiding a GIL-scheduling race (#87 SSH / #94 Telnet).
+
+    When the first line is whitespace-only (a newline echo from
+    ``client_to_shell_tap``), the function blocks on a second
+    ``readline()`` instead of sending the echo alone.  This guarantees
+    the echo and the prompt that follows it are always delivered in the
+    same ``sendall()`` call, even when the shell is slow (e.g. hot
+    reload YAML re-parse in ``precmd()``).
+
+    A send timeout is retried (U1 — unified for both transports); each
+    send attempt is gated on a preceding ``run_srv.is_set()`` check (the
+    check and the send are not atomic, so a clear racing in between is
+    tolerated — D11).
+    """
+    while run_srv.is_set():
+        if transport.is_closed():
+            break
+        line = shell_stdout.readline()
+        if not line:
+            break
+
+        # Coalesce: brief pause lets the shell enqueue the prompt
+        # after the newline echo, so both are sent in one packet.
+        time.sleep(_COALESCE_DELAY)
+
+        batch = process_tap_line(line)
+        drained = shell_stdout.drain()
+
+        if not drained and batch.strip() == "":
+            # Echo-only batch (e.g. "\r\n") with nothing else queued.
+            # The shell hasn't produced the prompt yet — block until it
+            # does so we never send a bare echo as a separate packet.
+            next_line = shell_stdout.readline()
+            if next_line:
+                batch += process_tap_line(next_line)
+                # Drain any extra items that arrived alongside the prompt.
+                time.sleep(_COALESCE_DELAY)
+                drained = shell_stdout.drain()
+
+        for extra in drained:
+            # Separate consecutive lines that don't end with a newline
+            # (e.g. prompts: "SimNOS>") so they aren't concatenated into
+            # "SimNOS>SimNOS>..." which breaks netmiko's find_prompt().
+            if batch and not batch.endswith("\n"):
+                batch += "\r\n"
+            batch += process_tap_line(extra)
+
+        log.debug("tap_bridge.shell_to_client_tap [%s] sending batch to client %s", transport.name, [batch])
+        written = False
+        while run_srv.is_set() and not written:
+            try:
+                transport.sendall(batch.encode(encoding="utf-8"))
+                written = True
+            except TimeoutError:
+                log.debug("tap_bridge.shell_to_client_tap [%s] write timeout, retrying", transport.name)
+                continue
+            except transport.io_errors as e:
+                log.error("tap_bridge.shell_to_client_tap [%s] client write error: %s", transport.name, e)
+                break
+        if not written:
+            break
+        shell_replied_event.set()
+
+    run_srv.clear()

--- a/simnos/plugins/servers/telnet_server.py
+++ b/simnos/plugins/servers/telnet_server.py
@@ -6,7 +6,6 @@ and the existing TCPServerBase + TapIO architecture. No external dependencies.
 """
 
 import contextlib
-import io
 import ipaddress
 import logging
 import socket
@@ -17,7 +16,8 @@ from typing import Any
 from simnos.core.nos import Nos
 from simnos.core.servers import TCPServerBase
 from simnos.core.timeouts import SHUTDOWN_IO_TIMEOUT
-from simnos.plugins.servers.tap_io import TapIO, process_tap_line
+from simnos.plugins.servers.tap_bridge import client_to_shell_tap, shell_to_client_tap
+from simnos.plugins.servers.tap_io import TapIO
 
 log = logging.getLogger(__name__)
 
@@ -49,6 +49,34 @@ def _is_loopback(address: str) -> bool:
         return all(ipaddress.ip_address(ai[4][0]).is_loopback for ai in info)
     except (OSError, ValueError):
         return False
+
+
+class TelnetSocketAdapter:
+    """TransportAdapter implementation wrapping a raw Telnet socket (G3 / #225).
+
+    Delegates byte reads to ``TelnetServer._recv_byte`` (private by design)
+    so IAC negotiation handling stays inside the Telnet protocol layer.
+    """
+
+    io_errors = (OSError,)
+    nul_resets_skip_lf = True  # RFC 854: CR NUL is a complete sequence
+    name = "telnet"
+
+    def __init__(self, sock: socket.socket, server: "TelnetServer"):
+        self._sock = sock
+        self._server = server
+
+    def recv_byte(self) -> bytes | None:
+        # Private-method delegation by design: the IAC layer stays in TelnetServer.
+        return self._server._recv_byte(self._sock)
+
+    def sendall(self, data: bytes) -> None:
+        self._sock.sendall(data)
+
+    def is_closed(self) -> bool:
+        # U2: known-local-closed early check only (peer disconnect is
+        # detected via recv_byte() -> None / send io_errors).
+        return self._sock.fileno() == -1
 
 
 class TelnetServer(TCPServerBase):
@@ -203,162 +231,6 @@ class TelnetServer(TCPServerBase):
         return username == self.username and password == self.password
 
     # ------------------------------------------------------------------
-    # Tap functions (socket ↔ shell bridge)
-    # ------------------------------------------------------------------
-
-    def socket_to_shell_tap(
-        self,
-        sock: socket.socket,
-        shell_stdin: TapIO,
-        shell_replied_event: threading.Event,
-        run_srv: threading.Event,
-        *,
-        shell_stdout: TapIO | None = None,
-    ) -> None:
-        """Read bytes from socket and forward complete lines to shell stdin.
-
-        When *shell_stdout* is provided, the newline echo (``\\r\\n``) for
-        line-ending bytes is written to *shell_stdout* instead of being sent
-        directly to the socket.  ``shell_to_socket_tap`` then batches the
-        echo together with the shell's response into a single ``sendall()``,
-        preventing a race where the client reads the echo and the prompt as
-        separate TCP segments (#94).
-        """
-        buffer: io.BytesIO = io.BytesIO()
-        skip_lf = False  # Set after \r to consume the trailing \n of CR LF
-        while run_srv.is_set():
-            try:
-                byte = self._recv_byte(sock)
-            except TimeoutError:
-                continue
-            except OSError:
-                log.error("telnet_server.socket_to_shell_tap socket read error")
-                break
-
-            # EOF / connection closed
-            if byte is None:
-                break
-
-            # Drop NUL bytes completely.
-            # CR NUL is a complete sequence (RFC 854), so reset skip_lf.
-            if byte == b"\x00":
-                skip_lf = False
-                continue
-
-            # Consume the LF half of a CR LF pair (RFC 854).
-            if skip_lf:
-                skip_lf = False
-                if byte == b"\n":
-                    continue
-
-            # Wait for the shell to reply, but check run_srv periodically
-            # so that shutdown is not blocked for the full wait duration.
-            while not shell_replied_event.wait(timeout=SHUTDOWN_IO_TIMEOUT):
-                if not run_srv.is_set():
-                    break
-            if not run_srv.is_set():
-                break
-
-            try:
-                if byte in (b"\r", b"\n"):
-                    skip_lf = byte == b"\r"
-                    if shell_stdout is not None:
-                        shell_stdout.write("\r\n")
-                    else:
-                        sock.sendall(b"\r\n")
-                    log.debug("telnet_server.socket_to_shell_tap echoing newline")
-                    buffer.write(byte)
-                    buffer.seek(0)
-                    line = buffer.read().decode(encoding="utf-8")
-                    buffer.seek(0)
-                    buffer.truncate()
-                    log.debug(
-                        "telnet_server.socket_to_shell_tap sending line to shell: %s",
-                        [line],
-                    )
-                    shell_stdin.write(line)
-                    shell_replied_event.clear()
-                else:
-                    sock.sendall(byte)
-                    log.debug(
-                        "telnet_server.socket_to_shell_tap echoing byte to socket: %s",
-                        [byte],
-                    )
-                    buffer.write(byte)
-            except OSError as e:
-                log.error("telnet_server.socket_to_shell_tap socket write error: %s", e)
-                break
-
-        # Signal all threads to stop
-        run_srv.clear()
-
-    def shell_to_socket_tap(
-        self,
-        sock: socket.socket,
-        shell_stdout: TapIO,
-        shell_replied_event: threading.Event,
-        run_srv: threading.Event,
-    ) -> None:
-        """Read lines from shell stdout and send them to the socket.
-
-        After reading the first available line, a brief coalescing pause
-        (1 ms) allows the shell to enqueue additional output (e.g. a prompt
-        following a newline echo).  All available lines are then sent in a
-        single ``sendall()`` call so the client receives them in one TCP
-        segment, avoiding a race where echo and prompt arrive separately
-        (#94, mirrors SSH fix in #87).
-
-        When the first line is whitespace-only (a newline echo from
-        ``socket_to_shell_tap``), the function blocks on a second
-        ``readline()`` instead of sending the echo alone.  This guarantees
-        the echo and the prompt that follows it are always delivered in the
-        same ``sendall()`` call.
-        """
-        while run_srv.is_set():
-            line = shell_stdout.readline()
-            if not line:
-                break
-
-            # Coalesce: brief pause lets the shell enqueue the prompt
-            # after the newline echo, so both are sent in one segment.
-            time.sleep(0.001)
-
-            batch = process_tap_line(line)
-            drained = shell_stdout.drain()
-
-            if not drained and batch.strip() == "":
-                # Echo-only batch (e.g. "\r\n") with nothing else queued.
-                # The shell hasn't produced the prompt yet — block until it
-                # does so we never send a bare echo as a separate segment.
-                next_line = shell_stdout.readline()
-                if next_line:
-                    batch += process_tap_line(next_line)
-                    # Drain any extra items that arrived alongside the prompt.
-                    time.sleep(0.001)
-                    drained = shell_stdout.drain()
-
-            for extra in drained:
-                # Separate consecutive lines that don't end with a newline
-                # (e.g. prompts) so they aren't concatenated into one string
-                # which breaks netmiko's find_prompt().
-                if batch and not batch.endswith("\n"):
-                    batch += "\r\n"
-                batch += process_tap_line(extra)
-
-            log.debug("telnet_server.shell_to_socket_tap sending batch to socket: %s", [batch])
-            if not run_srv.is_set():
-                break
-            try:
-                sock.sendall(batch.encode(encoding="utf-8"))
-            except OSError as e:
-                log.error("telnet_server.shell_to_socket_tap socket write error: %s", e)
-                break
-            shell_replied_event.set()
-
-        # Signal all threads to stop
-        run_srv.clear()
-
-    # ------------------------------------------------------------------
     # Watchdog
     # ------------------------------------------------------------------
 
@@ -435,22 +307,25 @@ class TelnetServer(TCPServerBase):
             # Create stdio for the shell
             shell_stdin, shell_stdout = TapIO(run_srv), TapIO(run_srv)
 
-            # Start socket→shell tap thread
-            socket_to_shell_tapper = threading.Thread(
-                target=self.socket_to_shell_tap,
-                args=(client, shell_stdin, shell_replied_event, run_srv),
+            # Bridge the socket and the shell through the shared tap pair
+            transport_adapter = TelnetSocketAdapter(client, self)
+
+            # Start client→shell tap thread
+            client_to_shell_tapper = threading.Thread(
+                target=client_to_shell_tap,
+                args=(transport_adapter, shell_stdin, shell_replied_event, run_srv),
                 kwargs={"shell_stdout": shell_stdout},
                 daemon=True,
             )
-            socket_to_shell_tapper.start()
+            client_to_shell_tapper.start()
 
-            # Start shell→socket tap thread
-            shell_to_socket_tapper = threading.Thread(
-                target=self.shell_to_socket_tap,
-                args=(client, shell_stdout, shell_replied_event, run_srv),
+            # Start shell→client tap thread
+            shell_to_client_tapper = threading.Thread(
+                target=shell_to_client_tap,
+                args=(transport_adapter, shell_stdout, shell_replied_event, run_srv),
                 daemon=True,
             )
-            shell_to_socket_tapper.start()
+            shell_to_client_tapper.start()
 
             # Create the client shell
             client_shell = self.shell(

--- a/simnos/plugins/servers/telnet_server.py
+++ b/simnos/plugins/servers/telnet_server.py
@@ -67,7 +67,6 @@ class TelnetSocketAdapter:
         self._server = server
 
     def recv_byte(self) -> bytes | None:
-        # Private-method delegation by design: the IAC layer stays in TelnetServer.
         return self._server._recv_byte(self._sock)
 
     def sendall(self, data: bytes) -> None:

--- a/tests/plugins/test_ssh_server_paramiko.py
+++ b/tests/plugins/test_ssh_server_paramiko.py
@@ -327,6 +327,28 @@ class ChannelToShellTapTest(unittest.TestCase):
         self.assertEqual(self.mock_run_srv.is_set.call_count, 2)
         self.mock_run_srv.clear.assert_called_once()
 
+    def test_client_to_shell_tap_break_loop_when_channel_closed_but_active(self):
+        """U2 widening pin: closed=True is detected even while the transport is alive.
+
+        Pre-G3, the client->shell loop only checked `channel.active`; the shared
+        is_closed() now also breaks on `channel.closed` (channel closed while the
+        underlying transport is still alive). Pins the OR short-circuit of
+        ParamikoChannelAdapter.is_closed() in the client->shell direction.
+        """
+        self.mock_channel.recv.return_value = b"a"
+        self.mock_channel.closed = True
+        self.mock_channel.active = True
+        client_to_shell_tap(
+            transport=self.adapter,
+            shell_stdin=self.mock_shell_stdin,
+            shell_replied_event=self.mock_shell_replied_event,
+            run_srv=self.mock_run_srv,
+        )
+        # Breaks at is_closed() before echoing or buffering the byte
+        self.mock_channel.sendall.assert_not_called()
+        self.mock_shell_stdin.write.assert_not_called()
+        self.mock_run_srv.clear.assert_called_once()
+
     def test_client_to_shell_tap_break_loop_if_os_error(self):
         """Check that client_to_shell_tap breaks the loop if an OSError occurs."""
         self.mock_channel.sendall.side_effect = OSError

--- a/tests/plugins/test_ssh_server_paramiko.py
+++ b/tests/plugins/test_ssh_server_paramiko.py
@@ -274,6 +274,43 @@ class TapIOTest(unittest.TestCase):
         self.assertEqual(tap_io.drain(), [])
 
 
+class ParamikoChannelAdapterTest(unittest.TestCase):
+    """Direct pins for ParamikoChannelAdapter (mirrors TelnetSocketAdapterTest).
+
+    recv_byte's b"" -> None EOF normalization (D3) and the is_closed()
+    closed-or-inactive truth table (U2) are pinned at the adapter level so a
+    regression cannot hide behind the loop tests' implicit coverage.
+    """
+
+    def setUp(self):
+        self.mock_channel: Mock = Mock()
+        self.adapter = ParamikoChannelAdapter(self.mock_channel)
+
+    def test_recv_byte_normalizes_empty_to_none(self):
+        """D3: b"" (paramiko EOF) is normalized to None."""
+        self.mock_channel.recv.return_value = b""
+        self.assertIsNone(self.adapter.recv_byte())
+
+    def test_recv_byte_passes_data_through(self):
+        """Regular bytes pass through unchanged."""
+        self.mock_channel.recv.return_value = b"x"
+        self.assertEqual(self.adapter.recv_byte(), b"x")
+
+    def test_is_closed_truth_table(self):
+        """U2: is_closed() == closed or not active (OR short-circuit)."""
+        cases = [
+            (False, True, False),
+            (True, True, True),
+            (False, False, True),
+            (True, False, True),
+        ]
+        for closed, active, expected in cases:
+            with self.subTest(closed=closed, active=active):
+                self.mock_channel.closed = closed
+                self.mock_channel.active = active
+                self.assertEqual(self.adapter.is_closed(), expected)
+
+
 class ChannelToShellTapTest(unittest.TestCase):
     """
     Test cases for client_to_shell_tap driven through a ParamikoChannelAdapter.

--- a/tests/plugins/test_ssh_server_paramiko.py
+++ b/tests/plugins/test_ssh_server_paramiko.py
@@ -18,11 +18,11 @@ import paramiko
 from simnos.core.timeouts import SHUTDOWN_IO_TIMEOUT
 from simnos.plugins.servers.ssh_server_paramiko import (
     _BUNDLED_MODULI,
+    ParamikoChannelAdapter,
     ParamikoSshServer,
     ParamikoSshServerInterface,
-    channel_to_shell_tap,
-    shell_to_channel_tap,
 )
+from simnos.plugins.servers.tap_bridge import client_to_shell_tap, shell_to_client_tap
 from simnos.plugins.servers.tap_io import TapIO
 
 
@@ -276,45 +276,49 @@ class TapIOTest(unittest.TestCase):
 
 class ChannelToShellTapTest(unittest.TestCase):
     """
-    Test cases for the channel_to_shell_tap function.
+    Test cases for client_to_shell_tap driven through a ParamikoChannelAdapter.
     """
 
     def setUp(self):
-        """Set up the mock channel object."""
+        """Set up the mock channel object wrapped in a ParamikoChannelAdapter."""
         self.mock_channel: Mock = Mock()
         self.mock_channel.recv.return_value = b"b"
+        # is_closed() reads both flags; default to a live channel.
+        self.mock_channel.closed = False
+        self.mock_channel.active = True
+        self.adapter = ParamikoChannelAdapter(self.mock_channel)
         self.mock_shell_stdin: Mock = Mock()
         self.mock_shell_replied_event: Mock = Mock()
         self.mock_run_srv: Mock = Mock()
 
-    def test_channel_to_shell_tap_received_byte(self):
-        """Check that channel_to_shell_tap receives a byte via channel.recv."""
+    def test_client_to_shell_tap_received_byte(self):
+        """Check that client_to_shell_tap receives a byte via channel.recv."""
         self.mock_run_srv.is_set.side_effect = [True] * 10 + [False]
-        channel_to_shell_tap(
-            channel=self.mock_channel,
+        client_to_shell_tap(
+            transport=self.adapter,
             shell_stdin=self.mock_shell_stdin,
             shell_replied_event=self.mock_shell_replied_event,
             run_srv=self.mock_run_srv,
         )
         self.mock_channel.recv.assert_called_with(1)
 
-    def test_channel_to_shell_tap_shell_replied_event_wait(self):
-        """Check that channel_to_shell_tap waits for the shell_replied_event."""
+    def test_client_to_shell_tap_shell_replied_event_wait(self):
+        """Check that client_to_shell_tap waits for the shell_replied_event."""
         self.mock_run_srv.is_set.side_effect = [True] * 10 + [False]
-        channel_to_shell_tap(
-            channel=self.mock_channel,
+        client_to_shell_tap(
+            transport=self.adapter,
             shell_stdin=self.mock_shell_stdin,
             shell_replied_event=self.mock_shell_replied_event,
             run_srv=self.mock_run_srv,
         )
         self.mock_shell_replied_event.wait.assert_called_with(timeout=SHUTDOWN_IO_TIMEOUT)
 
-    def test_channel_to_shell_tap_break_loop_when_channel_not_active(self):
-        """Check that channel_to_shell_tap breaks the loop when the channel is not active."""
+    def test_client_to_shell_tap_break_loop_when_channel_not_active(self):
+        """Check that client_to_shell_tap breaks the loop when the channel is not active."""
         self.mock_channel.recv.return_value = b"a"
         self.mock_channel.active = False
-        channel_to_shell_tap(
-            channel=self.mock_channel,
+        client_to_shell_tap(
+            transport=self.adapter,
             shell_stdin=self.mock_shell_stdin,
             shell_replied_event=self.mock_shell_replied_event,
             run_srv=self.mock_run_srv,
@@ -323,11 +327,11 @@ class ChannelToShellTapTest(unittest.TestCase):
         self.assertEqual(self.mock_run_srv.is_set.call_count, 2)
         self.mock_run_srv.clear.assert_called_once()
 
-    def test_channel_to_shell_tap_break_loop_if_os_error(self):
-        """Check that channel_to_shell_tap breaks the loop if an OSError occurs."""
+    def test_client_to_shell_tap_break_loop_if_os_error(self):
+        """Check that client_to_shell_tap breaks the loop if an OSError occurs."""
         self.mock_channel.sendall.side_effect = OSError
-        channel_to_shell_tap(
-            channel=self.mock_channel,
+        client_to_shell_tap(
+            transport=self.adapter,
             shell_stdin=self.mock_shell_stdin,
             shell_replied_event=self.mock_shell_replied_event,
             run_srv=self.mock_run_srv,
@@ -335,11 +339,11 @@ class ChannelToShellTapTest(unittest.TestCase):
         # 2 calls: while loop condition + run_srv guard after interruptible wait
         self.assertEqual(self.mock_run_srv.is_set.call_count, 2)
 
-    def test_channel_to_shell_tap_break_loop_if_eof_error(self):
-        """Check that channel_to_shell_tap breaks the loop if an EOFError occurs."""
+    def test_client_to_shell_tap_break_loop_if_eof_error(self):
+        """Check that client_to_shell_tap breaks the loop if an EOFError occurs."""
         self.mock_channel.sendall.side_effect = EOFError
-        channel_to_shell_tap(
-            channel=self.mock_channel,
+        client_to_shell_tap(
+            transport=self.adapter,
             shell_stdin=self.mock_shell_stdin,
             shell_replied_event=self.mock_shell_replied_event,
             run_srv=self.mock_run_srv,
@@ -347,11 +351,11 @@ class ChannelToShellTapTest(unittest.TestCase):
         # 2 calls: while loop condition + run_srv guard after interruptible wait
         self.assertEqual(self.mock_run_srv.is_set.call_count, 2)
 
-    def test_channel_to_shell_tap_break_loop_if_ssh_exception(self):
+    def test_client_to_shell_tap_break_loop_if_ssh_exception(self):
         """SSHException on sendall should break the loop (#85)."""
         self.mock_channel.sendall.side_effect = paramiko.SSHException("Transport closed")
-        channel_to_shell_tap(
-            channel=self.mock_channel,
+        client_to_shell_tap(
+            transport=self.adapter,
             shell_stdin=self.mock_shell_stdin,
             shell_replied_event=self.mock_shell_replied_event,
             run_srv=self.mock_run_srv,
@@ -359,12 +363,12 @@ class ChannelToShellTapTest(unittest.TestCase):
         # 2 calls: while loop condition + run_srv guard after interruptible wait
         self.assertEqual(self.mock_run_srv.is_set.call_count, 2)
 
-    def test_channel_to_shell_tap_recv_ssh_exception_breaks(self):
+    def test_client_to_shell_tap_recv_ssh_exception_breaks(self):
         """SSHException on recv should break the tap loop (#85)."""
         self.mock_channel.recv.side_effect = paramiko.SSHException("Transport closed")
         self.mock_run_srv.is_set.return_value = True
-        channel_to_shell_tap(
-            channel=self.mock_channel,
+        client_to_shell_tap(
+            transport=self.adapter,
             shell_stdin=self.mock_shell_stdin,
             shell_replied_event=self.mock_shell_replied_event,
             run_srv=self.mock_run_srv,
@@ -372,12 +376,12 @@ class ChannelToShellTapTest(unittest.TestCase):
         self.mock_channel.recv.assert_called_once_with(1)
         self.mock_run_srv.clear.assert_called_once()
 
-    def test_channel_to_shell_tap_byte_return_character(self):
+    def test_client_to_shell_tap_byte_return_character(self):
         """CRLF should be treated as a single line terminator (skip_lf consumes LF)."""
         self.mock_run_srv.is_set.side_effect = [True] * 4 + [False]
         self.mock_channel.recv.side_effect = [b"\r", b"\n", b""]
-        channel_to_shell_tap(
-            channel=self.mock_channel,
+        client_to_shell_tap(
+            transport=self.adapter,
             shell_stdin=self.mock_shell_stdin,
             shell_replied_event=self.mock_shell_replied_event,
             run_srv=self.mock_run_srv,
@@ -388,12 +392,12 @@ class ChannelToShellTapTest(unittest.TestCase):
 
         self.assertEqual(self.mock_shell_replied_event.clear.call_count, 1)
 
-    def test_channel_to_shell_tap_crlf_single_line(self):
+    def test_client_to_shell_tap_crlf_single_line(self):
         """CRLF after data should produce one line, not two."""
         self.mock_run_srv.is_set.side_effect = [True] * 6 + [False]
         self.mock_channel.recv.side_effect = [b"h", b"i", b"\r", b"\n", b""]
-        channel_to_shell_tap(
-            channel=self.mock_channel,
+        client_to_shell_tap(
+            transport=self.adapter,
             shell_stdin=self.mock_shell_stdin,
             shell_replied_event=self.mock_shell_replied_event,
             run_srv=self.mock_run_srv,
@@ -401,24 +405,24 @@ class ChannelToShellTapTest(unittest.TestCase):
         self.mock_shell_stdin.write.assert_called_once_with("hi\r")
         self.assertEqual(self.mock_channel.sendall.call_count, 3)  # h, i, \r\n
 
-    def test_channel_to_shell_tap_cr_nul_lf_keeps_skip_lf(self):
+    def test_client_to_shell_tap_cr_nul_lf_keeps_skip_lf(self):
         """SSH NUL does not reset skip_lf (unlike Telnet CR NUL)."""
         self.mock_run_srv.is_set.side_effect = [True] * 6 + [False]
         self.mock_channel.recv.side_effect = [b"a", b"\r", b"\x00", b"\n", b""]
-        channel_to_shell_tap(
-            channel=self.mock_channel,
+        client_to_shell_tap(
+            transport=self.adapter,
             shell_stdin=self.mock_shell_stdin,
             shell_replied_event=self.mock_shell_replied_event,
             run_srv=self.mock_run_srv,
         )
         self.mock_shell_stdin.write.assert_called_once_with("a\r")
 
-    def test_channel_to_shell_tap_cr_followed_by_data(self):
+    def test_client_to_shell_tap_cr_followed_by_data(self):
         """CR followed by non-LF data should produce two lines."""
         self.mock_run_srv.is_set.side_effect = [True] * 8 + [False]
         self.mock_channel.recv.side_effect = [b"x", b"\r", b"y", b"\n", b""]
-        channel_to_shell_tap(
-            channel=self.mock_channel,
+        client_to_shell_tap(
+            transport=self.adapter,
             shell_stdin=self.mock_shell_stdin,
             shell_replied_event=self.mock_shell_replied_event,
             run_srv=self.mock_run_srv,
@@ -426,12 +430,12 @@ class ChannelToShellTapTest(unittest.TestCase):
         calls = [c[0][0] for c in self.mock_shell_stdin.write.call_args_list]
         self.assertEqual(calls, ["x\r", "y\n"])
 
-    def test_channel_to_shell_tap_initial_skip_lf(self):
+    def test_client_to_shell_tap_initial_skip_lf(self):
         """initial_skip_lf=True should consume a leading LF."""
         self.mock_run_srv.is_set.side_effect = [True] * 5 + [False]
         self.mock_channel.recv.side_effect = [b"\n", b"a", b"\r", b""]
-        channel_to_shell_tap(
-            channel=self.mock_channel,
+        client_to_shell_tap(
+            transport=self.adapter,
             shell_stdin=self.mock_shell_stdin,
             shell_replied_event=self.mock_shell_replied_event,
             run_srv=self.mock_run_srv,
@@ -439,12 +443,12 @@ class ChannelToShellTapTest(unittest.TestCase):
         )
         self.mock_shell_stdin.write.assert_called_once_with("a\r")
 
-    def test_channel_to_shell_tap_nul_bytes_are_dropped(self):
+    def test_client_to_shell_tap_nul_bytes_are_dropped(self):
         """NUL bytes should be silently dropped (not echoed, not buffered)."""
         self.mock_run_srv.is_set.side_effect = [True] * 5 + [False]
         self.mock_channel.recv.side_effect = [b"\x00", b"a", b"\n"]
-        channel_to_shell_tap(
-            channel=self.mock_channel,
+        client_to_shell_tap(
+            transport=self.adapter,
             shell_stdin=self.mock_shell_stdin,
             shell_replied_event=self.mock_shell_replied_event,
             run_srv=self.mock_run_srv,
@@ -456,12 +460,12 @@ class ChannelToShellTapTest(unittest.TestCase):
         self.assertEqual(self.mock_channel.sendall.call_count, 2)
         self.mock_shell_stdin.write.assert_called_with("a\n")
 
-    def test_channel_to_shell_tap_empty_byte_causes_exit(self):
+    def test_client_to_shell_tap_empty_byte_causes_exit(self):
         """Empty byte (EOF) should cause the loop to exit."""
         self.mock_run_srv.is_set.side_effect = [True, True]
         self.mock_channel.recv.side_effect = [b"", b"\n"]
-        channel_to_shell_tap(
-            channel=self.mock_channel,
+        client_to_shell_tap(
+            transport=self.adapter,
             shell_stdin=self.mock_shell_stdin,
             shell_replied_event=self.mock_shell_replied_event,
             run_srv=self.mock_run_srv,
@@ -469,12 +473,12 @@ class ChannelToShellTapTest(unittest.TestCase):
         # Empty byte triggers break before any write
         self.mock_channel.sendall.assert_not_called()
 
-    def test_channel_to_shell_tap_byte_return_other(self):
-        """Check that channel_to_shell_tap echoes bytes via channel.sendall."""
+    def test_client_to_shell_tap_byte_return_other(self):
+        """Check that client_to_shell_tap echoes bytes via channel.sendall."""
         self.mock_run_srv.is_set.side_effect = [True] * 6 + [False]
         self.mock_channel.recv.side_effect = [b"b", b"c", b"\n"]
-        channel_to_shell_tap(
-            channel=self.mock_channel,
+        client_to_shell_tap(
+            transport=self.adapter,
             shell_stdin=self.mock_shell_stdin,
             shell_replied_event=self.mock_shell_replied_event,
             run_srv=self.mock_run_srv,
@@ -485,12 +489,12 @@ class ChannelToShellTapTest(unittest.TestCase):
 
         self.assertEqual(self.mock_shell_stdin.write.call_count, 1)
 
-    def test_channel_to_shell_tap_exit_run_srv(self):
-        """Check that channel_to_shell_tap exits the run_srv."""
+    def test_client_to_shell_tap_exit_run_srv(self):
+        """Check that client_to_shell_tap exits the run_srv."""
         self.mock_run_srv.is_set.side_effect = [True, False]
         self.mock_channel.recv.side_effect = [b"\x00"]
-        channel_to_shell_tap(
-            channel=self.mock_channel,
+        client_to_shell_tap(
+            transport=self.adapter,
             shell_stdin=self.mock_shell_stdin,
             shell_replied_event=self.mock_shell_replied_event,
             run_srv=self.mock_run_srv,
@@ -498,12 +502,12 @@ class ChannelToShellTapTest(unittest.TestCase):
         self.assertEqual(self.mock_run_srv.is_set.call_count, 2)
         self.assertEqual(self.mock_channel.recv.call_count, 1)
 
-    def test_channel_to_shell_tap_timeout_error_continues_loop(self):
+    def test_client_to_shell_tap_timeout_error_continues_loop(self):
         """TimeoutError on recv() should be caught and the loop should continue."""
         self.mock_run_srv.is_set.side_effect = [True] * 4 + [False]
         self.mock_channel.recv.side_effect = [TimeoutError, b"a", b"\x00"]
-        channel_to_shell_tap(
-            channel=self.mock_channel,
+        client_to_shell_tap(
+            transport=self.adapter,
             shell_stdin=self.mock_shell_stdin,
             shell_replied_event=self.mock_shell_replied_event,
             run_srv=self.mock_run_srv,
@@ -513,13 +517,13 @@ class ChannelToShellTapTest(unittest.TestCase):
         # b"a" should be echoed back
         self.mock_channel.sendall.assert_any_call(b"a")
 
-    def test_channel_to_shell_tap_shell_stdout_receives_echo(self):
+    def test_client_to_shell_tap_shell_stdout_receives_echo(self):
         """When shell_stdout is provided, newline echo goes to shell_stdout, not channel (#96)."""
         self.mock_run_srv.is_set.side_effect = [True] * 4 + [False]
         self.mock_channel.recv.side_effect = [b"\r", b"\n", b""]
         mock_shell_stdout: Mock = Mock()
-        channel_to_shell_tap(
-            channel=self.mock_channel,
+        client_to_shell_tap(
+            transport=self.adapter,
             shell_stdin=self.mock_shell_stdin,
             shell_replied_event=self.mock_shell_replied_event,
             run_srv=self.mock_run_srv,
@@ -528,13 +532,13 @@ class ChannelToShellTapTest(unittest.TestCase):
         mock_shell_stdout.write.assert_called_once_with("\r\n")
         self.mock_channel.sendall.assert_not_called()
 
-    def test_channel_to_shell_tap_shell_stdout_data_then_newline(self):
+    def test_client_to_shell_tap_shell_stdout_data_then_newline(self):
         """With shell_stdout, regular bytes echo to channel; only newline goes to shell_stdout (#96)."""
         self.mock_run_srv.is_set.side_effect = [True] * 6 + [False]
         self.mock_channel.recv.side_effect = [b"a", b"\r", b"\n", b""]
         mock_shell_stdout: Mock = Mock()
-        channel_to_shell_tap(
-            channel=self.mock_channel,
+        client_to_shell_tap(
+            transport=self.adapter,
             shell_stdin=self.mock_shell_stdin,
             shell_replied_event=self.mock_shell_replied_event,
             run_srv=self.mock_run_srv,
@@ -543,19 +547,19 @@ class ChannelToShellTapTest(unittest.TestCase):
         self.mock_channel.sendall.assert_called_once_with(b"a")
         mock_shell_stdout.write.assert_called_once_with("\r\n")
 
-    def test_channel_to_shell_tap_no_shell_stdout_echo_to_channel(self):
+    def test_client_to_shell_tap_no_shell_stdout_echo_to_channel(self):
         """When shell_stdout is None (default), newline echo goes to channel.sendall (#96)."""
         self.mock_run_srv.is_set.side_effect = [True] * 4 + [False]
         self.mock_channel.recv.side_effect = [b"\r", b"\n", b""]
-        channel_to_shell_tap(
-            channel=self.mock_channel,
+        client_to_shell_tap(
+            transport=self.adapter,
             shell_stdin=self.mock_shell_stdin,
             shell_replied_event=self.mock_shell_replied_event,
             run_srv=self.mock_run_srv,
         )
         self.mock_channel.sendall.assert_called_once_with(b"\r\n")
 
-    def test_channel_to_shell_tap_shell_stdout_event_clear_order(self):
+    def test_client_to_shell_tap_shell_stdout_event_clear_order(self):
         """shell_replied_event.clear() is called after shell_stdin.write, with shell_stdout (#96)."""
         self.mock_run_srv.is_set.side_effect = [True] * 4 + [False]
         self.mock_channel.recv.side_effect = [b"\r", b"\n", b""]
@@ -564,8 +568,8 @@ class ChannelToShellTapTest(unittest.TestCase):
         self.mock_shell_stdin.write.side_effect = lambda x: call_order.append("shell_stdin.write")
         mock_shell_stdout.write.side_effect = lambda x: call_order.append("shell_stdout.write")
         self.mock_shell_replied_event.clear.side_effect = lambda: call_order.append("event.clear")
-        channel_to_shell_tap(
-            channel=self.mock_channel,
+        client_to_shell_tap(
+            transport=self.adapter,
             shell_stdin=self.mock_shell_stdin,
             shell_replied_event=self.mock_shell_replied_event,
             run_srv=self.mock_run_srv,
@@ -576,36 +580,39 @@ class ChannelToShellTapTest(unittest.TestCase):
 
 class ShellToChannelTapTest(unittest.TestCase):
     """
-    Test cases for the shell_to_channel_tap function.
+    Test cases for shell_to_client_tap driven through a ParamikoChannelAdapter.
     """
 
     def setUp(self):
-        """Set up the mock channel object."""
+        """Set up the mock channel object wrapped in a ParamikoChannelAdapter."""
         self.mock_channel: Mock = Mock()
+        # is_closed() reads both flags; default to a live channel.
         self.mock_channel.closed = False
+        self.mock_channel.active = True
+        self.adapter = ParamikoChannelAdapter(self.mock_channel)
         self.mock_shell_stdout: Mock = Mock()
         self.mock_shell_stdout.drain.return_value = []
         self.mock_shell_replied_event: Mock = Mock()
         self.mock_run_srv: Mock = Mock()
 
-    def test_shell_to_channel_tap_channel_closed(self):
-        """Check that shell_to_channel_tap exits when channel.closed is True."""
+    def test_shell_to_client_tap_channel_closed(self):
+        """Check that shell_to_client_tap exits when channel.closed is True."""
         self.mock_channel.closed = True
-        shell_to_channel_tap(
-            channel=self.mock_channel,
+        shell_to_client_tap(
+            transport=self.adapter,
             shell_stdout=self.mock_shell_stdout,
             shell_replied_event=self.mock_shell_replied_event,
             run_srv=self.mock_run_srv,
         )
         self.mock_run_srv.is_set.assert_called_once()
 
-    def test_shell_to_channel_tap_shell_stdout_readline_return_none(self):
+    def test_shell_to_client_tap_shell_stdout_readline_return_none(self):
         """
-        Check that shell_to_channel_tap exits when readline returns None.
+        Check that shell_to_client_tap exits when readline returns None.
         """
         self.mock_shell_stdout.readline.return_value = None
-        shell_to_channel_tap(
-            channel=self.mock_channel,
+        shell_to_client_tap(
+            transport=self.adapter,
             shell_stdout=self.mock_shell_stdout,
             shell_replied_event=self.mock_shell_replied_event,
             run_srv=self.mock_run_srv,
@@ -613,7 +620,7 @@ class ShellToChannelTapTest(unittest.TestCase):
         self.mock_shell_stdout.readline.assert_called_once()
         self.mock_run_srv.is_set.assert_called_once()
 
-    def test_shell_to_channel_tap_shell_stdout_readline_return_carry_return(self):
+    def test_shell_to_client_tap_shell_stdout_readline_return_carry_return(self):
         """
         Check that echo-only readline triggers a second readline for the prompt.
 
@@ -623,36 +630,36 @@ class ShellToChannelTapTest(unittest.TestCase):
         """
         self.mock_run_srv.is_set.side_effect = [True] * 10 + [False]
         self.mock_shell_stdout.readline.side_effect = ["\r\n", "Router>", ""]
-        shell_to_channel_tap(
-            channel=self.mock_channel,
+        shell_to_client_tap(
+            transport=self.adapter,
             shell_stdout=self.mock_shell_stdout,
             shell_replied_event=self.mock_shell_replied_event,
             run_srv=self.mock_run_srv,
         )
         self.mock_channel.sendall.assert_called_once_with(b"\r\nRouter>")
 
-    def test_shell_to_channel_tap_shell_stdout_readline_return_newline(self):
+    def test_shell_to_client_tap_shell_stdout_readline_return_newline(self):
         """
         Check that LF echo triggers a second readline and LF is converted to CRLF.
         """
         self.mock_run_srv.is_set.side_effect = [True] * 10 + [False]
         self.mock_shell_stdout.readline.side_effect = ["\n", "Router>", ""]
-        shell_to_channel_tap(
-            channel=self.mock_channel,
+        shell_to_client_tap(
+            transport=self.adapter,
             shell_stdout=self.mock_shell_stdout,
             shell_replied_event=self.mock_shell_replied_event,
             run_srv=self.mock_run_srv,
         )
         self.mock_channel.sendall.assert_called_once_with(b"\r\nRouter>")
 
-    def test_shell_to_channel_tap_shell_stdout_readline_return_other(self):
+    def test_shell_to_client_tap_shell_stdout_readline_return_other(self):
         """
-        Check that shell_to_channel_tap sends data via channel.sendall.
+        Check that shell_to_client_tap sends data via channel.sendall.
         """
         self.mock_run_srv.is_set.side_effect = [True, True, True, False]
         self.mock_shell_stdout.readline.return_value = "b"
-        shell_to_channel_tap(
-            channel=self.mock_channel,
+        shell_to_client_tap(
+            transport=self.adapter,
             shell_stdout=self.mock_shell_stdout,
             shell_replied_event=self.mock_shell_replied_event,
             run_srv=self.mock_run_srv,
@@ -660,12 +667,12 @@ class ShellToChannelTapTest(unittest.TestCase):
         self.mock_shell_stdout.readline.assert_called_once()
         self.mock_channel.sendall.assert_called_once_with(b"b")
 
-    def test_shell_to_channel_tap_socket_error(self):
-        """Check that shell_to_channel_tap breaks the loop if a socket error occurs."""
+    def test_shell_to_client_tap_socket_error(self):
+        """Check that shell_to_client_tap breaks the loop if a socket error occurs."""
         self.mock_shell_stdout.readline.return_value = "b"
         self.mock_channel.sendall.side_effect = OSError(104, "Connection reset by peer")
-        shell_to_channel_tap(
-            channel=self.mock_channel,
+        shell_to_client_tap(
+            transport=self.adapter,
             shell_stdout=self.mock_shell_stdout,
             shell_replied_event=self.mock_shell_replied_event,
             run_srv=self.mock_run_srv,
@@ -673,12 +680,12 @@ class ShellToChannelTapTest(unittest.TestCase):
         # Called twice: outer loop check + inner retry loop check
         self.assertEqual(self.mock_run_srv.is_set.call_count, 2)
 
-    def test_shell_to_channel_tap_ssh_exception(self):
-        """Check that shell_to_channel_tap breaks the loop if SSHException occurs (#85)."""
+    def test_shell_to_client_tap_ssh_exception(self):
+        """Check that shell_to_client_tap breaks the loop if SSHException occurs (#85)."""
         self.mock_shell_stdout.readline.return_value = "b"
         self.mock_channel.sendall.side_effect = paramiko.SSHException("Transport closed")
-        shell_to_channel_tap(
-            channel=self.mock_channel,
+        shell_to_client_tap(
+            transport=self.adapter,
             shell_stdout=self.mock_shell_stdout,
             shell_replied_event=self.mock_shell_replied_event,
             run_srv=self.mock_run_srv,
@@ -686,24 +693,24 @@ class ShellToChannelTapTest(unittest.TestCase):
         # Called twice: outer loop check + inner retry loop check
         self.assertEqual(self.mock_run_srv.is_set.call_count, 2)
 
-    def test_shell_to_channel_tap_set_replied_flag(self):
-        """Check that shell_to_channel_tap sets the replied flag."""
+    def test_shell_to_client_tap_set_replied_flag(self):
+        """Check that shell_to_client_tap sets the replied flag."""
         self.mock_run_srv.is_set.side_effect = [True, True, True, False]
         self.mock_shell_stdout.readline.return_value = "b"
-        shell_to_channel_tap(
-            channel=self.mock_channel,
+        shell_to_client_tap(
+            transport=self.adapter,
             shell_stdout=self.mock_shell_stdout,
             shell_replied_event=self.mock_shell_replied_event,
             run_srv=self.mock_run_srv,
         )
         self.mock_shell_replied_event.set.assert_called_once()
 
-    def test_shell_to_channel_tap_exit_run_srv(self):
-        """Check that shell_to_channel_tap exits the run_srv."""
+    def test_shell_to_client_tap_exit_run_srv(self):
+        """Check that shell_to_client_tap exits the run_srv."""
         self.mock_run_srv.is_set.side_effect = [True, True, True, False]
         self.mock_shell_stdout.readline.return_value = "b"
-        shell_to_channel_tap(
-            channel=self.mock_channel,
+        shell_to_client_tap(
+            transport=self.adapter,
             shell_stdout=self.mock_shell_stdout,
             shell_replied_event=self.mock_shell_replied_event,
             run_srv=self.mock_run_srv,
@@ -993,14 +1000,14 @@ class ParamikoSshServerTest(unittest.TestCase):
         paramiko_server.watchdog(mock_is_running, mock_run_srv, mock_session, mock_shell)
         mock_shell.stop.assert_called_once()
 
-    @mock.patch("simnos.plugins.servers.ssh_server_paramiko.channel_to_shell_tap")
-    @mock.patch("simnos.plugins.servers.ssh_server_paramiko.shell_to_channel_tap")
+    @mock.patch("simnos.plugins.servers.ssh_server_paramiko.client_to_shell_tap")
+    @mock.patch("simnos.plugins.servers.ssh_server_paramiko.shell_to_client_tap")
     @mock.patch("paramiko.Transport")
     def test_connection_function(
         self,
         mock_transport: MagicMock,
-        mock_shell_to_channel_tap: MagicMock,
-        mock_channel_to_shell_tap: MagicMock,
+        mock_shell_to_client_tap: MagicMock,
+        mock_client_to_shell_tap: MagicMock,
     ):
         """Check that the connection function is executed correctly."""
         mock_client: MagicMock = MagicMock()
@@ -1009,8 +1016,8 @@ class ParamikoSshServerTest(unittest.TestCase):
         paramiko_server.connection_function(mock_client, mock_is_running)
 
         mock_transport.assert_called_once()
-        mock_shell_to_channel_tap.assert_called_once()
-        mock_channel_to_shell_tap.assert_called_once()
+        mock_shell_to_client_tap.assert_called_once()
+        mock_client_to_shell_tap.assert_called_once()
 
     @mock.patch("paramiko.Transport")
     def test_connection_function_accept_returns_none(self, mock_transport_cls: MagicMock):
@@ -1743,32 +1750,36 @@ class TeardownFixTests(unittest.TestCase):
         server.watchdog(mock_is_running, mock_run_srv, mock_session, mock_shell)
         mock_shell.stop.assert_called_once()
 
-    # -- channel_to_shell_tap tests -------------------------------------------
+    # -- client_to_shell_tap tests -------------------------------------------
 
-    def test_channel_to_shell_tap_oserror_breaks(self):
+    def test_client_to_shell_tap_oserror_breaks(self):
         """OSError on recv should break the tap loop."""
         mock_channel = Mock()
         mock_channel.recv.side_effect = OSError("channel closed")
         mock_shell_stdin = Mock()
         mock_shell_replied_event = Mock()
         mock_run_srv = Mock()
-        channel_to_shell_tap(mock_channel, mock_shell_stdin, mock_shell_replied_event, mock_run_srv)
+        client_to_shell_tap(
+            ParamikoChannelAdapter(mock_channel), mock_shell_stdin, mock_shell_replied_event, mock_run_srv
+        )
         mock_run_srv.clear.assert_called_once()
 
-    def test_channel_to_shell_tap_clears_run_srv(self):
-        """channel_to_shell_tap should call run_srv.clear() on exit."""
+    def test_client_to_shell_tap_clears_run_srv(self):
+        """client_to_shell_tap should call run_srv.clear() on exit."""
         mock_channel = Mock()
         mock_channel.recv.return_value = b""  # EOF
         mock_shell_stdin = Mock()
         mock_shell_replied_event = Mock()
         mock_run_srv = Mock()
-        channel_to_shell_tap(mock_channel, mock_shell_stdin, mock_shell_replied_event, mock_run_srv)
+        client_to_shell_tap(
+            ParamikoChannelAdapter(mock_channel), mock_shell_stdin, mock_shell_replied_event, mock_run_srv
+        )
         mock_run_srv.clear.assert_called_once()
 
-    # -- shell_to_channel_tap tests -------------------------------------------
+    # -- shell_to_client_tap tests -------------------------------------------
 
-    def test_shell_to_channel_tap_clears_run_srv(self):
-        """shell_to_channel_tap should call run_srv.clear() on exit."""
+    def test_shell_to_client_tap_clears_run_srv(self):
+        """shell_to_client_tap should call run_srv.clear() on exit."""
         mock_channel = Mock()
         mock_channel.closed = False
         mock_shell_stdout = Mock()
@@ -1776,10 +1787,12 @@ class TeardownFixTests(unittest.TestCase):
         mock_shell_stdout.readline.return_value = None  # EOF
         mock_shell_replied_event = Mock()
         mock_run_srv = Mock()
-        shell_to_channel_tap(mock_channel, mock_shell_stdout, mock_shell_replied_event, mock_run_srv)
+        shell_to_client_tap(
+            ParamikoChannelAdapter(mock_channel), mock_shell_stdout, mock_shell_replied_event, mock_run_srv
+        )
         mock_run_srv.clear.assert_called_once()
 
-    def test_shell_to_channel_tap_breaks_on_non_timeout_oserror(self):
+    def test_shell_to_client_tap_breaks_on_non_timeout_oserror(self):
         """Non-TimeoutError OSError should break and reach run_srv.clear()."""
         mock_channel = Mock()
         mock_channel.closed = False
@@ -1789,10 +1802,12 @@ class TeardownFixTests(unittest.TestCase):
         mock_channel.sendall.side_effect = OSError(32, "Broken pipe")
         mock_shell_replied_event = Mock()
         mock_run_srv = Mock()
-        shell_to_channel_tap(mock_channel, mock_shell_stdout, mock_shell_replied_event, mock_run_srv)
+        shell_to_client_tap(
+            ParamikoChannelAdapter(mock_channel), mock_shell_stdout, mock_shell_replied_event, mock_run_srv
+        )
         mock_run_srv.clear.assert_called_once()
 
-    def test_shell_to_channel_tap_retries_on_timeout(self):
+    def test_shell_to_client_tap_retries_on_timeout(self):
         """Write-side TimeoutError should retry same line without loss."""
         mock_channel = Mock()
         mock_channel.closed = False
@@ -1803,7 +1818,9 @@ class TeardownFixTests(unittest.TestCase):
         mock_channel.sendall.side_effect = [TimeoutError(), None]
         mock_shell_replied_event = Mock()
         mock_run_srv = Mock()
-        shell_to_channel_tap(mock_channel, mock_shell_stdout, mock_shell_replied_event, mock_run_srv)
+        shell_to_client_tap(
+            ParamikoChannelAdapter(mock_channel), mock_shell_stdout, mock_shell_replied_event, mock_run_srv
+        )
         # sendall should have been called twice with the same data
         assert mock_channel.sendall.call_count == 2
         mock_channel.sendall.assert_any_call(b"hello\r\n")
@@ -1811,14 +1828,14 @@ class TeardownFixTests(unittest.TestCase):
 
     # -- connection_function tests --------------------------------------------
 
-    @mock.patch("simnos.plugins.servers.ssh_server_paramiko.channel_to_shell_tap")
-    @mock.patch("simnos.plugins.servers.ssh_server_paramiko.shell_to_channel_tap")
+    @mock.patch("simnos.plugins.servers.ssh_server_paramiko.client_to_shell_tap")
+    @mock.patch("simnos.plugins.servers.ssh_server_paramiko.shell_to_client_tap")
     @mock.patch("paramiko.Transport")
     def test_channel_settimeout_is_called(
         self,
         mock_transport_cls: MagicMock,
-        mock_shell_to_channel_tap: MagicMock,
-        mock_channel_to_shell_tap: MagicMock,
+        mock_shell_to_client_tap: MagicMock,
+        mock_client_to_shell_tap: MagicMock,
     ):
         """connection_function should call channel.settimeout(self.timeout)."""
         mock_session = MagicMock()
@@ -1888,14 +1905,14 @@ class TeardownFixTests(unittest.TestCase):
         assert mock_session.banner_timeout == SHUTDOWN_IO_TIMEOUT
         assert mock_session.handshake_timeout == SHUTDOWN_IO_TIMEOUT
 
-    @mock.patch("simnos.plugins.servers.ssh_server_paramiko.channel_to_shell_tap")
-    @mock.patch("simnos.plugins.servers.ssh_server_paramiko.shell_to_channel_tap")
+    @mock.patch("simnos.plugins.servers.ssh_server_paramiko.client_to_shell_tap")
+    @mock.patch("simnos.plugins.servers.ssh_server_paramiko.shell_to_client_tap")
     @mock.patch("paramiko.Transport")
     def test_tapper_threads_are_daemon(
         self,
         mock_transport_cls: MagicMock,
-        mock_shell_to_channel_tap: MagicMock,
-        mock_channel_to_shell_tap: MagicMock,
+        mock_shell_to_client_tap: MagicMock,
+        mock_client_to_shell_tap: MagicMock,
     ):
         """Tapper and watchdog threads should be created with daemon=True."""
         mock_session = MagicMock()
@@ -1915,7 +1932,7 @@ class TeardownFixTests(unittest.TestCase):
         with mock.patch("simnos.plugins.servers.ssh_server_paramiko.threading.Thread", side_effect=capture_thread):
             server.connection_function(MagicMock(), Mock())
 
-        # 3 threads: channel_to_shell_tapper, shell_to_channel_tapper, watchdog
+        # 3 threads: client_to_shell_tapper, shell_to_client_tapper, watchdog
         assert len(threads_created) == 3
         for t in threads_created:
             assert t.daemon, f"Thread {t.name} should be daemon"

--- a/tests/plugins/test_tap_bridge.py
+++ b/tests/plugins/test_tap_bridge.py
@@ -1,0 +1,206 @@
+"""
+Test cases for the transport-agnostic tap functions in tap_bridge (G3 / #225).
+
+Uses an in-memory FakeTransport so the shared loop logic is tested without
+any real transport. Transport-specific behaviour (paramiko exceptions, IAC
+handling) stays pinned in test_ssh_server_paramiko.py / test_telnet_server.py.
+
+Pinned contracts:
+- D11: each send attempt is gated on a preceding run_srv.is_set() check
+  (SSH retry-loop form adopted for both transports).
+- U1: a batch-send TimeoutError is retried, not treated as a disconnect.
+- U2: is_closed() True breaks both loops early.
+- Q1: nul_resets_skip_lf quirk switches the CR NUL behaviour per transport.
+- Exception-policy table: TimeoutError handling differs per operation and
+  must be caught BEFORE transport.io_errors (TimeoutError ⊂ OSError).
+"""
+
+import unittest
+from unittest.mock import Mock
+
+from simnos.plugins.servers.tap_bridge import client_to_shell_tap, shell_to_client_tap
+
+
+class FakeTransport:
+    """In-memory TransportAdapter with per-operation exception injection."""
+
+    io_errors = (OSError,)
+    name = "fake"
+
+    def __init__(self, recv_script=None, *, nul_resets_skip_lf=False):
+        # recv_script: list of bytes / None (EOF) / Exception instances to raise
+        self.recv_script = list(recv_script or [])
+        self.nul_resets_skip_lf = nul_resets_skip_lf
+        self.sent: list[bytes] = []
+        self.send_errors: list[BaseException] = []  # popped per sendall call
+        self.closed = False
+
+    def recv_byte(self):
+        if not self.recv_script:
+            return None  # EOF when script is exhausted
+        item = self.recv_script.pop(0)
+        if isinstance(item, BaseException):
+            raise item
+        return item
+
+    def sendall(self, data: bytes) -> None:
+        if self.send_errors:
+            raise self.send_errors.pop(0)
+        self.sent.append(data)
+
+    def is_closed(self) -> bool:
+        return self.closed
+
+
+def _events(is_set_fuel=None):
+    """Build (shell_replied_event, run_srv) mocks. wait() returns True."""
+    shell_replied_event = Mock()
+    shell_replied_event.wait.return_value = True
+    run_srv = Mock()
+    if is_set_fuel is not None:
+        run_srv.is_set.side_effect = is_set_fuel
+    else:
+        run_srv.is_set.return_value = True
+    return shell_replied_event, run_srv
+
+
+class ClientToShellTapQuirkTest(unittest.TestCase):
+    """Q1: nul_resets_skip_lf switches CR NUL semantics in the shared loop."""
+
+    def test_nul_preserves_skip_lf_when_flag_false(self):
+        """SSH semantics: CR NUL LF — NUL keeps skip_lf, LF is consumed."""
+        transport = FakeTransport([b"a", b"\r", b"\x00", b"\n"], nul_resets_skip_lf=False)
+        shell_stdin = Mock()
+        ev, run_srv = _events()
+        client_to_shell_tap(transport, shell_stdin, ev, run_srv)
+        shell_stdin.write.assert_called_once_with("a\r")
+
+    def test_nul_resets_skip_lf_when_flag_true(self):
+        """Telnet semantics (RFC 854): CR NUL completes the sequence, LF is a new line."""
+        transport = FakeTransport([b"a", b"\r", b"\x00", b"\n"], nul_resets_skip_lf=True)
+        shell_stdin = Mock()
+        ev, run_srv = _events()
+        client_to_shell_tap(transport, shell_stdin, ev, run_srv)
+        self.assertEqual(shell_stdin.write.call_count, 2)
+        shell_stdin.write.assert_any_call("a\r")
+        shell_stdin.write.assert_any_call("\n")
+
+
+class ClientToShellTapPolicyTest(unittest.TestCase):
+    """Exception-policy table pins for the client→shell direction."""
+
+    def test_recv_timeout_continues(self):
+        """recv TimeoutError → continue (line still assembled afterwards)."""
+        transport = FakeTransport([TimeoutError(), b"a", b"\n"])
+        shell_stdin = Mock()
+        ev, run_srv = _events()
+        client_to_shell_tap(transport, shell_stdin, ev, run_srv)
+        shell_stdin.write.assert_called_once_with("a\n")
+
+    def test_recv_io_error_breaks(self):
+        """recv io_errors → break (disconnect)."""
+        transport = FakeTransport([OSError("gone")])
+        shell_stdin = Mock()
+        ev, run_srv = _events()
+        client_to_shell_tap(transport, shell_stdin, ev, run_srv)
+        shell_stdin.write.assert_not_called()
+        run_srv.clear.assert_called_once()
+
+    def test_echo_send_timeout_breaks(self):
+        """Echo-send TimeoutError → break (pre-G3 behaviour kept; NOT retried)."""
+        transport = FakeTransport([b"a", b"b"])
+        transport.send_errors = [TimeoutError()]
+        shell_stdin = Mock()
+        ev, run_srv = _events()
+        client_to_shell_tap(transport, shell_stdin, ev, run_srv)
+        # First echo raised → loop broke → nothing was sent, no line reached the shell
+        self.assertEqual(transport.sent, [])
+        shell_stdin.write.assert_not_called()
+        run_srv.clear.assert_called_once()
+
+    def test_echo_send_io_error_breaks(self):
+        """Echo-send io_errors → break."""
+        transport = FakeTransport([b"a", b"b"])
+        transport.send_errors = [OSError("reset")]
+        shell_stdin = Mock()
+        ev, run_srv = _events()
+        client_to_shell_tap(transport, shell_stdin, ev, run_srv)
+        shell_stdin.write.assert_not_called()
+        run_srv.clear.assert_called_once()
+
+    def test_is_closed_breaks_loop(self):
+        """U2: is_closed() True breaks before processing the byte."""
+        transport = FakeTransport([b"a"])
+        transport.closed = True
+        shell_stdin = Mock()
+        ev, run_srv = _events()
+        client_to_shell_tap(transport, shell_stdin, ev, run_srv)
+        self.assertEqual(transport.sent, [])
+        shell_stdin.write.assert_not_called()
+
+
+class ShellToClientTapPolicyTest(unittest.TestCase):
+    """Exception-policy + D11/U1 pins for the shell→client direction."""
+
+    def _stdout(self, lines):
+        shell_stdout = Mock()
+        shell_stdout.readline.side_effect = lines
+        shell_stdout.drain.return_value = []
+        return shell_stdout
+
+    def test_batch_send_timeout_retries(self):
+        """U1: batch-send TimeoutError → retry the same batch (both transports)."""
+        transport = FakeTransport()
+        transport.send_errors = [TimeoutError()]
+        shell_stdout = self._stdout(["hello\r\n", ""])
+        ev, run_srv = _events()
+        shell_to_client_tap(transport, shell_stdout, ev, run_srv)
+        # Retried after the timeout: the batch eventually arrived exactly once
+        self.assertEqual(transport.sent, [b"hello\r\n"])
+        ev.set.assert_called_once()
+
+    def test_batch_send_io_error_breaks(self):
+        """Batch-send io_errors → break (no retry, no replied event)."""
+        transport = FakeTransport()
+        transport.send_errors = [OSError("reset")]
+        shell_stdout = self._stdout(["hello\r\n", ""])
+        ev, run_srv = _events()
+        shell_to_client_tap(transport, shell_stdout, ev, run_srv)
+        self.assertEqual(transport.sent, [])
+        ev.set.assert_not_called()
+        run_srv.clear.assert_called_once()
+
+    def test_d11_no_send_when_cleared_before_attempt(self):
+        """D11: if run_srv is cleared before the send attempt, nothing is sent."""
+        transport = FakeTransport()
+        shell_stdout = self._stdout(["hello\r\n", ""])
+        # outer loop True, retry-loop gate False
+        ev, run_srv = _events([True, False])
+        shell_to_client_tap(transport, shell_stdout, ev, run_srv)
+        self.assertEqual(transport.sent, [])
+        ev.set.assert_not_called()
+
+    def test_d11_no_resend_when_cleared_during_retry(self):
+        """D11: if run_srv is cleared during a TimeoutError retry, no resend happens."""
+        transport = FakeTransport()
+        transport.send_errors = [TimeoutError()]
+        shell_stdout = self._stdout(["hello\r\n", ""])
+        # outer True, retry gate True (send raises), retry re-gate False
+        ev, run_srv = _events([True, True, False])
+        shell_to_client_tap(transport, shell_stdout, ev, run_srv)
+        self.assertEqual(transport.sent, [])
+        ev.set.assert_not_called()
+
+    def test_is_closed_breaks_loop(self):
+        """U2: is_closed() True breaks before reading from the shell."""
+        transport = FakeTransport()
+        transport.closed = True
+        shell_stdout = self._stdout(["hello\r\n", ""])
+        ev, run_srv = _events()
+        shell_to_client_tap(transport, shell_stdout, ev, run_srv)
+        shell_stdout.readline.assert_not_called()
+        self.assertEqual(transport.sent, [])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/plugins/test_tap_bridge.py
+++ b/tests/plugins/test_tap_bridge.py
@@ -200,7 +200,3 @@ class ShellToClientTapPolicyTest(unittest.TestCase):
         shell_to_client_tap(transport, shell_stdout, ev, run_srv)
         shell_stdout.readline.assert_not_called()
         self.assertEqual(transport.sent, [])
-
-
-if __name__ == "__main__":
-    unittest.main()

--- a/tests/plugins/test_telnet_server.py
+++ b/tests/plugins/test_telnet_server.py
@@ -792,6 +792,45 @@ class ShellToSocketTapTest(unittest.TestCase):
         self.sock.sendall.assert_called_once_with(b"Router>\r\nRouter>")
 
 
+class TelnetSocketAdapterTest(unittest.TestCase):
+    """U2 pins for TelnetSocketAdapter.is_closed() (real fileno() == -1 detection).
+
+    The FakeTransport tests in test_tap_bridge.py pin that the shared loops
+    consult is_closed(); these tests pin the Telnet adapter's actual
+    implementation so a regression to `return False` cannot pass unnoticed.
+    """
+
+    def setUp(self):
+        self.server = _make_server()
+
+    def test_is_closed_false_on_live_socket(self):
+        """A live (open) socket reports is_closed() == False."""
+        sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+        try:
+            adapter = TelnetSocketAdapter(sock, self.server)
+            self.assertFalse(adapter.is_closed())
+        finally:
+            sock.close()
+
+    def test_is_closed_true_after_local_close(self):
+        """A locally closed socket (fileno() == -1) reports is_closed() == True."""
+        sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+        sock.close()
+        adapter = TelnetSocketAdapter(sock, self.server)
+        self.assertTrue(adapter.is_closed())
+
+    def test_shell_to_client_tap_stops_on_closed_socket(self):
+        """U2: a locally-closed socket stops the shell->client loop before any read."""
+        sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+        sock.close()
+        adapter = TelnetSocketAdapter(sock, self.server)
+        shell_stdout = MagicMock()
+        run_srv = MagicMock()
+        run_srv.is_set.return_value = True
+        shell_to_client_tap(adapter, shell_stdout, MagicMock(), run_srv)
+        shell_stdout.readline.assert_not_called()
+
+
 class SocketToShellTapShellStdoutTest(unittest.TestCase):
     """Test echo routing via shell_stdout parameter."""
 
@@ -862,7 +901,7 @@ class WatchdogTest(unittest.TestCase):
         self.run_srv = MagicMock()
         self.shell = MagicMock()
 
-    @unittest.mock.patch("simnos.plugins.servers.tap_bridge.time.sleep")
+    @unittest.mock.patch("simnos.plugins.servers.telnet_server.time.sleep")
     def test_run_srv_loop(self, mock_sleep):
         """Watchdog loops while run_srv is set, then stops shell."""
         self.run_srv.is_set.side_effect = [True, True, False]
@@ -871,7 +910,7 @@ class WatchdogTest(unittest.TestCase):
         self.assertEqual(mock_sleep.call_count, 2)
         self.shell.stop.assert_called_once()
 
-    @unittest.mock.patch("simnos.plugins.servers.tap_bridge.time.sleep")
+    @unittest.mock.patch("simnos.plugins.servers.telnet_server.time.sleep")
     def test_breaks_when_is_running_cleared(self, _mock_sleep):
         """Watchdog breaks when is_running is cleared, then stops shell."""
         self.run_srv.is_set.return_value = True
@@ -879,7 +918,7 @@ class WatchdogTest(unittest.TestCase):
         self.server.watchdog(self.is_running, self.run_srv, self.shell)
         self.shell.stop.assert_called_once()
 
-    @unittest.mock.patch("simnos.plugins.servers.tap_bridge.time.sleep")
+    @unittest.mock.patch("simnos.plugins.servers.telnet_server.time.sleep")
     def test_shell_stop_called_on_exit(self, _mock_sleep):
         """shell.stop() is always called on watchdog exit."""
         # Case: run_srv cleared
@@ -887,7 +926,7 @@ class WatchdogTest(unittest.TestCase):
         self.server.watchdog(self.is_running, self.run_srv, self.shell)
         self.assertEqual(self.shell.stop.call_count, 1)
 
-    @unittest.mock.patch("simnos.plugins.servers.tap_bridge.time.sleep")
+    @unittest.mock.patch("simnos.plugins.servers.telnet_server.time.sleep")
     def test_sleep_interval_capped_by_shutdown_timeout(self, mock_sleep):
         """Sleep interval is the minimum of watchdog_interval and SHUTDOWN_IO_TIMEOUT."""
         self.server.watchdog_interval = 10.0  # Larger than SHUTDOWN_IO_TIMEOUT

--- a/tests/plugins/test_telnet_server.py
+++ b/tests/plugins/test_telnet_server.py
@@ -12,6 +12,7 @@ from unittest.mock import MagicMock
 from simnos.core.pydantic_models import ModelSimnosInventory
 from simnos.core.timeouts import SHUTDOWN_IO_TIMEOUT
 from simnos.plugins.servers import servers_plugins
+from simnos.plugins.servers.tap_bridge import client_to_shell_tap, shell_to_client_tap
 from simnos.plugins.servers.telnet_server import (
     DO,
     DONT,
@@ -24,6 +25,7 @@ from simnos.plugins.servers.telnet_server import (
     WILL,
     WONT,
     TelnetServer,
+    TelnetSocketAdapter,
     _is_loopback,
 )
 
@@ -529,114 +531,115 @@ class TelnetIntegrationTest(unittest.TestCase):
 
 
 class SocketToShellTapTest(unittest.TestCase):
-    """Test cases for TelnetServer.socket_to_shell_tap()."""
+    """Test cases for client_to_shell_tap() via TelnetSocketAdapter."""
 
     def setUp(self):
         self.server = _make_server()
         self.sock = MagicMock(spec=socket.socket)
+        self.adapter = TelnetSocketAdapter(self.sock, self.server)
         self.shell_stdin = MagicMock()
         self.shell_replied_event = MagicMock()
         self.shell_replied_event.wait.return_value = True
         self.run_srv = MagicMock()
 
-    @unittest.mock.patch("simnos.plugins.servers.telnet_server.time.sleep")
+    @unittest.mock.patch("simnos.plugins.servers.tap_bridge.time.sleep")
     @unittest.mock.patch.object(TelnetServer, "_recv_byte")
     def test_normal_byte_echoed_to_socket(self, mock_recv, _mock_sleep):
         """A normal byte is echoed to the socket and buffered."""
         mock_recv.side_effect = [b"a", None]  # One byte, then EOF
         self.run_srv.is_set.side_effect = [True, True, True, False]
-        self.server.socket_to_shell_tap(self.sock, self.shell_stdin, self.shell_replied_event, self.run_srv)
+        client_to_shell_tap(self.adapter, self.shell_stdin, self.shell_replied_event, self.run_srv)
         self.sock.sendall.assert_called_with(b"a")
 
-    @unittest.mock.patch("simnos.plugins.servers.telnet_server.time.sleep")
+    @unittest.mock.patch("simnos.plugins.servers.tap_bridge.time.sleep")
     @unittest.mock.patch.object(TelnetServer, "_recv_byte")
     def test_newline_sends_line_to_shell(self, mock_recv, _mock_sleep):
         """Receiving a newline sends the buffered line to the shell and clears replied event."""
         mock_recv.side_effect = [b"h", b"i", b"\r", None]
         self.run_srv.is_set.side_effect = [True] * 7 + [False]
-        self.server.socket_to_shell_tap(self.sock, self.shell_stdin, self.shell_replied_event, self.run_srv)
+        client_to_shell_tap(self.adapter, self.shell_stdin, self.shell_replied_event, self.run_srv)
         self.shell_stdin.write.assert_called_once_with("hi\r")
         self.shell_replied_event.clear.assert_called_once()
         # Newline echo: \r\n sent to socket for the newline character
         self.sock.sendall.assert_any_call(b"\r\n")
 
-    @unittest.mock.patch("simnos.plugins.servers.telnet_server.time.sleep")
+    @unittest.mock.patch("simnos.plugins.servers.tap_bridge.time.sleep")
     @unittest.mock.patch.object(TelnetServer, "_recv_byte")
     def test_crlf_sends_single_line_to_shell(self, mock_recv, _mock_sleep):
         """CRLF input: \\r triggers line send, trailing \\n is consumed (RFC 854)."""
         mock_recv.side_effect = [b"h", b"i", b"\r", b"\n", None]
         self.run_srv.is_set.side_effect = [True] * 10 + [False]
-        self.server.socket_to_shell_tap(self.sock, self.shell_stdin, self.shell_replied_event, self.run_srv)
+        client_to_shell_tap(self.adapter, self.shell_stdin, self.shell_replied_event, self.run_srv)
         self.shell_stdin.write.assert_called_once_with("hi\r")
 
-    @unittest.mock.patch("simnos.plugins.servers.telnet_server.time.sleep")
+    @unittest.mock.patch("simnos.plugins.servers.tap_bridge.time.sleep")
     @unittest.mock.patch.object(TelnetServer, "_recv_byte")
     def test_cr_nul_resets_skip_lf(self, mock_recv, _mock_sleep):
         """CR NUL is a complete sequence (RFC 854); a subsequent LF is a new line."""
         mock_recv.side_effect = [b"a", b"\r", b"\x00", b"\n", None]
         self.run_srv.is_set.side_effect = [True] * 12 + [False]
-        self.server.socket_to_shell_tap(self.sock, self.shell_stdin, self.shell_replied_event, self.run_srv)
+        client_to_shell_tap(self.adapter, self.shell_stdin, self.shell_replied_event, self.run_srv)
         self.assertEqual(self.shell_stdin.write.call_count, 2)
         self.shell_stdin.write.assert_any_call("a\r")
         self.shell_stdin.write.assert_any_call("\n")
 
-    @unittest.mock.patch("simnos.plugins.servers.telnet_server.time.sleep")
+    @unittest.mock.patch("simnos.plugins.servers.tap_bridge.time.sleep")
     @unittest.mock.patch.object(TelnetServer, "_recv_byte")
     def test_cr_followed_by_data_preserves_data(self, mock_recv, _mock_sleep):
         """CR followed by a non-LF byte: line is sent, next byte is not lost."""
         mock_recv.side_effect = [b"x", b"\r", b"y", None]
         self.run_srv.is_set.side_effect = [True] * 10 + [False]
-        self.server.socket_to_shell_tap(self.sock, self.shell_stdin, self.shell_replied_event, self.run_srv)
+        client_to_shell_tap(self.adapter, self.shell_stdin, self.shell_replied_event, self.run_srv)
         self.shell_stdin.write.assert_called_once_with("x\r")
         self.sock.sendall.assert_any_call(b"y")
 
-    @unittest.mock.patch("simnos.plugins.servers.telnet_server.time.sleep")
+    @unittest.mock.patch("simnos.plugins.servers.tap_bridge.time.sleep")
     @unittest.mock.patch.object(TelnetServer, "_recv_byte")
     def test_eof_breaks_loop(self, mock_recv, _mock_sleep):
         """EOF (None) breaks the loop and clears run_srv."""
         mock_recv.return_value = None
         self.run_srv.is_set.return_value = True
-        self.server.socket_to_shell_tap(self.sock, self.shell_stdin, self.shell_replied_event, self.run_srv)
+        client_to_shell_tap(self.adapter, self.shell_stdin, self.shell_replied_event, self.run_srv)
         self.run_srv.clear.assert_called_once()
 
-    @unittest.mock.patch("simnos.plugins.servers.telnet_server.time.sleep")
+    @unittest.mock.patch("simnos.plugins.servers.tap_bridge.time.sleep")
     @unittest.mock.patch.object(TelnetServer, "_recv_byte")
     def test_nul_bytes_dropped(self, mock_recv, _mock_sleep):
         """NUL bytes (0x00) are dropped and not echoed."""
         mock_recv.side_effect = [b"\x00", b"a", None]
         self.run_srv.is_set.side_effect = [True] * 4 + [False]
-        self.server.socket_to_shell_tap(self.sock, self.shell_stdin, self.shell_replied_event, self.run_srv)
+        client_to_shell_tap(self.adapter, self.shell_stdin, self.shell_replied_event, self.run_srv)
         self.sock.sendall.assert_called_once_with(b"a")
 
-    @unittest.mock.patch("simnos.plugins.servers.telnet_server.time.sleep")
+    @unittest.mock.patch("simnos.plugins.servers.tap_bridge.time.sleep")
     @unittest.mock.patch.object(TelnetServer, "_recv_byte")
     def test_oserror_on_recv_breaks_loop(self, mock_recv, _mock_sleep):
         """OSError during recv breaks the loop."""
         mock_recv.side_effect = OSError("Read error")
         self.run_srv.is_set.return_value = True
-        self.server.socket_to_shell_tap(self.sock, self.shell_stdin, self.shell_replied_event, self.run_srv)
+        client_to_shell_tap(self.adapter, self.shell_stdin, self.shell_replied_event, self.run_srv)
         self.run_srv.clear.assert_called_once()
 
-    @unittest.mock.patch("simnos.plugins.servers.telnet_server.time.sleep")
+    @unittest.mock.patch("simnos.plugins.servers.tap_bridge.time.sleep")
     @unittest.mock.patch.object(TelnetServer, "_recv_byte")
     def test_oserror_on_sendall_breaks_loop(self, mock_recv, _mock_sleep):
         """OSError during sendall breaks the loop."""
         mock_recv.side_effect = [b"a", b"b"]
         self.sock.sendall.side_effect = OSError("Write error")
         self.run_srv.is_set.return_value = True
-        self.server.socket_to_shell_tap(self.sock, self.shell_stdin, self.shell_replied_event, self.run_srv)
+        client_to_shell_tap(self.adapter, self.shell_stdin, self.shell_replied_event, self.run_srv)
         self.run_srv.clear.assert_called_once()
 
-    @unittest.mock.patch("simnos.plugins.servers.telnet_server.time.sleep")
+    @unittest.mock.patch("simnos.plugins.servers.tap_bridge.time.sleep")
     @unittest.mock.patch.object(TelnetServer, "_recv_byte")
     def test_run_srv_clear_exits_loop(self, mock_recv, _mock_sleep):
         """If run_srv is cleared externally, the loop exits."""
         mock_recv.return_value = b"a"
         self.run_srv.is_set.return_value = False
-        self.server.socket_to_shell_tap(self.sock, self.shell_stdin, self.shell_replied_event, self.run_srv)
+        client_to_shell_tap(self.adapter, self.shell_stdin, self.shell_replied_event, self.run_srv)
         mock_recv.assert_not_called()
 
-    @unittest.mock.patch("simnos.plugins.servers.telnet_server.time.sleep")
+    @unittest.mock.patch("simnos.plugins.servers.tap_bridge.time.sleep")
     @unittest.mock.patch.object(TelnetServer, "_recv_byte")
     def test_shutdown_during_shell_wait(self, mock_recv, _mock_sleep):
         """If run_srv is cleared while waiting for shell reply, the loop exits."""
@@ -644,37 +647,38 @@ class SocketToShellTapTest(unittest.TestCase):
         # wait() returns False (timeout), then run_srv is checked and found False
         self.shell_replied_event.wait.return_value = False
         self.run_srv.is_set.side_effect = [True, True, False, False]
-        self.server.socket_to_shell_tap(self.sock, self.shell_stdin, self.shell_replied_event, self.run_srv)
+        client_to_shell_tap(self.adapter, self.shell_stdin, self.shell_replied_event, self.run_srv)
         # Should exit without processing the byte 'a' because the inner wait loop breaks
         self.sock.sendall.assert_not_called()
         # Verify the interruptible wait uses SHUTDOWN_IO_TIMEOUT
         self.shell_replied_event.wait.assert_called_with(timeout=SHUTDOWN_IO_TIMEOUT)
 
-    @unittest.mock.patch("simnos.plugins.servers.telnet_server.time.sleep")
+    @unittest.mock.patch("simnos.plugins.servers.tap_bridge.time.sleep")
     @unittest.mock.patch.object(TelnetServer, "_recv_byte")
     def test_timeout_error_continues_loop(self, mock_recv, _mock_sleep):
         """TimeoutError during _recv_byte is caught and loop continues."""
         mock_recv.side_effect = [TimeoutError(), b"a", None]
         self.run_srv.is_set.side_effect = [True] * 4 + [False]
-        self.server.socket_to_shell_tap(self.sock, self.shell_stdin, self.shell_replied_event, self.run_srv)
+        client_to_shell_tap(self.adapter, self.shell_stdin, self.shell_replied_event, self.run_srv)
         self.sock.sendall.assert_called_once_with(b"a")
 
-    @unittest.mock.patch("simnos.plugins.servers.telnet_server.time.sleep")
+    @unittest.mock.patch("simnos.plugins.servers.tap_bridge.time.sleep")
     @unittest.mock.patch.object(TelnetServer, "_recv_byte")
     def test_shell_replied_event_cleared_on_newline(self, mock_recv, _mock_sleep):
         """Receiving a newline clears the shell_replied_event."""
         mock_recv.side_effect = [b"\n", None]
         self.run_srv.is_set.side_effect = [True] * 3 + [False]
-        self.server.socket_to_shell_tap(self.sock, self.shell_stdin, self.shell_replied_event, self.run_srv)
+        client_to_shell_tap(self.adapter, self.shell_stdin, self.shell_replied_event, self.run_srv)
         self.shell_replied_event.clear.assert_called_once()
 
 
 class ShellToSocketTapTest(unittest.TestCase):
-    """Test cases for TelnetServer.shell_to_socket_tap()."""
+    """Test cases for shell_to_client_tap() via TelnetSocketAdapter."""
 
     def setUp(self):
         self.server = _make_server()
         self.sock = MagicMock(spec=socket.socket)
+        self.adapter = TelnetSocketAdapter(self.sock, self.server)
         self.shell_stdout = MagicMock()
         self.shell_stdout.drain.return_value = []
         self.shell_replied_event = MagicMock()
@@ -683,8 +687,13 @@ class ShellToSocketTapTest(unittest.TestCase):
     def test_line_forwarded_to_socket(self):
         """A line from the shell is forwarded to the socket and event is set."""
         self.shell_stdout.readline.side_effect = ["Router>\r\n", ""]
-        self.run_srv.is_set.side_effect = [True, True, False]
-        self.server.shell_to_socket_tap(self.sock, self.shell_stdout, self.shell_replied_event, self.run_srv)
+        self.run_srv.is_set.side_effect = [
+            True,
+            True,
+            True,
+            False,
+        ]  # D11: retry-loop form consumes one extra is_set per send
+        shell_to_client_tap(self.adapter, self.shell_stdout, self.shell_replied_event, self.run_srv)
         self.sock.sendall.assert_called_once_with(b"Router>\r\n")
         self.shell_replied_event.set.assert_called_once()
 
@@ -692,28 +701,38 @@ class ShellToSocketTapTest(unittest.TestCase):
         """Empty line from shell (EOF) breaks the loop and clears run_srv."""
         self.shell_stdout.readline.return_value = ""
         self.run_srv.is_set.return_value = True
-        self.server.shell_to_socket_tap(self.sock, self.shell_stdout, self.shell_replied_event, self.run_srv)
+        shell_to_client_tap(self.adapter, self.shell_stdout, self.shell_replied_event, self.run_srv)
         self.run_srv.clear.assert_called_once()
 
     def test_run_srv_cleared_skips_sendall(self):
         """When run_srv is cleared after readline, sendall is skipped."""
         self.shell_stdout.readline.side_effect = ["Router>\r\n", ""]
         self.run_srv.is_set.side_effect = [True, False]
-        self.server.shell_to_socket_tap(self.sock, self.shell_stdout, self.shell_replied_event, self.run_srv)
+        shell_to_client_tap(self.adapter, self.shell_stdout, self.shell_replied_event, self.run_srv)
         self.sock.sendall.assert_not_called()
 
     def test_nul_stripped_from_line(self):
         """NUL bytes are stripped from the shell output."""
         self.shell_stdout.readline.side_effect = ["abc\x00def\r\n", ""]
-        self.run_srv.is_set.side_effect = [True, True, False]
-        self.server.shell_to_socket_tap(self.sock, self.shell_stdout, self.shell_replied_event, self.run_srv)
+        self.run_srv.is_set.side_effect = [
+            True,
+            True,
+            True,
+            False,
+        ]  # D11: retry-loop form consumes one extra is_set per send
+        shell_to_client_tap(self.adapter, self.shell_stdout, self.shell_replied_event, self.run_srv)
         self.sock.sendall.assert_called_once_with(b"abcdef\r\n")
 
     def test_lf_converted_to_crlf(self):
         """Bare LF from shell is converted to CRLF."""
         self.shell_stdout.readline.side_effect = ["line\n", ""]
-        self.run_srv.is_set.side_effect = [True, True, False]
-        self.server.shell_to_socket_tap(self.sock, self.shell_stdout, self.shell_replied_event, self.run_srv)
+        self.run_srv.is_set.side_effect = [
+            True,
+            True,
+            True,
+            False,
+        ]  # D11: retry-loop form consumes one extra is_set per send
+        shell_to_client_tap(self.adapter, self.shell_stdout, self.shell_replied_event, self.run_srv)
         self.sock.sendall.assert_called_once_with(b"line\r\n")
 
     def test_oserror_on_sendall_breaks_loop(self):
@@ -721,14 +740,19 @@ class ShellToSocketTapTest(unittest.TestCase):
         self.shell_stdout.readline.return_value = "Router>\r\n"
         self.sock.sendall.side_effect = OSError("Write error")
         self.run_srv.is_set.return_value = True
-        self.server.shell_to_socket_tap(self.sock, self.shell_stdout, self.shell_replied_event, self.run_srv)
+        shell_to_client_tap(self.adapter, self.shell_stdout, self.shell_replied_event, self.run_srv)
         self.run_srv.clear.assert_called_once()
 
     def test_shell_replied_event_set_after_send(self):
         """Successfully sending a line to the socket sets the replied event."""
         self.shell_stdout.readline.side_effect = ["hi\r\n", ""]
-        self.run_srv.is_set.side_effect = [True, True, False]
-        self.server.shell_to_socket_tap(self.sock, self.shell_stdout, self.shell_replied_event, self.run_srv)
+        self.run_srv.is_set.side_effect = [
+            True,
+            True,
+            True,
+            False,
+        ]  # D11: retry-loop form consumes one extra is_set per send
+        shell_to_client_tap(self.adapter, self.shell_stdout, self.shell_replied_event, self.run_srv)
         self.shell_replied_event.set.assert_called_once()
 
     def test_echo_only_blocks_for_prompt(self):
@@ -736,7 +760,7 @@ class ShellToSocketTapTest(unittest.TestCase):
         self.shell_stdout.readline.side_effect = ["\r\n", "Router>", ""]
         self.shell_stdout.drain.side_effect = [[], [], []]
         self.run_srv.is_set.side_effect = [True, True, True, False]
-        self.server.shell_to_socket_tap(self.sock, self.shell_stdout, self.shell_replied_event, self.run_srv)
+        shell_to_client_tap(self.adapter, self.shell_stdout, self.shell_replied_event, self.run_srv)
         # Echo and prompt are sent together in one sendall
         self.sock.sendall.assert_called_once_with(b"\r\nRouter>")
 
@@ -744,16 +768,26 @@ class ShellToSocketTapTest(unittest.TestCase):
         """Drained lines are coalesced into a single sendall."""
         self.shell_stdout.readline.side_effect = ["line1\r\n", ""]
         self.shell_stdout.drain.side_effect = [["line2\r\n", "Router>"], []]
-        self.run_srv.is_set.side_effect = [True, True, False]
-        self.server.shell_to_socket_tap(self.sock, self.shell_stdout, self.shell_replied_event, self.run_srv)
+        self.run_srv.is_set.side_effect = [
+            True,
+            True,
+            True,
+            False,
+        ]  # D11: retry-loop form consumes one extra is_set per send
+        shell_to_client_tap(self.adapter, self.shell_stdout, self.shell_replied_event, self.run_srv)
         self.sock.sendall.assert_called_once_with(b"line1\r\nline2\r\nRouter>")
 
     def test_prompt_separator_prevents_concatenation(self):
         """Consecutive prompts without trailing newline get \\r\\n separator."""
         self.shell_stdout.readline.side_effect = ["Router>", ""]
         self.shell_stdout.drain.side_effect = [["Router>"], []]
-        self.run_srv.is_set.side_effect = [True, True, False]
-        self.server.shell_to_socket_tap(self.sock, self.shell_stdout, self.shell_replied_event, self.run_srv)
+        self.run_srv.is_set.side_effect = [
+            True,
+            True,
+            True,
+            False,
+        ]  # D11: retry-loop form consumes one extra is_set per send
+        shell_to_client_tap(self.adapter, self.shell_stdout, self.shell_replied_event, self.run_srv)
         # Prompts are separated, not concatenated as "Router>Router>"
         self.sock.sendall.assert_called_once_with(b"Router>\r\nRouter>")
 
@@ -764,20 +798,21 @@ class SocketToShellTapShellStdoutTest(unittest.TestCase):
     def setUp(self):
         self.server = _make_server()
         self.sock = MagicMock(spec=socket.socket)
+        self.adapter = TelnetSocketAdapter(self.sock, self.server)
         self.shell_stdin = MagicMock()
         self.shell_stdout = MagicMock()
         self.shell_replied_event = MagicMock()
         self.shell_replied_event.wait.return_value = True
         self.run_srv = MagicMock()
 
-    @unittest.mock.patch("simnos.plugins.servers.telnet_server.time.sleep")
+    @unittest.mock.patch("simnos.plugins.servers.tap_bridge.time.sleep")
     @unittest.mock.patch.object(TelnetServer, "_recv_byte")
     def test_newline_echo_routed_to_shell_stdout(self, mock_recv, _mock_sleep):
         """When shell_stdout is provided, newline echo goes to shell_stdout, not socket."""
         mock_recv.side_effect = [b"\r", None]
         self.run_srv.is_set.side_effect = [True] * 5 + [False]
-        self.server.socket_to_shell_tap(
-            self.sock,
+        client_to_shell_tap(
+            self.adapter,
             self.shell_stdin,
             self.shell_replied_event,
             self.run_srv,
@@ -788,28 +823,28 @@ class SocketToShellTapShellStdoutTest(unittest.TestCase):
         sendall_args = [call.args[0] for call in self.sock.sendall.call_args_list]
         self.assertNotIn(b"\r\n", sendall_args)
 
-    @unittest.mock.patch("simnos.plugins.servers.telnet_server.time.sleep")
+    @unittest.mock.patch("simnos.plugins.servers.tap_bridge.time.sleep")
     @unittest.mock.patch.object(TelnetServer, "_recv_byte")
     def test_newline_echo_to_socket_without_shell_stdout(self, mock_recv, _mock_sleep):
         """Without shell_stdout, newline echo goes directly to socket."""
         mock_recv.side_effect = [b"\r", None]
         self.run_srv.is_set.side_effect = [True] * 5 + [False]
-        self.server.socket_to_shell_tap(
-            self.sock,
+        client_to_shell_tap(
+            self.adapter,
             self.shell_stdin,
             self.shell_replied_event,
             self.run_srv,
         )
         self.sock.sendall.assert_any_call(b"\r\n")
 
-    @unittest.mock.patch("simnos.plugins.servers.telnet_server.time.sleep")
+    @unittest.mock.patch("simnos.plugins.servers.tap_bridge.time.sleep")
     @unittest.mock.patch.object(TelnetServer, "_recv_byte")
     def test_normal_byte_still_echoed_to_socket(self, mock_recv, _mock_sleep):
         """Normal bytes are always echoed directly to socket, even with shell_stdout."""
         mock_recv.side_effect = [b"a", None]
         self.run_srv.is_set.side_effect = [True, True, True, False]
-        self.server.socket_to_shell_tap(
-            self.sock,
+        client_to_shell_tap(
+            self.adapter,
             self.shell_stdin,
             self.shell_replied_event,
             self.run_srv,
@@ -827,7 +862,7 @@ class WatchdogTest(unittest.TestCase):
         self.run_srv = MagicMock()
         self.shell = MagicMock()
 
-    @unittest.mock.patch("simnos.plugins.servers.telnet_server.time.sleep")
+    @unittest.mock.patch("simnos.plugins.servers.tap_bridge.time.sleep")
     def test_run_srv_loop(self, mock_sleep):
         """Watchdog loops while run_srv is set, then stops shell."""
         self.run_srv.is_set.side_effect = [True, True, False]
@@ -836,7 +871,7 @@ class WatchdogTest(unittest.TestCase):
         self.assertEqual(mock_sleep.call_count, 2)
         self.shell.stop.assert_called_once()
 
-    @unittest.mock.patch("simnos.plugins.servers.telnet_server.time.sleep")
+    @unittest.mock.patch("simnos.plugins.servers.tap_bridge.time.sleep")
     def test_breaks_when_is_running_cleared(self, _mock_sleep):
         """Watchdog breaks when is_running is cleared, then stops shell."""
         self.run_srv.is_set.return_value = True
@@ -844,7 +879,7 @@ class WatchdogTest(unittest.TestCase):
         self.server.watchdog(self.is_running, self.run_srv, self.shell)
         self.shell.stop.assert_called_once()
 
-    @unittest.mock.patch("simnos.plugins.servers.telnet_server.time.sleep")
+    @unittest.mock.patch("simnos.plugins.servers.tap_bridge.time.sleep")
     def test_shell_stop_called_on_exit(self, _mock_sleep):
         """shell.stop() is always called on watchdog exit."""
         # Case: run_srv cleared
@@ -852,7 +887,7 @@ class WatchdogTest(unittest.TestCase):
         self.server.watchdog(self.is_running, self.run_srv, self.shell)
         self.assertEqual(self.shell.stop.call_count, 1)
 
-    @unittest.mock.patch("simnos.plugins.servers.telnet_server.time.sleep")
+    @unittest.mock.patch("simnos.plugins.servers.tap_bridge.time.sleep")
     def test_sleep_interval_capped_by_shutdown_timeout(self, mock_sleep):
         """Sleep interval is the minimum of watchdog_interval and SHUTDOWN_IO_TIMEOUT."""
         self.server.watchdog_interval = 10.0  # Larger than SHUTDOWN_IO_TIMEOUT


### PR DESCRIPTION
🐙claude: Refs #225 (PR1/2)。棚卸し G3 group (P-3 + P-11 + P-15) の実装。

## 概要

SSH (`ssh_server_paramiko.py`) と Telnet (`telnet_server.py`) で 95% 重複していた tap function 対を、**TransportAdapter Protocol + 共通 tap 関数** (`tap_bridge.py` 新設) に統合。#87/#94 系の echo coalesce 修正が single-site になる。

## 設計のポイント (local design doc で cross-review 2 round 済)

- **loop は旧 SSH 版を字句維持** — #87 coalesce のタイミング挙動を変えない。差分 (byte 読み / 例外型 / 送信先 / NUL quirk) のみ adapter 参照に置換
- **例外順序契約**: TimeoutError ⊂ OSError (Py3.10+) のため、`except TimeoutError` を `except transport.io_errors` より**先に**置く順序で契約を表現。操作別ポリシー (recv=continue / echo 送信=break / batch 送信=retry) を table-driven test で pin
- **挙動統一 (Telnet 改善)**:
  - U1: batch 送信 timeout を retry 化 — 現状 Telnet は TimeoutError が except OSError に落ちて即切断 (潜在バグ) だったのを SSH と統一
  - U2: `is_closed()` による local close 早期検出 (SSH 側も `closed or not active` に微強化、pin 済)
- **quirk 保持 (Q1)**: NUL 受信時の skip_lf (SSH=保持 / Telnet=RFC 854 リセット) は意図的な transport 仕様差なので `nul_resets_skip_lf` flag で両挙動維持。既存 pin 2 件そのまま green
- **paramiko 依存は ssh module に閉じる** (tap_bridge は paramiko を import しない)

## 変更

| ファイル | 変更 |
|---------|------|
| `tap_bridge.py` | 新規: Protocol + client_to_shell_tap / shell_to_client_tap + _COALESCE_DELAY |
| `ssh_server_paramiko.py` | 旧 tap 対削除 → ParamikoChannelAdapter |
| `telnet_server.py` | 旧 tap 対削除 → TelnetSocketAdapter (IAC 処理は TelnetServer に残す) |
| `test_tap_bridge.py` | 新規: FakeTransport + 例外ポリシー / Q1 / U1 / U2 / D11 pin |
| 既存テスト ×2 | call-site 約 61 件を adapter 経由に書き換え (アサーション温存) + adapter 直接 pin クラス追加 |

## 検証

- ruff / yamllint / bandit / ty 全 green
- pytest **785 passed** + 4 subtests (+19 新規。D4 quirk pin 含む既存 pin 全維持)
- `invoke netmiko-check cisco_ios` → OK (#87 再発なし)
- cross-review (codex / gemini / claude) 1 round: SHOULD FIX 2 件 (U2 pin 補強) 取り込み済

## merge 前の推奨 gate

- [ ] compatibility workflow (netmiko / scrapli / ansible) を本 branch で手動 dispatch

## 備考

- PR2 (P-5: read_line + interactive_login 統一) は本 PR merge 後に続く
- `scratch/cmd2-poc/` が旧関数を import しているが凍結 PoC (git 管理外) のため追従不要

🤖 Generated with [Claude Code](https://claude.com/claude-code)