### PR TITLE
refactor: G3 PR2 — read_line / interactive_login を tap_bridge に統一 (#225)

### DIFF
--- a/simnos/plugins/servers/ssh_server_paramiko.py
+++ b/simnos/plugins/servers/ssh_server_paramiko.py
@@ -16,7 +16,11 @@ import paramiko.rsakey
 from simnos.core.nos import Nos
 from simnos.core.servers import TCPServerBase
 from simnos.core.timeouts import SHUTDOWN_IO_TIMEOUT
-from simnos.plugins.servers.tap_bridge import client_to_shell_tap, shell_to_client_tap
+from simnos.plugins.servers.tap_bridge import (
+    client_to_shell_tap,
+    interactive_login,
+    shell_to_client_tap,
+)
 from simnos.plugins.servers.tap_io import TapIO
 
 log = logging.getLogger(__name__)
@@ -337,71 +341,32 @@ class ParamikoSshServer(TCPServerBase):
 
         shell.stop()
 
-    def _read_channel_line(
-        self,
-        channel,
-        echo: bool = True,
-        skip_lf: bool = False,
-    ) -> tuple[str, bool]:
-        """
-        Read a single line from the channel byte-by-byte.
-
-        :param channel: paramiko Channel
-        :param echo: if True, echo each byte back to the client
-        :param skip_lf: if True, consume a leading LF left over from a previous CR
-        :return: (line without trailing CR/LF, whether next call should skip LF)
-        """
-        channel.settimeout(self.timeout)
-        buf = b""
-        while True:
-            try:
-                byte = channel.recv(1)
-            except TimeoutError:
-                continue
-            except (OSError, EOFError, paramiko.SSHException):
-                break
-            if byte in (b"", None):
-                break
-            if skip_lf:
-                skip_lf = False
-                if byte == b"\n":
-                    continue
-            if byte == b"\r":
-                if echo:
-                    channel.sendall(b"\r\n")
-                return buf.decode("utf-8", errors="replace"), True
-            if byte == b"\n":
-                if echo:
-                    channel.sendall(b"\r\n")
-                return buf.decode("utf-8", errors="replace"), False
-            if echo:
-                channel.sendall(byte)
-            buf += byte
-        return buf.decode("utf-8", errors="replace"), False
-
     def _channel_login(self, channel) -> tuple[bool, bool]:
         """
         Perform channel-level login for auth_none platforms (e.g. Dell PowerConnect).
 
-        Sends "User Name:" / "Password:" prompts and validates credentials.
+        Thin wrapper around tap_bridge.interactive_login supplying the
+        Dell-style prompts; the interaction itself is shared with Telnet.
+        Expects the channel timeout to be configured by the caller
+        (connection_function) beforehand.
 
         :param channel: paramiko Channel
         :return: (authenticated, skip_lf) — skip_lf should be forwarded to
                  client_to_shell_tap so it can consume a trailing LF after
                  the final CR of the password line.
         """
-        channel.sendall(b"\r\nUser Name:")
-        username, skip_lf = self._read_channel_line(channel, echo=True, skip_lf=False)
-        channel.sendall(b"\r\nPassword:")
-        password, skip_lf = self._read_channel_line(channel, echo=False, skip_lf=skip_lf)
-        channel.sendall(b"\r\n")
-
-        if username == self.username and password == self.password:
-            log.debug("Channel login succeeded for user %s", username)
-            return True, skip_lf
-
-        log.warning("Channel login failed for user %s", username)
-        return False, skip_lf
+        authenticated, skip_lf = interactive_login(
+            ParamikoChannelAdapter(channel),
+            self.username,
+            self.password,
+            user_prompt=b"\r\nUser Name:",
+            pass_prompt=b"\r\nPassword:",
+        )
+        if authenticated:
+            log.debug("Channel login succeeded for user %s", self.username)
+        else:
+            log.warning("Channel login failed")
+        return authenticated, skip_lf
 
     def connection_function(self, client: socket.socket, is_running: threading.Event):
         shell_replied_event = threading.Event()
@@ -445,18 +410,24 @@ class ParamikoSshServer(TCPServerBase):
                 log.warning("session.accept() returned None or server stopping, closing transport")
                 return
 
+            # Timeout responsibility lives here (not in the adapter / shared
+            # helpers): configure it before any channel I/O below.
+            channel.settimeout(self.timeout)
+
             # For auth_none platforms (e.g. Dell PowerConnect), perform channel-level
             # login before starting the shell.  When publickey auth is also configured,
             # clients that authenticate via publickey bypass this channel-level login
             # intentionally — SSH-level publickey auth already verified the identity.
             skip_lf = False
             if server.auth_method_used == "none":
-                authenticated, skip_lf = self._channel_login(channel)
+                try:
+                    authenticated, skip_lf = self._channel_login(channel)
+                except (TimeoutError, OSError, EOFError, paramiko.SSHException):
+                    log.debug("Client disconnected during channel login")
+                    return
                 if not authenticated:
                     log.warning("Channel login failed, closing connection")
                     return
-
-            channel.settimeout(self.timeout)
 
             # create stdio for the shell
             shell_stdin, shell_stdout = TapIO(run_srv), TapIO(run_srv)

--- a/simnos/plugins/servers/ssh_server_paramiko.py
+++ b/simnos/plugins/servers/ssh_server_paramiko.py
@@ -355,18 +355,13 @@ class ParamikoSshServer(TCPServerBase):
                  client_to_shell_tap so it can consume a trailing LF after
                  the final CR of the password line.
         """
-        authenticated, skip_lf = interactive_login(
+        return interactive_login(
             ParamikoChannelAdapter(channel),
             self.username,
             self.password,
             user_prompt=b"\r\nUser Name:",
             pass_prompt=b"\r\nPassword:",
         )
-        if authenticated:
-            log.debug("Channel login succeeded for user %s", self.username)
-        else:
-            log.warning("Channel login failed")
-        return authenticated, skip_lf
 
     def connection_function(self, client: socket.socket, is_running: threading.Event):
         shell_replied_event = threading.Event()

--- a/simnos/plugins/servers/tap_bridge.py
+++ b/simnos/plugins/servers/tap_bridge.py
@@ -5,6 +5,11 @@ transport differences are absorbed by TransportAdapter implementations
 that live in the respective server modules (G3 / #225). The loop logic is
 ported verbatim from the former SSH tap pair in ssh_server_paramiko.py so
 that the #87 echo-coalescing behaviour is preserved byte for byte.
+
+NUL handling is intentionally asymmetric between the two layers (do not
+"unify" it): read_line keeps mid-line NUL bytes in the buffer so login
+credentials are compared exactly (auth-bypass prevention), while
+client_to_shell_tap drops every NUL before it reaches the shell.
 """
 
 import io
@@ -293,8 +298,11 @@ def read_line(
     Exception contract:
     - recv TimeoutError -> retry (continue).
     - recv io_errors / EOF -> return the partial line read so far (U4 —
-      unified on the SSH behaviour; auth then fails on the partial value
-      and the connection closes through the normal path).
+      unified on the SSH behaviour). NOTE: the return value does not
+      distinguish a terminated line from a truncated one; a caller
+      comparing the line against an expected value will match when the
+      client sent the exact value and then disconnected without a
+      terminator (pre-G3 SSH equivalent, pinned in tests).
     - echo send errors propagate to the caller.
     """
     buf = b""
@@ -346,9 +354,12 @@ def interactive_login(
     LF/NUL left over from the final CR of the password line.
 
     Exception contract: prompt sends and echo sends propagate; recv
-    io_errors yield partial lines via read_line (U4) and fail the
-    comparison. Callers must wrap this call in try/except covering
-    TimeoutError and transport.io_errors.
+    io_errors yield partial lines via read_line (U4). A truncated
+    credential fails the comparison; an exact credential followed by an
+    abrupt disconnect (no terminator) still authenticates — the pre-G3
+    SSH behaviour, kept for equivalence (the connection then tears down
+    through the taps' EOF path anyway). Callers must wrap this call in
+    try/except covering TimeoutError and transport.io_errors.
     """
     transport.sendall(user_prompt)
     entered_user, skip_lf = read_line(transport, echo=True, skip_lf=False)

--- a/simnos/plugins/servers/tap_bridge.py
+++ b/simnos/plugins/servers/tap_bridge.py
@@ -268,3 +268,91 @@ def shell_to_client_tap(
         shell_replied_event.set()
 
     run_srv.clear()
+
+
+def read_line(
+    transport: TransportAdapter,
+    *,
+    echo: bool = True,
+    skip_lf: bool = False,
+) -> tuple[str, bool]:
+    """Read one line byte-by-byte from the client transport.
+
+    Returns (line without trailing CR/LF, next_skip_lf). A CR terminator
+    sets next_skip_lf=True so the *next* call consumes the trailing LF of a
+    CR LF pair — the #88 skip_lf-propagation pattern, unified for both
+    transports (U3; replaces the former Telnet blocking one-byte consume).
+
+    skip_lf handling on entry:
+    - LF: consumed (second half of a CR LF pair), skip_lf cleared.
+    - NUL with transport.nul_resets_skip_lf=True (Telnet): consumed
+      (RFC 854 CR NUL is a complete sequence), skip_lf cleared.
+    - CR: skip_lf cleared, the CR is processed as a line terminator.
+    - any other byte: skip_lf cleared, the byte is processed normally.
+
+    Exception contract:
+    - recv TimeoutError -> retry (continue).
+    - recv io_errors / EOF -> return the partial line read so far (U4 —
+      unified on the SSH behaviour; auth then fails on the partial value
+      and the connection closes through the normal path).
+    - echo send errors propagate to the caller.
+    """
+    buf = b""
+    while True:
+        try:
+            byte = transport.recv_byte()
+        except TimeoutError:
+            continue
+        except transport.io_errors:
+            break
+        if byte is None:
+            break
+        if skip_lf:
+            skip_lf = False
+            if byte == b"\n":
+                continue
+            if byte == b"\x00" and transport.nul_resets_skip_lf:
+                continue
+        if byte == b"\r":
+            if echo:
+                transport.sendall(b"\r\n")
+            return buf.decode("utf-8", errors="replace"), True
+        if byte == b"\n":
+            if echo:
+                transport.sendall(b"\r\n")
+            return buf.decode("utf-8", errors="replace"), False
+        if echo:
+            transport.sendall(byte)
+        buf += byte
+    return buf.decode("utf-8", errors="replace"), False
+
+
+def interactive_login(
+    transport: TransportAdapter,
+    username: str,
+    password: str,
+    *,
+    user_prompt: bytes,
+    pass_prompt: bytes,
+) -> tuple[bool, bool]:
+    """Prompt for username/password over the transport and validate them.
+
+    The prompt byte strings are transport-specific (SSH channel login uses
+    Dell-style ``b"\\r\\nUser Name:"``, Telnet uses ``b"Username: "``), so
+    they are parameters; the interaction shape is shared.
+
+    Returns (authenticated, skip_lf). The skip_lf flag must be forwarded to
+    client_to_shell_tap (initial_skip_lf) so it can consume the trailing
+    LF/NUL left over from the final CR of the password line.
+
+    Exception contract: prompt sends and echo sends propagate; recv
+    io_errors yield partial lines via read_line (U4) and fail the
+    comparison. Callers must wrap this call in try/except covering
+    TimeoutError and transport.io_errors.
+    """
+    transport.sendall(user_prompt)
+    entered_user, skip_lf = read_line(transport, echo=True, skip_lf=False)
+    transport.sendall(pass_prompt)
+    entered_pass, skip_lf = read_line(transport, echo=False, skip_lf=skip_lf)
+    transport.sendall(b"\r\n")
+    return (entered_user == username and entered_pass == password), skip_lf

--- a/simnos/plugins/servers/tap_bridge.py
+++ b/simnos/plugins/servers/tap_bridge.py
@@ -355,4 +355,11 @@ def interactive_login(
     transport.sendall(pass_prompt)
     entered_pass, skip_lf = read_line(transport, echo=False, skip_lf=skip_lf)
     transport.sendall(b"\r\n")
-    return (entered_user == username and entered_pass == password), skip_lf
+    authenticated = entered_user == username and entered_pass == password
+    log.debug(
+        "tap_bridge.interactive_login [%s] %s for user %s",
+        transport.name,
+        "succeeded" if authenticated else "failed",
+        entered_user,
+    )
+    return authenticated, skip_lf

--- a/simnos/plugins/servers/telnet_server.py
+++ b/simnos/plugins/servers/telnet_server.py
@@ -16,7 +16,11 @@ from typing import Any
 from simnos.core.nos import Nos
 from simnos.core.servers import TCPServerBase
 from simnos.core.timeouts import SHUTDOWN_IO_TIMEOUT
-from simnos.plugins.servers.tap_bridge import client_to_shell_tap, shell_to_client_tap
+from simnos.plugins.servers.tap_bridge import (
+    client_to_shell_tap,
+    interactive_login,
+    shell_to_client_tap,
+)
 from simnos.plugins.servers.tap_io import TapIO
 
 log = logging.getLogger(__name__)
@@ -176,58 +180,29 @@ class TelnetServer(TCPServerBase):
                 continue
 
     # ------------------------------------------------------------------
-    # Line reading and authentication
+    # Authentication
     # ------------------------------------------------------------------
 
-    def _read_line(self, sock: socket.socket, echo: bool = True) -> str:
-        """
-        Read a single line from the socket byte-by-byte using _recv_byte.
-
-        Handles CR LF, CR NUL (RFC 854), and bare LF as line terminators.
-
-        :param sock: client socket
-        :param echo: if True, echo each byte back to the client
-        :return: the line read (without trailing CR/LF)
-        """
-        buf = b""
-        while True:
-            try:
-                byte = self._recv_byte(sock)
-            except TimeoutError:
-                continue
-            if byte is None:
-                break
-            if byte == b"\r":
-                if echo:
-                    sock.sendall(b"\r\n")
-                # Consume trailing LF or NUL after CR (RFC 854).
-                # Non-standard followers are discarded for simplicity;
-                # in practice, clients always send CR LF or CR NUL.
-                with contextlib.suppress(TimeoutError):
-                    self._recv_byte(sock)
-                break
-            if byte == b"\n":
-                if echo:
-                    sock.sendall(b"\r\n")
-                break
-            if echo:
-                sock.sendall(byte)
-            buf += byte
-        return buf.decode("utf-8", errors="replace")
-
-    def _authenticate(self, sock: socket.socket) -> bool:
+    def _authenticate(self, sock: socket.socket) -> tuple[bool, bool]:
         """
         Perform username/password authentication over the Telnet connection.
 
+        Thin wrapper around tap_bridge.interactive_login supplying the
+        Telnet prompts; the interaction itself is shared with SSH channel
+        login. The trailing LF/NUL after a CR is no longer consumed with a
+        blocking read — it is reported via skip_lf and must be forwarded to
+        client_to_shell_tap (initial_skip_lf), matching SSH (U3).
+
         :param sock: client socket
-        :return: True if authentication succeeded
+        :return: (authenticated, skip_lf)
         """
-        sock.sendall(b"Username: ")
-        username = self._read_line(sock, echo=True)
-        sock.sendall(b"Password: ")
-        password = self._read_line(sock, echo=False)
-        sock.sendall(b"\r\n")
-        return username == self.username and password == self.password
+        return interactive_login(
+            TelnetSocketAdapter(sock, self),
+            self.username,
+            self.password,
+            user_prompt=b"Username: ",
+            pass_prompt=b"Password: ",
+        )
 
     # ------------------------------------------------------------------
     # Watchdog
@@ -293,7 +268,7 @@ class TelnetServer(TCPServerBase):
 
             # Authenticate
             try:
-                auth_ok = self._authenticate(client)
+                auth_ok, skip_lf = self._authenticate(client)
             except (TimeoutError, OSError):
                 log.debug("Client disconnected during authentication")
                 return
@@ -309,11 +284,12 @@ class TelnetServer(TCPServerBase):
             # Bridge the socket and the shell through the shared tap pair
             transport_adapter = TelnetSocketAdapter(client, self)
 
-            # Start client→shell tap thread
+            # Start client→shell tap thread (skip_lf forwards the pending
+            # LF/NUL from the password line's CR — U3, matches SSH)
             client_to_shell_tapper = threading.Thread(
                 target=client_to_shell_tap,
                 args=(transport_adapter, shell_stdin, shell_replied_event, run_srv),
-                kwargs={"shell_stdout": shell_stdout},
+                kwargs={"initial_skip_lf": skip_lf, "shell_stdout": shell_stdout},
                 daemon=True,
             )
             client_to_shell_tapper.start()

--- a/tests/plugins/test_ssh_server_paramiko.py
+++ b/tests/plugins/test_ssh_server_paramiko.py
@@ -22,7 +22,7 @@ from simnos.plugins.servers.ssh_server_paramiko import (
     ParamikoSshServer,
     ParamikoSshServerInterface,
 )
-from simnos.plugins.servers.tap_bridge import client_to_shell_tap, shell_to_client_tap
+from simnos.plugins.servers.tap_bridge import client_to_shell_tap, read_line, shell_to_client_tap
 from simnos.plugins.servers.tap_io import TapIO
 
 
@@ -1511,17 +1511,11 @@ class ParamikoSshServerChannelLoginTest(unittest.TestCase):
 
 
 class ReadChannelLineTest(unittest.TestCase):
-    """Test cases for _read_channel_line CRLF handling."""
+    """CRLF/skip_lf pins for the shared read_line via ParamikoChannelAdapter.
 
-    def setUp(self):
-        self.arguments = {
-            "shell": Mock(),
-            "nos": Mock(),
-            "nos_inventory_config": {},
-            "port": 22,
-            "username": "admin",
-            "password": "admin",
-        }
+    Replaces the former ParamikoSshServer._read_channel_line tests (PR2 #225);
+    the assertions are unchanged — the SSH semantics carried over verbatim.
+    """
 
     def _make_channel(self, data: bytes):
         """Create a mock channel whose recv returns bytes one at a time."""
@@ -1534,49 +1528,43 @@ class ReadChannelLineTest(unittest.TestCase):
 
     def test_read_channel_line_bare_cr(self):
         """Bare CR should return (line, True) without blocking."""
-        server = ParamikoSshServer(**self.arguments)
         channel = self._make_channel(b"test\r")
-        line, skip_lf = server._read_channel_line(channel)
+        line, skip_lf = read_line(ParamikoChannelAdapter(channel))
         self.assertEqual(line, "test")
         self.assertTrue(skip_lf)
 
     def test_read_channel_line_bare_lf(self):
         """Bare LF should return (line, False)."""
-        server = ParamikoSshServer(**self.arguments)
         channel = self._make_channel(b"test\n")
-        line, skip_lf = server._read_channel_line(channel)
+        line, skip_lf = read_line(ParamikoChannelAdapter(channel))
         self.assertEqual(line, "test")
         self.assertFalse(skip_lf)
 
     def test_read_channel_line_skip_lf_consumes_lf(self):
         """skip_lf=True should consume a leading LF, then read normally."""
-        server = ParamikoSshServer(**self.arguments)
         channel = self._make_channel(b"\nnext\r")
-        line, skip_lf = server._read_channel_line(channel, skip_lf=True)
+        line, skip_lf = read_line(ParamikoChannelAdapter(channel), skip_lf=True)
         self.assertEqual(line, "next")
         self.assertTrue(skip_lf)
 
     def test_read_channel_line_skip_lf_non_lf(self):
         """skip_lf=True with non-LF first byte should not consume it."""
-        server = ParamikoSshServer(**self.arguments)
         channel = self._make_channel(b"Pass\r")
-        line, skip_lf = server._read_channel_line(channel, skip_lf=True)
+        line, skip_lf = read_line(ParamikoChannelAdapter(channel), skip_lf=True)
         self.assertEqual(line, "Pass")
         self.assertTrue(skip_lf)
 
     def test_read_channel_line_nul_preserved(self):
         """NUL bytes should be preserved in login input to prevent auth bypass."""
-        server = ParamikoSshServer(**self.arguments)
         channel = self._make_channel(b"ad\x00min\r")
-        line, skip_lf = server._read_channel_line(channel)
+        line, skip_lf = read_line(ParamikoChannelAdapter(channel))
         self.assertEqual(line, "ad\x00min")
         self.assertTrue(skip_lf)
 
     def test_read_channel_line_eof(self):
         """EOF should return accumulated buffer with skip_lf=False."""
-        server = ParamikoSshServer(**self.arguments)
         channel = self._make_channel(b"partial")
-        line, skip_lf = server._read_channel_line(channel)
+        line, skip_lf = read_line(ParamikoChannelAdapter(channel))
         self.assertEqual(line, "partial")
         self.assertFalse(skip_lf)
 

--- a/tests/plugins/test_ssh_server_paramiko.py
+++ b/tests/plugins/test_ssh_server_paramiko.py
@@ -1510,7 +1510,7 @@ class ParamikoSshServerChannelLoginTest(unittest.TestCase):
         self.assertTrue(skip_lf)
 
 
-class ReadChannelLineTest(unittest.TestCase):
+class ReadLineTest(unittest.TestCase):
     """CRLF/skip_lf pins for the shared read_line via ParamikoChannelAdapter.
 
     Replaces the former ParamikoSshServer._read_channel_line tests (PR2 #225);
@@ -1526,42 +1526,42 @@ class ReadChannelLineTest(unittest.TestCase):
         mock_channel.sendall = MagicMock()
         return mock_channel
 
-    def test_read_channel_line_bare_cr(self):
+    def test_read_line_bare_cr(self):
         """Bare CR should return (line, True) without blocking."""
         channel = self._make_channel(b"test\r")
         line, skip_lf = read_line(ParamikoChannelAdapter(channel))
         self.assertEqual(line, "test")
         self.assertTrue(skip_lf)
 
-    def test_read_channel_line_bare_lf(self):
+    def test_read_line_bare_lf(self):
         """Bare LF should return (line, False)."""
         channel = self._make_channel(b"test\n")
         line, skip_lf = read_line(ParamikoChannelAdapter(channel))
         self.assertEqual(line, "test")
         self.assertFalse(skip_lf)
 
-    def test_read_channel_line_skip_lf_consumes_lf(self):
+    def test_read_line_skip_lf_consumes_lf(self):
         """skip_lf=True should consume a leading LF, then read normally."""
         channel = self._make_channel(b"\nnext\r")
         line, skip_lf = read_line(ParamikoChannelAdapter(channel), skip_lf=True)
         self.assertEqual(line, "next")
         self.assertTrue(skip_lf)
 
-    def test_read_channel_line_skip_lf_non_lf(self):
+    def test_read_line_skip_lf_non_lf(self):
         """skip_lf=True with non-LF first byte should not consume it."""
         channel = self._make_channel(b"Pass\r")
         line, skip_lf = read_line(ParamikoChannelAdapter(channel), skip_lf=True)
         self.assertEqual(line, "Pass")
         self.assertTrue(skip_lf)
 
-    def test_read_channel_line_nul_preserved(self):
+    def test_read_line_nul_preserved(self):
         """NUL bytes should be preserved in login input to prevent auth bypass."""
         channel = self._make_channel(b"ad\x00min\r")
         line, skip_lf = read_line(ParamikoChannelAdapter(channel))
         self.assertEqual(line, "ad\x00min")
         self.assertTrue(skip_lf)
 
-    def test_read_channel_line_eof(self):
+    def test_read_line_eof(self):
         """EOF should return accumulated buffer with skip_lf=False."""
         channel = self._make_channel(b"partial")
         line, skip_lf = read_line(ParamikoChannelAdapter(channel))

--- a/tests/plugins/test_ssh_server_paramiko.py
+++ b/tests/plugins/test_ssh_server_paramiko.py
@@ -1895,6 +1895,38 @@ class TeardownFixTests(unittest.TestCase):
 
         mock_channel.settimeout.assert_called_once_with(server.timeout)
 
+    @mock.patch("simnos.plugins.servers.ssh_server_paramiko.client_to_shell_tap")
+    @mock.patch("simnos.plugins.servers.ssh_server_paramiko.shell_to_client_tap")
+    @mock.patch("paramiko.Transport")
+    def test_channel_login_send_error_closes_connection(
+        self,
+        mock_transport_cls: MagicMock,
+        mock_shell_to_client_tap: MagicMock,
+        mock_client_to_shell_tap: MagicMock,
+    ):
+        """PR2 caller-wrap pin: a send error during channel login closes the
+        connection without starting taps/shell and without propagating."""
+        mock_session = MagicMock()
+        mock_channel = MagicMock()
+        mock_session.accept.return_value = mock_channel
+        mock_transport_cls.return_value = mock_session
+
+        server = ParamikoSshServer(**self.arguments)
+        with (
+            mock.patch("simnos.plugins.servers.ssh_server_paramiko.ParamikoSshServerInterface") as mock_iface_cls,
+            mock.patch.object(
+                ParamikoSshServer,
+                "_channel_login",
+                side_effect=paramiko.SSHException("send failed"),
+            ),
+        ):
+            mock_iface_cls.return_value.auth_method_used = "none"
+            server.connection_function(MagicMock(), Mock())  # must not raise
+
+        mock_client_to_shell_tap.assert_not_called()
+        mock_shell_to_client_tap.assert_not_called()
+        mock_session.close.assert_called_once()
+
     @mock.patch("paramiko.Transport")
     def test_session_accept_bounded(self, mock_transport_cls: MagicMock):
         """session.accept() should be called with SHUTDOWN_IO_TIMEOUT."""

--- a/tests/plugins/test_tap_bridge.py
+++ b/tests/plugins/test_tap_bridge.py
@@ -59,6 +59,11 @@ class FakeTransport:
         return self.closed
 
 
+def _bytes_script(data: bytes) -> list[bytes]:
+    """Split *data* into a per-byte recv script."""
+    return [bytes([b]) for b in data]
+
+
 def _events(is_set_fuel=None):
     """Build (shell_replied_event, run_srv) mocks. wait() returns True."""
     shell_replied_event = Mock()
@@ -207,11 +212,6 @@ class ShellToClientTapPolicyTest(unittest.TestCase):
         shell_to_client_tap(transport, shell_stdout, ev, run_srv)
         shell_stdout.readline.assert_not_called()
         self.assertEqual(transport.sent, [])
-
-
-def _bytes_script(data: bytes) -> list[bytes]:
-    """Split *data* into a per-byte recv script."""
-    return [bytes([b]) for b in data]
 
 
 class ReadLinePolicyTest(unittest.TestCase):

--- a/tests/plugins/test_tap_bridge.py
+++ b/tests/plugins/test_tap_bridge.py
@@ -10,6 +10,8 @@ Pinned contracts:
   (SSH retry-loop form adopted for both transports).
 - U1: a batch-send TimeoutError is retried, not treated as a disconnect.
 - U2: is_closed() True breaks both loops early.
+- U3: read_line propagates skip_lf instead of blocking for the CR follower.
+- U4: read_line returns the partial line on recv io_errors.
 - Q1: nul_resets_skip_lf quirk switches the CR NUL behaviour per transport.
 - Exception-policy table: TimeoutError handling differs per operation and
   must be caught BEFORE transport.io_errors (TimeoutError ⊂ OSError).
@@ -18,7 +20,12 @@ Pinned contracts:
 import unittest
 from unittest.mock import Mock
 
-from simnos.plugins.servers.tap_bridge import client_to_shell_tap, shell_to_client_tap
+from simnos.plugins.servers.tap_bridge import (
+    client_to_shell_tap,
+    interactive_login,
+    read_line,
+    shell_to_client_tap,
+)
 
 
 class FakeTransport:
@@ -200,3 +207,135 @@ class ShellToClientTapPolicyTest(unittest.TestCase):
         shell_to_client_tap(transport, shell_stdout, ev, run_srv)
         shell_stdout.readline.assert_not_called()
         self.assertEqual(transport.sent, [])
+
+
+def _bytes_script(data: bytes) -> list[bytes]:
+    """Split *data* into a per-byte recv script."""
+    return [bytes([b]) for b in data]
+
+
+class ReadLinePolicyTest(unittest.TestCase):
+    """read_line (PR2): U3 skip_lf propagation, U4 partial line, exception policy."""
+
+    def test_cr_sets_skip_lf(self):
+        """A CR terminator reports skip_lf=True for the next call (U3)."""
+        transport = FakeTransport(_bytes_script(b"hi\r"))
+        self.assertEqual(read_line(transport, echo=False), ("hi", True))
+
+    def test_skip_lf_consumes_lf(self):
+        """skip_lf=True consumes a leading LF (second half of CR LF)."""
+        transport = FakeTransport(_bytes_script(b"\nok\r"))
+        self.assertEqual(read_line(transport, echo=False, skip_lf=True), ("ok", True))
+
+    def test_skip_lf_nul_quirk_true_consumes(self):
+        """Q1 Telnet: skip_lf=True consumes a leading NUL (RFC 854 CR NUL)."""
+        transport = FakeTransport(_bytes_script(b"\x00ok\r"), nul_resets_skip_lf=True)
+        self.assertEqual(read_line(transport, echo=False, skip_lf=True), ("ok", True))
+
+    def test_skip_lf_nul_quirk_false_keeps_byte(self):
+        """Q1 SSH: skip_lf=True does NOT consume a NUL — it joins the line."""
+        transport = FakeTransport(_bytes_script(b"\x00ok\r"), nul_resets_skip_lf=False)
+        self.assertEqual(read_line(transport, echo=False, skip_lf=True), ("\x00ok", True))
+
+    def test_skip_lf_cr_is_line_terminator(self):
+        """skip_lf=True with a CR: skip_lf clears and the CR terminates an empty line."""
+        transport = FakeTransport(_bytes_script(b"\rok\r"))
+        self.assertEqual(read_line(transport, echo=False, skip_lf=True), ("", True))
+
+    def test_skip_lf_regular_byte_processed_normally(self):
+        """skip_lf=True with a regular byte: the byte belongs to the line."""
+        transport = FakeTransport(_bytes_script(b"Xok\n"))
+        self.assertEqual(read_line(transport, echo=False, skip_lf=True), ("Xok", False))
+
+    def test_recv_timeout_continues(self):
+        """recv TimeoutError -> retry."""
+        transport = FakeTransport([TimeoutError(), b"a", b"\n"])
+        self.assertEqual(read_line(transport, echo=False), ("a", False))
+
+    def test_recv_io_error_returns_partial(self):
+        """U4: recv io_errors -> the partial line read so far is returned."""
+        transport = FakeTransport([b"a", b"b", OSError("gone")])
+        self.assertEqual(read_line(transport, echo=False), ("ab", False))
+
+    def test_eof_returns_partial(self):
+        """EOF (None) -> the partial line read so far is returned."""
+        transport = FakeTransport([b"a", b"b"])  # script exhaustion = EOF
+        self.assertEqual(read_line(transport, echo=False), ("ab", False))
+
+    def test_echo_send_error_propagates(self):
+        """Echo send errors are NOT caught — they propagate to the caller."""
+        transport = FakeTransport(_bytes_script(b"ab\r"))
+        transport.send_errors = [OSError("reset")]
+        with self.assertRaises(OSError):
+            read_line(transport, echo=True)
+
+
+class InteractiveLoginTest(unittest.TestCase):
+    """interactive_login (PR2): boundary patterns per the G3 design.
+
+    CR LF / CR NUL / CR + regular byte at the username/password boundary,
+    for both nul_resets_skip_lf settings.
+    """
+
+    def _login(self, data: bytes, *, nul_resets_skip_lf: bool):
+        transport = FakeTransport(_bytes_script(data), nul_resets_skip_lf=nul_resets_skip_lf)
+        result = interactive_login(
+            transport,
+            "admin",
+            "secret",
+            user_prompt=b"Username: ",
+            pass_prompt=b"Password: ",
+        )
+        return result, transport
+
+    def test_cr_lf_boundary_both_quirks(self):
+        """CR LF at the boundary authenticates for both transports."""
+        for quirk in (False, True):
+            with self.subTest(nul_resets_skip_lf=quirk):
+                (auth_ok, skip_lf), _ = self._login(b"admin\r\nsecret\r\n", nul_resets_skip_lf=quirk)
+                self.assertTrue(auth_ok)
+                # Final \n is left for the tap (skip_lf=True from the final CR)
+                self.assertTrue(skip_lf)
+
+    def test_cr_nul_boundary_quirk_true(self):
+        """Q1 Telnet: CR NUL at the boundary — NUL consumed, auth succeeds."""
+        (auth_ok, skip_lf), _ = self._login(b"admin\r\x00secret\r", nul_resets_skip_lf=True)
+        self.assertTrue(auth_ok)
+        self.assertTrue(skip_lf)
+
+    def test_cr_nul_boundary_quirk_false(self):
+        """Q1 SSH: CR NUL at the boundary — NUL joins the password, auth fails.
+
+        Faithful to the pre-G3 SSH behaviour (no CR NUL convention); SSH
+        clients never send CR NUL so this only pins the quirk split.
+        """
+        (auth_ok, _), _ = self._login(b"admin\r\x00secret\r", nul_resets_skip_lf=False)
+        self.assertFalse(auth_ok)
+
+    def test_cr_data_boundary(self):
+        """CR + regular byte at the boundary: the byte joins the password."""
+        (auth_ok, _), _ = self._login(b"admin\rXsecret\r", nul_resets_skip_lf=True)
+        self.assertFalse(auth_ok)  # password read as "Xsecret"
+
+    def test_prompts_and_password_not_echoed(self):
+        """Prompts are sent; username echoes, password does not."""
+        (auth_ok, _), transport = self._login(b"admin\rsecret\r", nul_resets_skip_lf=False)
+        self.assertTrue(auth_ok)
+        sent = b"".join(transport.sent)
+        self.assertIn(b"Username: ", sent)
+        self.assertIn(b"Password: ", sent)
+        self.assertIn(b"admin", sent.replace(b"Username: ", b""))  # echoed per byte
+        self.assertNotIn(b"secret", sent)
+
+    def test_prompt_send_error_propagates(self):
+        """Prompt send errors propagate to the caller (caller wraps)."""
+        transport = FakeTransport(_bytes_script(b"admin\r"))
+        transport.send_errors = [OSError("reset")]
+        with self.assertRaises(OSError):
+            interactive_login(
+                transport,
+                "admin",
+                "secret",
+                user_prompt=b"Username: ",
+                pass_prompt=b"Password: ",
+            )

--- a/tests/plugins/test_tap_bridge.py
+++ b/tests/plugins/test_tap_bridge.py
@@ -339,3 +339,66 @@ class InteractiveLoginTest(unittest.TestCase):
                 user_prompt=b"Username: ",
                 pass_prompt=b"Password: ",
             )
+
+    def test_exact_credential_then_eof_authenticates(self):
+        """U4 pin: exact credential + abrupt disconnect (no terminator) authenticates.
+
+        read_line cannot distinguish a terminated line from a truncated one,
+        so this matches — the pre-G3 SSH behaviour, kept for equivalence.
+        The connection still tears down right after via the taps' EOF path.
+        """
+        (auth_ok, skip_lf), _ = self._login(b"admin\rsecret", nul_resets_skip_lf=False)
+        self.assertTrue(auth_ok)
+        self.assertFalse(skip_lf)
+
+    def test_truncated_credential_then_eof_fails(self):
+        """U4 pin: a truncated credential fails the comparison."""
+        (auth_ok, _), _ = self._login(b"admin\rsecr", nul_resets_skip_lf=False)
+        self.assertFalse(auth_ok)
+
+
+class LoginToTapBoundaryTest(unittest.TestCase):
+    """Password→tap boundary pins (G3 design acceptance: 3 patterns × both quirks).
+
+    Wires interactive_login's returned skip_lf into client_to_shell_tap
+    (initial_skip_lf) on the same transport — mirroring connection_function —
+    and asserts the password line's CR follower is consumed/kept correctly
+    by the tap. Complements InteractiveLoginTest, which covers the
+    username→password boundary.
+    """
+
+    def _run(self, data: bytes, *, nul_resets_skip_lf: bool) -> list[str]:
+        transport = FakeTransport(_bytes_script(data), nul_resets_skip_lf=nul_resets_skip_lf)
+        auth_ok, skip_lf = interactive_login(
+            transport,
+            "admin",
+            "secret",
+            user_prompt=b"Username: ",
+            pass_prompt=b"Password: ",
+        )
+        self.assertTrue(auth_ok)
+        shell_stdin = Mock()
+        ev, run_srv = _events()
+        client_to_shell_tap(transport, shell_stdin, ev, run_srv, initial_skip_lf=skip_lf)
+        return [c.args[0] for c in shell_stdin.write.call_args_list]
+
+    def test_password_cr_lf_boundary(self):
+        """CR LF: the trailing LF is consumed by the tap via initial_skip_lf (both quirks)."""
+        for quirk in (False, True):
+            with self.subTest(nul_resets_skip_lf=quirk):
+                writes = self._run(b"admin\r\nsecret\r\ncmd\n", nul_resets_skip_lf=quirk)
+                self.assertEqual(writes, ["cmd\n"])
+
+    def test_password_cr_nul_lf_boundary_quirk_split(self):
+        """CR NUL LF: quirk True treats LF as a new line, quirk False consumes it."""
+        writes_telnet = self._run(b"admin\r\nsecret\r\x00\ncmd\n", nul_resets_skip_lf=True)
+        self.assertEqual(writes_telnet, ["\n", "cmd\n"])
+        writes_ssh = self._run(b"admin\r\nsecret\r\x00\ncmd\n", nul_resets_skip_lf=False)
+        self.assertEqual(writes_ssh, ["cmd\n"])
+
+    def test_password_cr_data_boundary(self):
+        """CR + regular byte: the byte reaches the shell as line data (both quirks)."""
+        for quirk in (False, True):
+            with self.subTest(nul_resets_skip_lf=quirk):
+                writes = self._run(b"admin\r\nsecret\rXcmd\n", nul_resets_skip_lf=quirk)
+                self.assertEqual(writes, ["Xcmd\n"])

--- a/tests/plugins/test_telnet_server.py
+++ b/tests/plugins/test_telnet_server.py
@@ -12,7 +12,7 @@ from unittest.mock import MagicMock
 from simnos.core.pydantic_models import ModelSimnosInventory
 from simnos.core.timeouts import SHUTDOWN_IO_TIMEOUT
 from simnos.plugins.servers import servers_plugins
-from simnos.plugins.servers.tap_bridge import client_to_shell_tap, shell_to_client_tap
+from simnos.plugins.servers.tap_bridge import client_to_shell_tap, read_line, shell_to_client_tap
 from simnos.plugins.servers.telnet_server import (
     DO,
     DONT,
@@ -181,24 +181,31 @@ class HandleNegotiationTest(unittest.TestCase):
 
 
 class AuthenticateTest(unittest.TestCase):
-    """Test cases for TelnetServer._authenticate()."""
+    """Test cases for TelnetServer._authenticate() (interactive_login wrapper).
+
+    Since PR2 (#225) _authenticate returns (authenticated, skip_lf): the
+    trailing LF/NUL after the password line's CR is reported via skip_lf
+    instead of being consumed with a blocking read (U3).
+    """
 
     def setUp(self):
         self.server = _make_server(username="admin", password="secret")
 
     def test_authenticate_success(self):
-        """Correct credentials return True."""
+        """Correct credentials return (True, skip_lf=True after a CR-terminated password)."""
         sock = MagicMock(spec=socket.socket)
         sock.recv.side_effect = [bytes([b]) for b in b"admin\r\n"] + [bytes([b]) for b in b"secret\r\n"]
-        result = self.server._authenticate(sock)
-        self.assertTrue(result)
+        auth_ok, skip_lf = self.server._authenticate(sock)
+        self.assertTrue(auth_ok)
+        # U3: the final \n is NOT consumed here — reported for the tap to skip
+        self.assertTrue(skip_lf)
 
     def test_authenticate_failure(self):
-        """Wrong credentials return False."""
+        """Wrong credentials return (False, skip_lf)."""
         sock = MagicMock(spec=socket.socket)
         sock.recv.side_effect = [bytes([b]) for b in b"admin\r\n"] + [bytes([b]) for b in b"wrong\r\n"]
-        result = self.server._authenticate(sock)
-        self.assertFalse(result)
+        auth_ok, _skip_lf = self.server._authenticate(sock)
+        self.assertFalse(auth_ok)
 
     def test_authenticate_echo_disabled_for_password(self):
         """Password input should not be echoed back."""
@@ -215,31 +222,52 @@ class AuthenticateTest(unittest.TestCase):
 
 
 class ReadLineTest(unittest.TestCase):
-    """Test cases for TelnetServer._read_line() line termination."""
+    """Line-termination pins for the shared read_line via TelnetSocketAdapter.
+
+    Replaces the former TelnetServer._read_line tests. U3 changed the CR
+    follower handling: the LF/NUL after a CR is no longer consumed with a
+    blocking read inside the call — it is consumed by the NEXT read_line
+    call via skip_lf propagation (boundary patterns pinned per the G3
+    design: CR LF / CR NUL / CR + regular byte).
+    """
 
     def setUp(self):
         self.server = _make_server()
 
-    def test_read_line_cr_lf(self):
-        """CR LF terminates the line, consuming the LF."""
+    def _adapter(self, input_bytes: bytes) -> TelnetSocketAdapter:
         sock = MagicMock(spec=socket.socket)
-        sock.recv.side_effect = [bytes([b]) for b in b"hi\r\n"]
-        result = self.server._read_line(sock, echo=False)
-        self.assertEqual(result, "hi")
+        sock.recv.side_effect = [bytes([b]) for b in input_bytes]
+        return TelnetSocketAdapter(sock, self.server)
 
-    def test_read_line_cr_nul(self):
-        """CR NUL (RFC 854) terminates the line, consuming the NUL."""
-        sock = MagicMock(spec=socket.socket)
-        sock.recv.side_effect = [bytes([b]) for b in b"hi\r\x00"]
-        result = self.server._read_line(sock, echo=False)
-        self.assertEqual(result, "hi")
+    def test_read_line_cr_lf_boundary(self):
+        """CR LF across a boundary: LF is consumed by the next call via skip_lf."""
+        adapter = self._adapter(b"hi\r\nok\r")
+        line, skip_lf = read_line(adapter, echo=False)
+        self.assertEqual((line, skip_lf), ("hi", True))
+        line, skip_lf = read_line(adapter, echo=False, skip_lf=skip_lf)
+        self.assertEqual((line, skip_lf), ("ok", True))
+
+    def test_read_line_cr_nul_boundary(self):
+        """CR NUL (RFC 854): NUL is consumed by the next call (nul_resets_skip_lf=True)."""
+        adapter = self._adapter(b"hi\r\x00ok\r")
+        line, skip_lf = read_line(adapter, echo=False)
+        self.assertEqual((line, skip_lf), ("hi", True))
+        line, skip_lf = read_line(adapter, echo=False, skip_lf=skip_lf)
+        self.assertEqual((line, skip_lf), ("ok", True))
+
+    def test_read_line_cr_then_data_boundary(self):
+        """CR followed by a regular byte: the byte belongs to the next line."""
+        adapter = self._adapter(b"hi\rXok\n")
+        line, skip_lf = read_line(adapter, echo=False)
+        self.assertEqual((line, skip_lf), ("hi", True))
+        line, skip_lf = read_line(adapter, echo=False, skip_lf=skip_lf)
+        self.assertEqual((line, skip_lf), ("Xok", False))
 
     def test_read_line_bare_lf(self):
-        """Bare LF terminates the line."""
-        sock = MagicMock(spec=socket.socket)
-        sock.recv.side_effect = [bytes([b]) for b in b"hi\n"]
-        result = self.server._read_line(sock, echo=False)
-        self.assertEqual(result, "hi")
+        """Bare LF terminates the line with no pending skip_lf."""
+        adapter = self._adapter(b"hi\n")
+        line, skip_lf = read_line(adapter, echo=False)
+        self.assertEqual((line, skip_lf), ("hi", False))
 
 
 class PluginRegistrationTest(unittest.TestCase):


### PR DESCRIPTION
🐙claude: Closes #225 (PR2/2、PR1 = #226 merge 済)。棚卸し G3 group の P-5 を解消し G3 完結。

## 概要

`_read_channel_line` (SSH) / `_read_line` (Telnet) と `_channel_login` / `_authenticate` の重複を、tap_bridge の共通 `read_line` / `interactive_login` に統一。server 側は prompt 文字列を供給する thin wrapper のみ残す。

## 挙動統一 (設計確定済、いずれも pin 付き)

- **U3**: Telnet の CR 後続 LF/NUL 消費を「blocking 1 byte read」→「skip_lf 伝搬」(SSH #88 方式) に統一。`_authenticate` が `(auth_ok, skip_lf)` を返し、connection_function が `initial_skip_lf` として tap へ配線
- **U4**: `read_line` の recv io_errors / EOF は partial line を返す方式に統一 (旧 Telnet は caller へ伝播)。**注**: 戻り値は終端有無を区別しないため「正確な credential + 終端なし切断」は auth 成功する — 旧 SSH と同一挙動 (equivalence のため維持、test で pin。接続は tap の EOF 経路で直後に close)
- **Q1**: skip_lf 状態の NUL は `nul_resets_skip_lf=True` (Telnet、RFC 854) のみ消費。mid-line NUL は両 transport とも buffer 保持 (auth-bypass 防止 pin 温存)
- **timeout 責務**: caller (connection_function) に集約。SSH の settimeout を channel login 前に前倒し、SSH caller に例外 wrap を新設 (設計の caller-wrap 契約)

## SSH 側は挙動変化ゼロ

旧 `_read_channel_line` と共通 `read_line` は byte 単位で等価 (cross-review で照合済)。挙動が変わるのは Telnet 側のみ (U3/U4、いずれも SSH への統一)。

## テスト

- `ReadLinePolicyTest` (skip_lf 4 ケース + 例外 4 ケース) / `InteractiveLoginTest` (username 境界 3 パターン × 両 quirk + EOF 挙動 pin) / `LoginToTapBoundaryTest` (**password→tap 境界**を実配線で 3 パターン × 両 quirk pin)
- 既存 ReadLine / Authenticate 系は新仕様 (tuple 戻り値) にアサーション書き換え、判定本体は温存
- SSH connection_function の caller-wrap pin 追加

## 検証

- ruff / yamllint / ty 全 green
- pytest **808 passed + 10 subtests** (+25 新規 vs PR1 後)
- `invoke netmiko-check cisco_ios` → OK、telnet E2E green
- cross-review (codex / gemini / claude) 1 round: claude LGTM / gemini SUGGESTION / codex SHOULD FIX 2 件 → 全件取り込み済 (U4 docstring 訂正 + boundary pin 補強)

## merge 前の推奨 gate

- [ ] compatibility workflow (netmiko / scrapli / ansible) を本 branch で手動 dispatch

🤖 Generated with [Claude Code](https://claude.com/claude-code)