### PR TITLE
refactor: tap-loop test の run_srv fuel pattern を intent-based helper に統一 (#228)

### DIFF
--- a/tests/plugins/tap_test_helpers.py
+++ b/tests/plugins/tap_test_helpers.py
@@ -1,0 +1,43 @@
+"""run_srv mock constructors for the tap-loop tests (T-9 / #228).
+
+Default idiom: data sources (recv / readline scripts) are finite and
+EOF-terminated, so the tap loops exit via their EOF path and run_srv can
+stay live for the whole test — loop-internal is_set() consumption counts
+are NOT part of the test contract. Use countdown_run_srv() ONLY when the
+run_srv-cleared exit path itself is the behaviour under test.
+"""
+
+from itertools import chain, repeat
+from unittest.mock import Mock
+
+__all__ = ["countdown_run_srv", "live_run_srv"]
+
+
+def live_run_srv() -> Mock:
+    """run_srv that stays set; the loop must exit via data-source EOF.
+
+    A loop regression that ignores EOF exhausts the source's side_effect
+    script and fails visibly with StopIteration — no watchdog fuel needed.
+    """
+    run_srv = Mock()
+    run_srv.is_set.return_value = True
+    return run_srv
+
+
+def countdown_run_srv(true_count: int) -> Mock:
+    """run_srv whose is_set() returns True *true_count* times, then False forever.
+
+    For shutdown-path pins only: the test asserts the loop exits because
+    run_srv was cleared, so the True-count is part of the test's intent.
+    true_count=0 means "already shut down before the first check".
+    Callers MUST document the consumption mapping (which is_set() call gets
+    the first False) in the test docstring, and MUST assert an observable
+    invariant for the exit position — loop changes still require updating
+    *true_count* by hand, which is acceptable only because these tests pin
+    the shutdown path itself.
+    """
+    if true_count < 0:
+        raise ValueError(f"true_count must be >= 0, got {true_count}")
+    run_srv = Mock()
+    run_srv.is_set.side_effect = chain(repeat(True, true_count), repeat(False))
+    return run_srv

--- a/tests/plugins/test_ssh_server_paramiko.py
+++ b/tests/plugins/test_ssh_server_paramiko.py
@@ -24,6 +24,7 @@ from simnos.plugins.servers.ssh_server_paramiko import (
 )
 from simnos.plugins.servers.tap_bridge import client_to_shell_tap, read_line, shell_to_client_tap
 from simnos.plugins.servers.tap_io import TapIO
+from tests.plugins.tap_test_helpers import countdown_run_srv, live_run_srv
 
 
 class ParamikoSshServerInterfaceTest(unittest.TestCase):
@@ -326,11 +327,12 @@ class ChannelToShellTapTest(unittest.TestCase):
         self.adapter = ParamikoChannelAdapter(self.mock_channel)
         self.mock_shell_stdin: Mock = Mock()
         self.mock_shell_replied_event: Mock = Mock()
-        self.mock_run_srv: Mock = Mock()
+        # T-9 default: run_srv stays live, loops exit via the recv script's EOF.
+        self.mock_run_srv: Mock = live_run_srv()
 
     def test_client_to_shell_tap_received_byte(self):
         """Check that client_to_shell_tap receives a byte via channel.recv."""
-        self.mock_run_srv.is_set.side_effect = [True] * 10 + [False]
+        self.mock_channel.recv.side_effect = [b"b", b""]
         client_to_shell_tap(
             transport=self.adapter,
             shell_stdin=self.mock_shell_stdin,
@@ -341,7 +343,7 @@ class ChannelToShellTapTest(unittest.TestCase):
 
     def test_client_to_shell_tap_shell_replied_event_wait(self):
         """Check that client_to_shell_tap waits for the shell_replied_event."""
-        self.mock_run_srv.is_set.side_effect = [True] * 10 + [False]
+        self.mock_channel.recv.side_effect = [b"b", b""]
         client_to_shell_tap(
             transport=self.adapter,
             shell_stdin=self.mock_shell_stdin,
@@ -360,8 +362,9 @@ class ChannelToShellTapTest(unittest.TestCase):
             shell_replied_event=self.mock_shell_replied_event,
             run_srv=self.mock_run_srv,
         )
-        # while loop + run_srv guard = 2 calls
-        self.assertEqual(self.mock_run_srv.is_set.call_count, 2)
+        # Breaks at is_closed() before echoing or buffering the byte
+        self.mock_channel.sendall.assert_not_called()
+        self.mock_shell_stdin.write.assert_not_called()
         self.mock_run_srv.clear.assert_called_once()
 
     def test_client_to_shell_tap_break_loop_when_channel_closed_but_active(self):
@@ -395,8 +398,10 @@ class ChannelToShellTapTest(unittest.TestCase):
             shell_replied_event=self.mock_shell_replied_event,
             run_srv=self.mock_run_srv,
         )
-        # 2 calls: while loop condition + run_srv guard after interruptible wait
-        self.assertEqual(self.mock_run_srv.is_set.call_count, 2)
+        # Echo send raised: the byte reached sendall, never the shell.
+        self.mock_channel.sendall.assert_called_once_with(b"b")
+        self.mock_shell_stdin.write.assert_not_called()
+        self.mock_run_srv.clear.assert_called_once()
 
     def test_client_to_shell_tap_break_loop_if_eof_error(self):
         """Check that client_to_shell_tap breaks the loop if an EOFError occurs."""
@@ -407,8 +412,10 @@ class ChannelToShellTapTest(unittest.TestCase):
             shell_replied_event=self.mock_shell_replied_event,
             run_srv=self.mock_run_srv,
         )
-        # 2 calls: while loop condition + run_srv guard after interruptible wait
-        self.assertEqual(self.mock_run_srv.is_set.call_count, 2)
+        # Echo send raised: the byte reached sendall, never the shell.
+        self.mock_channel.sendall.assert_called_once_with(b"b")
+        self.mock_shell_stdin.write.assert_not_called()
+        self.mock_run_srv.clear.assert_called_once()
 
     def test_client_to_shell_tap_break_loop_if_ssh_exception(self):
         """SSHException on sendall should break the loop (#85)."""
@@ -419,13 +426,14 @@ class ChannelToShellTapTest(unittest.TestCase):
             shell_replied_event=self.mock_shell_replied_event,
             run_srv=self.mock_run_srv,
         )
-        # 2 calls: while loop condition + run_srv guard after interruptible wait
-        self.assertEqual(self.mock_run_srv.is_set.call_count, 2)
+        # Echo send raised: the byte reached sendall, never the shell.
+        self.mock_channel.sendall.assert_called_once_with(b"b")
+        self.mock_shell_stdin.write.assert_not_called()
+        self.mock_run_srv.clear.assert_called_once()
 
     def test_client_to_shell_tap_recv_ssh_exception_breaks(self):
         """SSHException on recv should break the tap loop (#85)."""
         self.mock_channel.recv.side_effect = paramiko.SSHException("Transport closed")
-        self.mock_run_srv.is_set.return_value = True
         client_to_shell_tap(
             transport=self.adapter,
             shell_stdin=self.mock_shell_stdin,
@@ -437,7 +445,6 @@ class ChannelToShellTapTest(unittest.TestCase):
 
     def test_client_to_shell_tap_byte_return_character(self):
         """CRLF should be treated as a single line terminator (skip_lf consumes LF)."""
-        self.mock_run_srv.is_set.side_effect = [True] * 4 + [False]
         self.mock_channel.recv.side_effect = [b"\r", b"\n", b""]
         client_to_shell_tap(
             transport=self.adapter,
@@ -453,7 +460,6 @@ class ChannelToShellTapTest(unittest.TestCase):
 
     def test_client_to_shell_tap_crlf_single_line(self):
         """CRLF after data should produce one line, not two."""
-        self.mock_run_srv.is_set.side_effect = [True] * 6 + [False]
         self.mock_channel.recv.side_effect = [b"h", b"i", b"\r", b"\n", b""]
         client_to_shell_tap(
             transport=self.adapter,
@@ -466,7 +472,6 @@ class ChannelToShellTapTest(unittest.TestCase):
 
     def test_client_to_shell_tap_cr_nul_lf_keeps_skip_lf(self):
         """SSH NUL does not reset skip_lf (unlike Telnet CR NUL)."""
-        self.mock_run_srv.is_set.side_effect = [True] * 6 + [False]
         self.mock_channel.recv.side_effect = [b"a", b"\r", b"\x00", b"\n", b""]
         client_to_shell_tap(
             transport=self.adapter,
@@ -478,7 +483,6 @@ class ChannelToShellTapTest(unittest.TestCase):
 
     def test_client_to_shell_tap_cr_followed_by_data(self):
         """CR followed by non-LF data should produce two lines."""
-        self.mock_run_srv.is_set.side_effect = [True] * 8 + [False]
         self.mock_channel.recv.side_effect = [b"x", b"\r", b"y", b"\n", b""]
         client_to_shell_tap(
             transport=self.adapter,
@@ -491,7 +495,6 @@ class ChannelToShellTapTest(unittest.TestCase):
 
     def test_client_to_shell_tap_initial_skip_lf(self):
         """initial_skip_lf=True should consume a leading LF."""
-        self.mock_run_srv.is_set.side_effect = [True] * 5 + [False]
         self.mock_channel.recv.side_effect = [b"\n", b"a", b"\r", b""]
         client_to_shell_tap(
             transport=self.adapter,
@@ -504,8 +507,7 @@ class ChannelToShellTapTest(unittest.TestCase):
 
     def test_client_to_shell_tap_nul_bytes_are_dropped(self):
         """NUL bytes should be silently dropped (not echoed, not buffered)."""
-        self.mock_run_srv.is_set.side_effect = [True] * 5 + [False]
-        self.mock_channel.recv.side_effect = [b"\x00", b"a", b"\n"]
+        self.mock_channel.recv.side_effect = [b"\x00", b"a", b"\n", b""]
         client_to_shell_tap(
             transport=self.adapter,
             shell_stdin=self.mock_shell_stdin,
@@ -521,7 +523,6 @@ class ChannelToShellTapTest(unittest.TestCase):
 
     def test_client_to_shell_tap_empty_byte_causes_exit(self):
         """Empty byte (EOF) should cause the loop to exit."""
-        self.mock_run_srv.is_set.side_effect = [True, True]
         self.mock_channel.recv.side_effect = [b"", b"\n"]
         client_to_shell_tap(
             transport=self.adapter,
@@ -534,8 +535,7 @@ class ChannelToShellTapTest(unittest.TestCase):
 
     def test_client_to_shell_tap_byte_return_other(self):
         """Check that client_to_shell_tap echoes bytes via channel.sendall."""
-        self.mock_run_srv.is_set.side_effect = [True] * 6 + [False]
-        self.mock_channel.recv.side_effect = [b"b", b"c", b"\n"]
+        self.mock_channel.recv.side_effect = [b"b", b"c", b"\n", b""]
         client_to_shell_tap(
             transport=self.adapter,
             shell_stdin=self.mock_shell_stdin,
@@ -549,8 +549,13 @@ class ChannelToShellTapTest(unittest.TestCase):
         self.assertEqual(self.mock_shell_stdin.write.call_count, 1)
 
     def test_client_to_shell_tap_exit_run_srv(self):
-        """Check that client_to_shell_tap exits the run_srv."""
-        self.mock_run_srv.is_set.side_effect = [True, False]
+        """run_srv cleared after one NUL byte: the loop exits without echoing.
+
+        countdown(1): the loop head consumes the True (the NUL is dropped
+        before the shell-wait guard); the second loop head gets the first
+        False.
+        """
+        self.mock_run_srv = countdown_run_srv(1)
         self.mock_channel.recv.side_effect = [b"\x00"]
         client_to_shell_tap(
             transport=self.adapter,
@@ -558,27 +563,27 @@ class ChannelToShellTapTest(unittest.TestCase):
             shell_replied_event=self.mock_shell_replied_event,
             run_srv=self.mock_run_srv,
         )
-        self.assertEqual(self.mock_run_srv.is_set.call_count, 2)
         self.assertEqual(self.mock_channel.recv.call_count, 1)
+        self.mock_channel.sendall.assert_not_called()
+        self.mock_run_srv.clear.assert_called_once()
 
     def test_client_to_shell_tap_timeout_error_continues_loop(self):
         """TimeoutError on recv() should be caught and the loop should continue."""
-        self.mock_run_srv.is_set.side_effect = [True] * 4 + [False]
-        self.mock_channel.recv.side_effect = [TimeoutError, b"a", b"\x00"]
+        self.mock_channel.recv.side_effect = [TimeoutError, b"a", b"\x00", b""]
         client_to_shell_tap(
             transport=self.adapter,
             shell_stdin=self.mock_shell_stdin,
             shell_replied_event=self.mock_shell_replied_event,
             run_srv=self.mock_run_srv,
         )
-        # recv called 3 times: TimeoutError, b"a", b"\x00"
-        self.assertEqual(self.mock_channel.recv.call_count, 3)
+        # recv called 4 times: TimeoutError, b"a", b"\x00", b"" (EOF) —
+        # the timeout did not abort the loop.
+        self.assertEqual(self.mock_channel.recv.call_count, 4)
         # b"a" should be echoed back
         self.mock_channel.sendall.assert_any_call(b"a")
 
     def test_client_to_shell_tap_shell_stdout_receives_echo(self):
         """When shell_stdout is provided, newline echo goes to shell_stdout, not channel (#96)."""
-        self.mock_run_srv.is_set.side_effect = [True] * 4 + [False]
         self.mock_channel.recv.side_effect = [b"\r", b"\n", b""]
         mock_shell_stdout: Mock = Mock()
         client_to_shell_tap(
@@ -593,7 +598,6 @@ class ChannelToShellTapTest(unittest.TestCase):
 
     def test_client_to_shell_tap_shell_stdout_data_then_newline(self):
         """With shell_stdout, regular bytes echo to channel; only newline goes to shell_stdout (#96)."""
-        self.mock_run_srv.is_set.side_effect = [True] * 6 + [False]
         self.mock_channel.recv.side_effect = [b"a", b"\r", b"\n", b""]
         mock_shell_stdout: Mock = Mock()
         client_to_shell_tap(
@@ -608,7 +612,6 @@ class ChannelToShellTapTest(unittest.TestCase):
 
     def test_client_to_shell_tap_no_shell_stdout_echo_to_channel(self):
         """When shell_stdout is None (default), newline echo goes to channel.sendall (#96)."""
-        self.mock_run_srv.is_set.side_effect = [True] * 4 + [False]
         self.mock_channel.recv.side_effect = [b"\r", b"\n", b""]
         client_to_shell_tap(
             transport=self.adapter,
@@ -620,7 +623,6 @@ class ChannelToShellTapTest(unittest.TestCase):
 
     def test_client_to_shell_tap_shell_stdout_event_clear_order(self):
         """shell_replied_event.clear() is called after shell_stdin.write, with shell_stdout (#96)."""
-        self.mock_run_srv.is_set.side_effect = [True] * 4 + [False]
         self.mock_channel.recv.side_effect = [b"\r", b"\n", b""]
         mock_shell_stdout: Mock = Mock()
         call_order: list[str] = []
@@ -652,7 +654,8 @@ class ShellToChannelTapTest(unittest.TestCase):
         self.mock_shell_stdout: Mock = Mock()
         self.mock_shell_stdout.drain.return_value = []
         self.mock_shell_replied_event: Mock = Mock()
-        self.mock_run_srv: Mock = Mock()
+        # T-9 default: run_srv stays live, loops exit via readline's "" EOF.
+        self.mock_run_srv: Mock = live_run_srv()
 
     def test_shell_to_client_tap_channel_closed(self):
         """Check that shell_to_client_tap exits when channel.closed is True."""
@@ -663,7 +666,8 @@ class ShellToChannelTapTest(unittest.TestCase):
             shell_replied_event=self.mock_shell_replied_event,
             run_srv=self.mock_run_srv,
         )
-        self.mock_run_srv.is_set.assert_called_once()
+        self.mock_channel.sendall.assert_not_called()
+        self.mock_run_srv.clear.assert_called_once()
 
     def test_shell_to_client_tap_shell_stdout_readline_return_none(self):
         """
@@ -677,7 +681,8 @@ class ShellToChannelTapTest(unittest.TestCase):
             run_srv=self.mock_run_srv,
         )
         self.mock_shell_stdout.readline.assert_called_once()
-        self.mock_run_srv.is_set.assert_called_once()
+        self.mock_channel.sendall.assert_not_called()
+        self.mock_run_srv.clear.assert_called_once()
 
     def test_shell_to_client_tap_shell_stdout_readline_return_carry_return(self):
         """
@@ -687,7 +692,6 @@ class ShellToChannelTapTest(unittest.TestCase):
         second readline is performed to wait for the prompt so they are
         sent together in one sendall().
         """
-        self.mock_run_srv.is_set.side_effect = [True] * 10 + [False]
         self.mock_shell_stdout.readline.side_effect = ["\r\n", "Router>", ""]
         shell_to_client_tap(
             transport=self.adapter,
@@ -701,7 +705,6 @@ class ShellToChannelTapTest(unittest.TestCase):
         """
         Check that LF echo triggers a second readline and LF is converted to CRLF.
         """
-        self.mock_run_srv.is_set.side_effect = [True] * 10 + [False]
         self.mock_shell_stdout.readline.side_effect = ["\n", "Router>", ""]
         shell_to_client_tap(
             transport=self.adapter,
@@ -715,15 +718,13 @@ class ShellToChannelTapTest(unittest.TestCase):
         """
         Check that shell_to_client_tap sends data via channel.sendall.
         """
-        self.mock_run_srv.is_set.side_effect = [True, True, True, False]
-        self.mock_shell_stdout.readline.return_value = "b"
+        self.mock_shell_stdout.readline.side_effect = ["b", ""]
         shell_to_client_tap(
             transport=self.adapter,
             shell_stdout=self.mock_shell_stdout,
             shell_replied_event=self.mock_shell_replied_event,
             run_srv=self.mock_run_srv,
         )
-        self.mock_shell_stdout.readline.assert_called_once()
         self.mock_channel.sendall.assert_called_once_with(b"b")
 
     def test_shell_to_client_tap_socket_error(self):
@@ -736,8 +737,10 @@ class ShellToChannelTapTest(unittest.TestCase):
             shell_replied_event=self.mock_shell_replied_event,
             run_srv=self.mock_run_srv,
         )
-        # Called twice: outer loop check + inner retry loop check
-        self.assertEqual(self.mock_run_srv.is_set.call_count, 2)
+        # Batch send raised: nothing was delivered, the reply flag stays unset.
+        self.mock_channel.sendall.assert_called_once()
+        self.mock_shell_replied_event.set.assert_not_called()
+        self.mock_run_srv.clear.assert_called_once()
 
     def test_shell_to_client_tap_ssh_exception(self):
         """Check that shell_to_client_tap breaks the loop if SSHException occurs (#85)."""
@@ -749,13 +752,14 @@ class ShellToChannelTapTest(unittest.TestCase):
             shell_replied_event=self.mock_shell_replied_event,
             run_srv=self.mock_run_srv,
         )
-        # Called twice: outer loop check + inner retry loop check
-        self.assertEqual(self.mock_run_srv.is_set.call_count, 2)
+        # Batch send raised: nothing was delivered, the reply flag stays unset.
+        self.mock_channel.sendall.assert_called_once()
+        self.mock_shell_replied_event.set.assert_not_called()
+        self.mock_run_srv.clear.assert_called_once()
 
     def test_shell_to_client_tap_set_replied_flag(self):
         """Check that shell_to_client_tap sets the replied flag."""
-        self.mock_run_srv.is_set.side_effect = [True, True, True, False]
-        self.mock_shell_stdout.readline.return_value = "b"
+        self.mock_shell_stdout.readline.side_effect = ["b", ""]
         shell_to_client_tap(
             transport=self.adapter,
             shell_stdout=self.mock_shell_stdout,
@@ -765,8 +769,15 @@ class ShellToChannelTapTest(unittest.TestCase):
         self.mock_shell_replied_event.set.assert_called_once()
 
     def test_shell_to_client_tap_exit_run_srv(self):
-        """Check that shell_to_client_tap exits the run_srv."""
-        self.mock_run_srv.is_set.side_effect = [True, True, True, False]
+        """One batch is sent, then run_srv is cleared and the loop exits.
+
+        countdown(3) bookkeeping for the current loop shape: outer head,
+        retry entry and the post-send retry re-check consume the Trues; the
+        second outer head gets the first False. The contract pinned here is
+        only "one batch sent, then shutdown" — the D11 send-gate structure
+        itself is pinned by the policy tests in test_tap_bridge.py.
+        """
+        self.mock_run_srv = countdown_run_srv(3)
         self.mock_shell_stdout.readline.return_value = "b"
         shell_to_client_tap(
             transport=self.adapter,
@@ -774,8 +785,9 @@ class ShellToChannelTapTest(unittest.TestCase):
             shell_replied_event=self.mock_shell_replied_event,
             run_srv=self.mock_run_srv,
         )
-        # 4 calls: outer(True), inner enter(True), inner exit recheck(True), outer exit(False)
-        self.assertEqual(self.mock_run_srv.is_set.call_count, 4)
+        self.mock_channel.sendall.assert_called_once_with(b"b")
+        self.mock_shell_replied_event.set.assert_called_once()
+        self.mock_run_srv.clear.assert_called_once()
 
 
 class ParamikoSshServerTest(unittest.TestCase):

--- a/tests/plugins/test_ssh_server_paramiko.py
+++ b/tests/plugins/test_ssh_server_paramiko.py
@@ -553,7 +553,8 @@ class ChannelToShellTapTest(unittest.TestCase):
 
         countdown(1): the loop head consumes the True (the NUL is dropped
         before the shell-wait guard); the second loop head gets the first
-        False.
+        False. No EOF tail: a mistuned countdown fails visibly with
+        StopIteration.
         """
         self.mock_run_srv = countdown_run_srv(1)
         self.mock_channel.recv.side_effect = [b"\x00"]

--- a/tests/plugins/test_ssh_server_paramiko.py
+++ b/tests/plugins/test_ssh_server_paramiko.py
@@ -523,7 +523,7 @@ class ChannelToShellTapTest(unittest.TestCase):
 
     def test_client_to_shell_tap_empty_byte_causes_exit(self):
         """Empty byte (EOF) should cause the loop to exit."""
-        self.mock_channel.recv.side_effect = [b"", b"\n"]
+        self.mock_channel.recv.side_effect = [b""]
         client_to_shell_tap(
             transport=self.adapter,
             shell_stdin=self.mock_shell_stdin,
@@ -738,7 +738,7 @@ class ShellToChannelTapTest(unittest.TestCase):
             run_srv=self.mock_run_srv,
         )
         # Batch send raised: nothing was delivered, the reply flag stays unset.
-        self.mock_channel.sendall.assert_called_once()
+        self.mock_channel.sendall.assert_called_once_with(b"b")
         self.mock_shell_replied_event.set.assert_not_called()
         self.mock_run_srv.clear.assert_called_once()
 
@@ -753,7 +753,7 @@ class ShellToChannelTapTest(unittest.TestCase):
             run_srv=self.mock_run_srv,
         )
         # Batch send raised: nothing was delivered, the reply flag stays unset.
-        self.mock_channel.sendall.assert_called_once()
+        self.mock_channel.sendall.assert_called_once_with(b"b")
         self.mock_shell_replied_event.set.assert_not_called()
         self.mock_run_srv.clear.assert_called_once()
 

--- a/tests/plugins/test_tap_bridge.py
+++ b/tests/plugins/test_tap_bridge.py
@@ -26,6 +26,7 @@ from simnos.plugins.servers.tap_bridge import (
     read_line,
     shell_to_client_tap,
 )
+from tests.plugins.tap_test_helpers import countdown_run_srv, live_run_srv
 
 
 class FakeTransport:
@@ -64,16 +65,15 @@ def _bytes_script(data: bytes) -> list[bytes]:
     return [bytes([b]) for b in data]
 
 
-def _events(is_set_fuel=None):
-    """Build (shell_replied_event, run_srv) mocks. wait() returns True."""
+def _events(run_srv=None):
+    """Build (shell_replied_event, run_srv) mocks. wait() returns True.
+
+    *run_srv* defaults to live_run_srv() (T-9 idiom: the loop exits via
+    data-source EOF); shutdown-path pins pass countdown_run_srv(n).
+    """
     shell_replied_event = Mock()
     shell_replied_event.wait.return_value = True
-    run_srv = Mock()
-    if is_set_fuel is not None:
-        run_srv.is_set.side_effect = is_set_fuel
-    else:
-        run_srv.is_set.return_value = True
-    return shell_replied_event, run_srv
+    return shell_replied_event, run_srv if run_srv is not None else live_run_srv()
 
 
 class ClientToShellTapQuirkTest(unittest.TestCase):
@@ -186,8 +186,9 @@ class ShellToClientTapPolicyTest(unittest.TestCase):
         """D11: if run_srv is cleared before the send attempt, nothing is sent."""
         transport = FakeTransport()
         shell_stdout = self._stdout(["hello\r\n", ""])
-        # outer loop True, retry-loop gate False
-        ev, run_srv = _events([True, False])
+        # countdown(1): outer loop head consumes the True, the retry-loop
+        # gate gets the first False — the send attempt must not happen.
+        ev, run_srv = _events(countdown_run_srv(1))
         shell_to_client_tap(transport, shell_stdout, ev, run_srv)
         self.assertEqual(transport.sent, [])
         ev.set.assert_not_called()
@@ -197,8 +198,9 @@ class ShellToClientTapPolicyTest(unittest.TestCase):
         transport = FakeTransport()
         transport.send_errors = [TimeoutError()]
         shell_stdout = self._stdout(["hello\r\n", ""])
-        # outer True, retry gate True (send raises), retry re-gate False
-        ev, run_srv = _events([True, True, False])
+        # countdown(2): outer head True, retry gate True (send raises),
+        # the retry re-gate gets the first False — no resend after timeout.
+        ev, run_srv = _events(countdown_run_srv(2))
         shell_to_client_tap(transport, shell_stdout, ev, run_srv)
         self.assertEqual(transport.sent, [])
         ev.set.assert_not_called()

--- a/tests/plugins/test_tap_bridge.py
+++ b/tests/plugins/test_tap_bridge.py
@@ -185,7 +185,8 @@ class ShellToClientTapPolicyTest(unittest.TestCase):
     def test_d11_no_send_when_cleared_before_attempt(self):
         """D11: if run_srv is cleared before the send attempt, nothing is sent."""
         transport = FakeTransport()
-        shell_stdout = self._stdout(["hello\r\n", ""])
+        # No EOF tail: a mistuned countdown fails visibly with StopIteration.
+        shell_stdout = self._stdout(["hello\r\n"])
         # countdown(1): outer loop head consumes the True, the retry-loop
         # gate gets the first False — the send attempt must not happen.
         ev, run_srv = _events(countdown_run_srv(1))
@@ -197,7 +198,8 @@ class ShellToClientTapPolicyTest(unittest.TestCase):
         """D11: if run_srv is cleared during a TimeoutError retry, no resend happens."""
         transport = FakeTransport()
         transport.send_errors = [TimeoutError()]
-        shell_stdout = self._stdout(["hello\r\n", ""])
+        # No EOF tail: a mistuned countdown fails visibly with StopIteration.
+        shell_stdout = self._stdout(["hello\r\n"])
         # countdown(2): outer head True, retry gate True (send raises),
         # the retry re-gate gets the first False — no resend after timeout.
         ev, run_srv = _events(countdown_run_srv(2))

--- a/tests/plugins/test_tap_test_helpers.py
+++ b/tests/plugins/test_tap_test_helpers.py
@@ -1,0 +1,45 @@
+"""
+Direct contract pins for tap_test_helpers (T-9 / #228).
+
+The tap-loop tests rely on these helpers indirectly through the current
+loop shapes; these tests pin the helper contracts themselves so a future
+helper change fails here first, not in some consuming loop test.
+"""
+
+import unittest
+
+from tests.plugins.tap_test_helpers import countdown_run_srv, live_run_srv
+
+
+class LiveRunSrvTest(unittest.TestCase):
+    """live_run_srv() must stay set for any number of checks."""
+
+    def test_is_set_returns_true_repeatedly(self):
+        """No hidden countdown: every is_set() call returns True."""
+        run_srv = live_run_srv()
+        self.assertTrue(all(run_srv.is_set() for _ in range(50)))
+
+
+class CountdownRunSrvTest(unittest.TestCase):
+    """countdown_run_srv(n) returns True n times, then False forever."""
+
+    def test_zero_is_false_from_the_first_check(self):
+        """countdown(0) = already shut down before the first check."""
+        run_srv = countdown_run_srv(0)
+        self.assertFalse(run_srv.is_set())
+
+    def test_returns_false_repeatedly_after_exhaustion(self):
+        """After the Trues run out, False keeps coming (no StopIteration).
+
+        Pins the chain(repeat(True, n), repeat(False)) form: loops that
+        re-check is_set() after the first False (e.g. an inner wait guard
+        plus the outer guard) must keep seeing False.
+        """
+        run_srv = countdown_run_srv(2)
+        observed = [run_srv.is_set() for _ in range(5)]
+        self.assertEqual(observed, [True, True, False, False, False])
+
+    def test_negative_true_count_raises_value_error(self):
+        """A negative count is a test bug, not an empty countdown."""
+        with self.assertRaisesRegex(ValueError, r"true_count must be >= 0, got -1"):
+            countdown_run_srv(-1)

--- a/tests/plugins/test_telnet_server.py
+++ b/tests/plugins/test_telnet_server.py
@@ -671,9 +671,10 @@ class SocketToShellTapTest(unittest.TestCase):
         countdown(2): loop head + first inner-wait guard consume the Trues;
         the second inner-wait guard gets the first False (wait() keeps
         timing out), and the post-wait guard sees False again — the byte
-        must not be echoed.
+        must not be echoed. No EOF tail: a mistuned countdown fails
+        visibly with StopIteration.
         """
-        mock_recv.side_effect = [b"a", b"b"]
+        mock_recv.side_effect = [b"a"]
         # wait() returns False (timeout), then run_srv is checked and found False
         self.shell_replied_event.wait.return_value = False
         self.run_srv = countdown_run_srv(2)

--- a/tests/plugins/test_telnet_server.py
+++ b/tests/plugins/test_telnet_server.py
@@ -28,6 +28,7 @@ from simnos.plugins.servers.telnet_server import (
     TelnetSocketAdapter,
     _is_loopback,
 )
+from tests.plugins.tap_test_helpers import countdown_run_srv, live_run_srv
 
 
 def _make_server(**kwargs) -> TelnetServer:
@@ -568,14 +569,14 @@ class SocketToShellTapTest(unittest.TestCase):
         self.shell_stdin = MagicMock()
         self.shell_replied_event = MagicMock()
         self.shell_replied_event.wait.return_value = True
-        self.run_srv = MagicMock()
+        # T-9 default: run_srv stays live, loops exit via the recv script's EOF.
+        self.run_srv = live_run_srv()
 
     @unittest.mock.patch("simnos.plugins.servers.tap_bridge.time.sleep")
     @unittest.mock.patch.object(TelnetServer, "_recv_byte")
     def test_normal_byte_echoed_to_socket(self, mock_recv, _mock_sleep):
         """A normal byte is echoed to the socket and buffered."""
         mock_recv.side_effect = [b"a", None]  # One byte, then EOF
-        self.run_srv.is_set.side_effect = [True, True, True, False]
         client_to_shell_tap(self.adapter, self.shell_stdin, self.shell_replied_event, self.run_srv)
         self.sock.sendall.assert_called_with(b"a")
 
@@ -584,7 +585,6 @@ class SocketToShellTapTest(unittest.TestCase):
     def test_newline_sends_line_to_shell(self, mock_recv, _mock_sleep):
         """Receiving a newline sends the buffered line to the shell and clears replied event."""
         mock_recv.side_effect = [b"h", b"i", b"\r", None]
-        self.run_srv.is_set.side_effect = [True] * 7 + [False]
         client_to_shell_tap(self.adapter, self.shell_stdin, self.shell_replied_event, self.run_srv)
         self.shell_stdin.write.assert_called_once_with("hi\r")
         self.shell_replied_event.clear.assert_called_once()
@@ -596,7 +596,6 @@ class SocketToShellTapTest(unittest.TestCase):
     def test_crlf_sends_single_line_to_shell(self, mock_recv, _mock_sleep):
         """CRLF input: \\r triggers line send, trailing \\n is consumed (RFC 854)."""
         mock_recv.side_effect = [b"h", b"i", b"\r", b"\n", None]
-        self.run_srv.is_set.side_effect = [True] * 10 + [False]
         client_to_shell_tap(self.adapter, self.shell_stdin, self.shell_replied_event, self.run_srv)
         self.shell_stdin.write.assert_called_once_with("hi\r")
 
@@ -605,7 +604,6 @@ class SocketToShellTapTest(unittest.TestCase):
     def test_cr_nul_resets_skip_lf(self, mock_recv, _mock_sleep):
         """CR NUL is a complete sequence (RFC 854); a subsequent LF is a new line."""
         mock_recv.side_effect = [b"a", b"\r", b"\x00", b"\n", None]
-        self.run_srv.is_set.side_effect = [True] * 12 + [False]
         client_to_shell_tap(self.adapter, self.shell_stdin, self.shell_replied_event, self.run_srv)
         self.assertEqual(self.shell_stdin.write.call_count, 2)
         self.shell_stdin.write.assert_any_call("a\r")
@@ -616,7 +614,6 @@ class SocketToShellTapTest(unittest.TestCase):
     def test_cr_followed_by_data_preserves_data(self, mock_recv, _mock_sleep):
         """CR followed by a non-LF byte: line is sent, next byte is not lost."""
         mock_recv.side_effect = [b"x", b"\r", b"y", None]
-        self.run_srv.is_set.side_effect = [True] * 10 + [False]
         client_to_shell_tap(self.adapter, self.shell_stdin, self.shell_replied_event, self.run_srv)
         self.shell_stdin.write.assert_called_once_with("x\r")
         self.sock.sendall.assert_any_call(b"y")
@@ -626,7 +623,6 @@ class SocketToShellTapTest(unittest.TestCase):
     def test_eof_breaks_loop(self, mock_recv, _mock_sleep):
         """EOF (None) breaks the loop and clears run_srv."""
         mock_recv.return_value = None
-        self.run_srv.is_set.return_value = True
         client_to_shell_tap(self.adapter, self.shell_stdin, self.shell_replied_event, self.run_srv)
         self.run_srv.clear.assert_called_once()
 
@@ -635,7 +631,6 @@ class SocketToShellTapTest(unittest.TestCase):
     def test_nul_bytes_dropped(self, mock_recv, _mock_sleep):
         """NUL bytes (0x00) are dropped and not echoed."""
         mock_recv.side_effect = [b"\x00", b"a", None]
-        self.run_srv.is_set.side_effect = [True] * 4 + [False]
         client_to_shell_tap(self.adapter, self.shell_stdin, self.shell_replied_event, self.run_srv)
         self.sock.sendall.assert_called_once_with(b"a")
 
@@ -644,7 +639,6 @@ class SocketToShellTapTest(unittest.TestCase):
     def test_oserror_on_recv_breaks_loop(self, mock_recv, _mock_sleep):
         """OSError during recv breaks the loop."""
         mock_recv.side_effect = OSError("Read error")
-        self.run_srv.is_set.return_value = True
         client_to_shell_tap(self.adapter, self.shell_stdin, self.shell_replied_event, self.run_srv)
         self.run_srv.clear.assert_called_once()
 
@@ -654,27 +648,35 @@ class SocketToShellTapTest(unittest.TestCase):
         """OSError during sendall breaks the loop."""
         mock_recv.side_effect = [b"a", b"b"]
         self.sock.sendall.side_effect = OSError("Write error")
-        self.run_srv.is_set.return_value = True
         client_to_shell_tap(self.adapter, self.shell_stdin, self.shell_replied_event, self.run_srv)
         self.run_srv.clear.assert_called_once()
 
     @unittest.mock.patch("simnos.plugins.servers.tap_bridge.time.sleep")
     @unittest.mock.patch.object(TelnetServer, "_recv_byte")
     def test_run_srv_clear_exits_loop(self, mock_recv, _mock_sleep):
-        """If run_srv is cleared externally, the loop exits."""
+        """If run_srv is already cleared, the loop exits without reading.
+
+        countdown(0): the loop head gets the first False — nothing is read.
+        """
         mock_recv.return_value = b"a"
-        self.run_srv.is_set.return_value = False
+        self.run_srv = countdown_run_srv(0)
         client_to_shell_tap(self.adapter, self.shell_stdin, self.shell_replied_event, self.run_srv)
         mock_recv.assert_not_called()
 
     @unittest.mock.patch("simnos.plugins.servers.tap_bridge.time.sleep")
     @unittest.mock.patch.object(TelnetServer, "_recv_byte")
     def test_shutdown_during_shell_wait(self, mock_recv, _mock_sleep):
-        """If run_srv is cleared while waiting for shell reply, the loop exits."""
+        """If run_srv is cleared while waiting for shell reply, the loop exits.
+
+        countdown(2): loop head + first inner-wait guard consume the Trues;
+        the second inner-wait guard gets the first False (wait() keeps
+        timing out), and the post-wait guard sees False again — the byte
+        must not be echoed.
+        """
         mock_recv.side_effect = [b"a", b"b"]
         # wait() returns False (timeout), then run_srv is checked and found False
         self.shell_replied_event.wait.return_value = False
-        self.run_srv.is_set.side_effect = [True, True, False, False]
+        self.run_srv = countdown_run_srv(2)
         client_to_shell_tap(self.adapter, self.shell_stdin, self.shell_replied_event, self.run_srv)
         # Should exit without processing the byte 'a' because the inner wait loop breaks
         self.sock.sendall.assert_not_called()
@@ -686,7 +688,6 @@ class SocketToShellTapTest(unittest.TestCase):
     def test_timeout_error_continues_loop(self, mock_recv, _mock_sleep):
         """TimeoutError during _recv_byte is caught and loop continues."""
         mock_recv.side_effect = [TimeoutError(), b"a", None]
-        self.run_srv.is_set.side_effect = [True] * 4 + [False]
         client_to_shell_tap(self.adapter, self.shell_stdin, self.shell_replied_event, self.run_srv)
         self.sock.sendall.assert_called_once_with(b"a")
 
@@ -695,7 +696,6 @@ class SocketToShellTapTest(unittest.TestCase):
     def test_shell_replied_event_cleared_on_newline(self, mock_recv, _mock_sleep):
         """Receiving a newline clears the shell_replied_event."""
         mock_recv.side_effect = [b"\n", None]
-        self.run_srv.is_set.side_effect = [True] * 3 + [False]
         client_to_shell_tap(self.adapter, self.shell_stdin, self.shell_replied_event, self.run_srv)
         self.shell_replied_event.clear.assert_called_once()
 
@@ -710,17 +710,12 @@ class ShellToSocketTapTest(unittest.TestCase):
         self.shell_stdout = MagicMock()
         self.shell_stdout.drain.return_value = []
         self.shell_replied_event = MagicMock()
-        self.run_srv = MagicMock()
+        # T-9 default: run_srv stays live, loops exit via readline's "" EOF.
+        self.run_srv = live_run_srv()
 
     def test_line_forwarded_to_socket(self):
         """A line from the shell is forwarded to the socket and event is set."""
         self.shell_stdout.readline.side_effect = ["Router>\r\n", ""]
-        self.run_srv.is_set.side_effect = [
-            True,
-            True,
-            True,
-            False,
-        ]  # D11: retry-loop form consumes one extra is_set per send
         shell_to_client_tap(self.adapter, self.shell_stdout, self.shell_replied_event, self.run_srv)
         self.sock.sendall.assert_called_once_with(b"Router>\r\n")
         self.shell_replied_event.set.assert_called_once()
@@ -728,38 +723,29 @@ class ShellToSocketTapTest(unittest.TestCase):
     def test_empty_line_breaks_loop(self):
         """Empty line from shell (EOF) breaks the loop and clears run_srv."""
         self.shell_stdout.readline.return_value = ""
-        self.run_srv.is_set.return_value = True
         shell_to_client_tap(self.adapter, self.shell_stdout, self.shell_replied_event, self.run_srv)
         self.run_srv.clear.assert_called_once()
 
     def test_run_srv_cleared_skips_sendall(self):
-        """When run_srv is cleared after readline, sendall is skipped."""
+        """When run_srv is cleared after readline, sendall is skipped (D11).
+
+        countdown(1): the loop head consumes the True; the retry-loop gate
+        gets the first False — the send attempt must not happen.
+        """
         self.shell_stdout.readline.side_effect = ["Router>\r\n", ""]
-        self.run_srv.is_set.side_effect = [True, False]
+        self.run_srv = countdown_run_srv(1)
         shell_to_client_tap(self.adapter, self.shell_stdout, self.shell_replied_event, self.run_srv)
         self.sock.sendall.assert_not_called()
 
     def test_nul_stripped_from_line(self):
         """NUL bytes are stripped from the shell output."""
         self.shell_stdout.readline.side_effect = ["abc\x00def\r\n", ""]
-        self.run_srv.is_set.side_effect = [
-            True,
-            True,
-            True,
-            False,
-        ]  # D11: retry-loop form consumes one extra is_set per send
         shell_to_client_tap(self.adapter, self.shell_stdout, self.shell_replied_event, self.run_srv)
         self.sock.sendall.assert_called_once_with(b"abcdef\r\n")
 
     def test_lf_converted_to_crlf(self):
         """Bare LF from shell is converted to CRLF."""
         self.shell_stdout.readline.side_effect = ["line\n", ""]
-        self.run_srv.is_set.side_effect = [
-            True,
-            True,
-            True,
-            False,
-        ]  # D11: retry-loop form consumes one extra is_set per send
         shell_to_client_tap(self.adapter, self.shell_stdout, self.shell_replied_event, self.run_srv)
         self.sock.sendall.assert_called_once_with(b"line\r\n")
 
@@ -767,19 +753,12 @@ class ShellToSocketTapTest(unittest.TestCase):
         """OSError during sendall breaks the loop."""
         self.shell_stdout.readline.return_value = "Router>\r\n"
         self.sock.sendall.side_effect = OSError("Write error")
-        self.run_srv.is_set.return_value = True
         shell_to_client_tap(self.adapter, self.shell_stdout, self.shell_replied_event, self.run_srv)
         self.run_srv.clear.assert_called_once()
 
     def test_shell_replied_event_set_after_send(self):
         """Successfully sending a line to the socket sets the replied event."""
         self.shell_stdout.readline.side_effect = ["hi\r\n", ""]
-        self.run_srv.is_set.side_effect = [
-            True,
-            True,
-            True,
-            False,
-        ]  # D11: retry-loop form consumes one extra is_set per send
         shell_to_client_tap(self.adapter, self.shell_stdout, self.shell_replied_event, self.run_srv)
         self.shell_replied_event.set.assert_called_once()
 
@@ -787,7 +766,6 @@ class ShellToSocketTapTest(unittest.TestCase):
         """Whitespace-only first line blocks on second readline for prompt."""
         self.shell_stdout.readline.side_effect = ["\r\n", "Router>", ""]
         self.shell_stdout.drain.side_effect = [[], [], []]
-        self.run_srv.is_set.side_effect = [True, True, True, False]
         shell_to_client_tap(self.adapter, self.shell_stdout, self.shell_replied_event, self.run_srv)
         # Echo and prompt are sent together in one sendall
         self.sock.sendall.assert_called_once_with(b"\r\nRouter>")
@@ -796,12 +774,6 @@ class ShellToSocketTapTest(unittest.TestCase):
         """Drained lines are coalesced into a single sendall."""
         self.shell_stdout.readline.side_effect = ["line1\r\n", ""]
         self.shell_stdout.drain.side_effect = [["line2\r\n", "Router>"], []]
-        self.run_srv.is_set.side_effect = [
-            True,
-            True,
-            True,
-            False,
-        ]  # D11: retry-loop form consumes one extra is_set per send
         shell_to_client_tap(self.adapter, self.shell_stdout, self.shell_replied_event, self.run_srv)
         self.sock.sendall.assert_called_once_with(b"line1\r\nline2\r\nRouter>")
 
@@ -809,12 +781,6 @@ class ShellToSocketTapTest(unittest.TestCase):
         """Consecutive prompts without trailing newline get \\r\\n separator."""
         self.shell_stdout.readline.side_effect = ["Router>", ""]
         self.shell_stdout.drain.side_effect = [["Router>"], []]
-        self.run_srv.is_set.side_effect = [
-            True,
-            True,
-            True,
-            False,
-        ]  # D11: retry-loop form consumes one extra is_set per send
         shell_to_client_tap(self.adapter, self.shell_stdout, self.shell_replied_event, self.run_srv)
         # Prompts are separated, not concatenated as "Router>Router>"
         self.sock.sendall.assert_called_once_with(b"Router>\r\nRouter>")
@@ -853,8 +819,7 @@ class TelnetSocketAdapterTest(unittest.TestCase):
         sock.close()
         adapter = TelnetSocketAdapter(sock, self.server)
         shell_stdout = MagicMock()
-        run_srv = MagicMock()
-        run_srv.is_set.return_value = True
+        run_srv = live_run_srv()
         shell_to_client_tap(adapter, shell_stdout, MagicMock(), run_srv)
         shell_stdout.readline.assert_not_called()
 
@@ -870,14 +835,14 @@ class SocketToShellTapShellStdoutTest(unittest.TestCase):
         self.shell_stdout = MagicMock()
         self.shell_replied_event = MagicMock()
         self.shell_replied_event.wait.return_value = True
-        self.run_srv = MagicMock()
+        # T-9 default: run_srv stays live, loops exit via the recv script's EOF.
+        self.run_srv = live_run_srv()
 
     @unittest.mock.patch("simnos.plugins.servers.tap_bridge.time.sleep")
     @unittest.mock.patch.object(TelnetServer, "_recv_byte")
     def test_newline_echo_routed_to_shell_stdout(self, mock_recv, _mock_sleep):
         """When shell_stdout is provided, newline echo goes to shell_stdout, not socket."""
         mock_recv.side_effect = [b"\r", None]
-        self.run_srv.is_set.side_effect = [True] * 5 + [False]
         client_to_shell_tap(
             self.adapter,
             self.shell_stdin,
@@ -895,7 +860,6 @@ class SocketToShellTapShellStdoutTest(unittest.TestCase):
     def test_newline_echo_to_socket_without_shell_stdout(self, mock_recv, _mock_sleep):
         """Without shell_stdout, newline echo goes directly to socket."""
         mock_recv.side_effect = [b"\r", None]
-        self.run_srv.is_set.side_effect = [True] * 5 + [False]
         client_to_shell_tap(
             self.adapter,
             self.shell_stdin,
@@ -909,7 +873,6 @@ class SocketToShellTapShellStdoutTest(unittest.TestCase):
     def test_normal_byte_still_echoed_to_socket(self, mock_recv, _mock_sleep):
         """Normal bytes are always echoed directly to socket, even with shell_stdout."""
         mock_recv.side_effect = [b"a", None]
-        self.run_srv.is_set.side_effect = [True, True, True, False]
         client_to_shell_tap(
             self.adapter,
             self.shell_stdin,

--- a/tests/plugins/test_telnet_server.py
+++ b/tests/plugins/test_telnet_server.py
@@ -730,9 +730,11 @@ class ShellToSocketTapTest(unittest.TestCase):
         """When run_srv is cleared after readline, sendall is skipped (D11).
 
         countdown(1): the loop head consumes the True; the retry-loop gate
-        gets the first False — the send attempt must not happen.
+        gets the first False — the send attempt must not happen. No EOF
+        tail: a mistuned countdown would exhaust the script and fail
+        visibly with StopIteration instead of silently exiting via EOF.
         """
-        self.shell_stdout.readline.side_effect = ["Router>\r\n", ""]
+        self.shell_stdout.readline.side_effect = ["Router>\r\n"]
         self.run_srv = countdown_run_srv(1)
         shell_to_client_tap(self.adapter, self.shell_stdout, self.shell_replied_event, self.run_srv)
         self.sock.sendall.assert_not_called()


### PR DESCRIPTION
🐙claude:

Closes #228

## 概要

T-9 (棚卸し doc 2026-05): tap-loop test の `run_srv.is_set.side_effect = [True]*N + [False]` fuel pattern を intent-based helper に統一する **test-only refactor**。production code 変更なし。

## 背景

fuel の N は loop 内部の is_set 消費回数に hand-tuning されており、G3 (#225) の retry-loop 化で telnet s2c 6 test の fuel 手動更新が必要になった実害あり。調査で「fuel と EOF 終端 script の二重 terminator のうち片方の tail が必ず死んでいる」「SSH / telnet / tap_bridge で exit 経路 idiom が drift」「有限 script の枯渇は StopIteration で可視 fail するため watchdog fuel 自体が不要」が判明 (設計 doc、cross-review 2 round 済)。

## 変更内容

### `tests/plugins/tap_test_helpers.py` (新規)
- `live_run_srv()` — default idiom。run_srv は live のまま、loop は data source の EOF で exit。loop 内部の is_set 消費数は test 契約から除外される
- `countdown_run_srv(n)` — shutdown-path pin 専用。`chain(repeat(True, n), repeat(False))` で **n 回 True → 以後ずっと False** (False を 2 回消費する `test_shutdown_during_shell_wait` 型に対応 + False 後の追加チェックを伴う将来の loop 変更に耐性)。負数は ValueError

### 置換 (意図別、設計の置換表どおり)
- **fuel 全廃 43 箇所** (SSH 21 / telnet 20 / tap_bridge 2): setUp の live default に集約、SSH の無限 source (`recv.return_value` / `readline.return_value`) は EOF 終端 script 化
- **call_count 系 pin 10 件** → 意図別不変条件に置換 (即 exit 系 = not-called / 例外系 = sendall called + write not called / s2c 例外系 = set not called / 1 周も回らない系)
- **shutdown-path pin 7 件** → countdown 化 + 消費 mapping docstring + 観測可能 assertion。countdown test の data script は EOF tail を持たない (誤調整時に StopIteration で可視 fail)
- **helper 契約の直接 pin test 追加** (`test_tap_test_helpers.py`、cross-review 取り込み)

### scope 外 (現状維持)
TapIO / watchdog test 群の fuel は tap-loop ではないため不変 (G6 で再評価)。

## 挙動 pin の維持
U1-U4 / Q1 / D11 の挙動 pin は全て維持。D11 の send-gate 構造 pin は test_tap_bridge.py policy test 側に集約 (SSH 側は「1 batch 送信後 shutdown」に契約再定義)。

## レビュー
- 設計 cross-review 2 round (🦊/🐳/🐙): MUST FIX 1 + SHOULD FIX 6 を全て設計反映済
- 実装 cross-review 1 round: 🐙 LGTM / 🦊 SUGGESTION (helper test、取り込み済) / 🐳 SUGGESTION (clear assertion 網羅は理由付き不採用 — loop 関数末尾の無条件 clear は直接呼び test では return と等価)

## テスト
- tests/plugins 465 passed / full suite 812 passed (docker 2 fail は main でも再現するローカル環境依存)
- ruff / yamllint / bandit clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)
