### PR TITLE
test: callable output (py plugin override) の content 検証を追加 — e2e sweep + device class unit tests (#230)

### DIFF
--- a/tests/core/test_netmiko_init_compat.py
+++ b/tests/core/test_netmiko_init_compat.py
@@ -210,6 +210,11 @@ def _classify_callable_commands(
     `.format(base_prompt=...)` post-processing step. Alias entries have
     no `output` key of their own, so they are skipped here; the alias
     target entry is swept independently.
+
+    Note: classification itself invokes the callables (probe + expected),
+    so a state-mutating callable would advance device state here before
+    the e2e session runs — fine today (all make_* are read-only), but a
+    sweep-eligibility redesign is needed if that ever changes.
     """
     initial_prompt = nos.initial_prompt.format(base_prompt=base_prompt)
     enable_prompt = (nos.enable_prompt or "").format(base_prompt=base_prompt)

--- a/tests/core/test_netmiko_init_compat.py
+++ b/tests/core/test_netmiko_init_compat.py
@@ -5,6 +5,8 @@ Verifies that:
 - netmiko session_preparation() does not produce "Unknown command" (#69, #71)
 - Unknown commands are handled gracefully without crashing
 - send_command returns the defined output for each platform (#76)
+- callable (py plugin override) outputs round-trip through netmiko,
+  with the sweep classification contract pinned directly (#230)
 - Shell exits cleanly on shutdown without thread leaks (#71 regression)
 """
 
@@ -16,7 +18,9 @@ from netmiko import ConnectHandler
 import pytest
 
 from simnos import SimNOS
-from tests.utils import NETMIKO_DEVICE_TYPE_MAP, get_free_port, get_platforms_from_md
+from simnos.core.nos import Nos
+from simnos.plugins.nos import nos_plugins
+from tests.utils import NETMIKO_DEVICE_TYPE_MAP, get_free_port, get_platforms_from_md, get_py_platforms
 
 HOSTNAME = "router"  # Inventory host key; also used as base_prompt in output formatting
 
@@ -122,9 +126,6 @@ def _get_test_command(device_type: str) -> tuple[str, str] | None:
     Excludes: special commands (_default_ etc.), alias, new_prompt,
     exit flag, callable output, and prompt-mode-changing commands.
     """
-    from simnos.core.nos import Nos
-    from simnos.plugins.nos import nos_plugins
-
     if device_type not in nos_plugins:
         return None
 
@@ -159,6 +160,96 @@ def _get_test_command(device_type: str) -> tuple[str, str] | None:
             fallback = (cmd_name, output)
 
     return fallback
+
+
+# (platform, command) pairs whose callable output depends on wall-clock
+# time. The expected value computed in the test process would race the
+# server-side call, so they are excluded from the e2e content sweep;
+# their format is pinned by the device-class unit tests
+# (tests/plugins/nos/) instead. Platform-qualified on purpose: a future
+# platform whose same-named command IS deterministic stays in the sweep.
+# If a new py plugin adds a time-dependent callable without listing it
+# here, the sweep fails on content mismatch — add the pair here and pin
+# the format in the unit tests for that platform.
+TIME_DEPENDENT_COMMANDS = {("cisco_ios", "show clock"), ("arista_eos", "show clock")}
+
+
+def _get_callable_test_commands(
+    device_type: str, base_prompt: str = HOSTNAME
+) -> tuple[list[tuple[str, str]], list[tuple[str, str]]]:
+    """Collect (cmd, expected) pairs for the callable-output e2e sweep.
+
+    Thin lookup wrapper: loads the same merged Nos the server uses
+    (`Host.start` equivalent) and delegates to
+    `_classify_callable_commands`, which is kept separate so its
+    classification contract can be pinned with a synthetic Nos.
+    """
+    return _classify_callable_commands(Nos(filename=nos_plugins[device_type]), device_type, base_prompt)
+
+
+def _classify_callable_commands(
+    nos: Nos, device_type: str, base_prompt: str
+) -> tuple[list[tuple[str, str]], list[tuple[str, str]]]:
+    """Classify callable commands into the (initial, enable) sweep phases.
+
+    Returns two lists of (cmd, expected): commands runnable at the
+    initial prompt and commands requiring enable mode. Eligible =
+    callable output that returns a str — dict-returning mode/exit
+    callables are unit-test scope at ANY prompt (config included) —
+    and is not in TIME_DEPENDENT_COMMANDS.
+
+    A *str-returning* callable matching neither the initial nor the
+    enable prompt (e.g. config-mode-only) raises AssertionError instead
+    of being silently dropped: extend the sweep (config phase) or add a
+    dedicated exclusion set — do not reuse TIME_DEPENDENT_COMMANDS for
+    non-time reasons.
+
+    The expected value is computed by invoking the callable with the
+    same 4-arg contract as `cmd_shell.default` (device, base_prompt=,
+    current_prompt=, command=) followed by the same
+    `.format(base_prompt=...)` post-processing step. Alias entries have
+    no `output` key of their own, so they are skipped here; the alias
+    target entry is swept independently.
+    """
+    initial_prompt = nos.initial_prompt.format(base_prompt=base_prompt)
+    enable_prompt = (nos.enable_prompt or "").format(base_prompt=base_prompt)
+
+    initial_cmds: list[tuple[str, str]] = []
+    enable_cmds: list[tuple[str, str]] = []
+    unclassified: list[str] = []
+    for cmd_name, cmd_data in nos.commands.items():
+        output = cmd_data.get("output")
+        if not callable(output) or (device_type, cmd_name) in TIME_DEPENDENT_COMMANDS:
+            continue
+        prompts = cmd_data.get("prompt")
+        prompts = [prompts] if isinstance(prompts, str) else (prompts or [])
+        formatted = [p.format(base_prompt=base_prompt) for p in prompts]
+        if initial_prompt in formatted:
+            current_prompt, bucket = initial_prompt, initial_cmds
+        elif enable_prompt and enable_prompt in formatted:
+            current_prompt, bucket = enable_prompt, enable_cmds
+        else:
+            # Outside the sweep phases. Probe with the command's own
+            # declared prompt to apply the eligibility contract: a dict
+            # return means mode/exit logic (unit-test scope at any
+            # prompt); only a str return here is real e2e coverage loss.
+            probe_prompt = formatted[0] if formatted else initial_prompt
+            probe = output(nos.device, base_prompt=base_prompt, current_prompt=probe_prompt, command=cmd_name)
+            if isinstance(probe, str):
+                unclassified.append(cmd_name)
+            continue
+        expected = output(nos.device, base_prompt=base_prompt, current_prompt=current_prompt, command=cmd_name)
+        if not isinstance(expected, str):
+            continue  # dict-returning mode/exit callables -> unit tests cover these
+        expected = expected.format(base_prompt=base_prompt)
+        bucket.append((cmd_name, expected))
+
+    assert not unclassified, (
+        f"{device_type}: str-returning callable commands outside the initial/enable "
+        f"sweep phases: {unclassified}. Extend the sweep (e.g. config phase) or add a "
+        f"dedicated exclusion set with a reason — do not reuse TIME_DEPENDENT_COMMANDS."
+    )
+    return initial_cmds, enable_cmds
 
 
 class TestSendCommandResponse:
@@ -205,6 +296,153 @@ class TestSendCommandResponse:
                 )
         finally:
             net.stop()
+
+    @pytest.mark.flaky(reruns=2, reruns_delay=1)
+    # Sweep test (multiple commands + enable), not a single-command test:
+    # 60s instead of the 30s used by the single-shot tests above.
+    @pytest.mark.timeout(60)
+    @pytest.mark.parametrize("device_type", get_py_platforms())
+    def test_send_command_returns_callable_output(self, device_type: str):
+        """Callable (py override) outputs must round-trip through netmiko.
+
+        Q16 (T-14 / #230): the static-command test above systematically
+        excludes callable outputs, so the dynamic outputs that py plugins
+        exist for had no e2e content verification. One session per
+        platform sweeps every eligible callable: initial-prompt commands
+        first, then enable-only commands after conn.enable() (skipped
+        when empty).
+
+        Marked `flaky` (reruns=2): same rationale as
+        test_send_command_returns_defined_output (netmiko auto-enable
+        handshake race on slow CI runners).
+        """
+        initial_cmds, enable_cmds = _get_callable_test_commands(device_type)
+        assert initial_cmds or enable_cmds, (
+            f"No eligible callable command found for {device_type}. "
+            "Every py platform must expose at least one str-returning callable."
+        )
+
+        port = get_free_port()
+        net = _make_simnos(device_type, port)
+        try:
+            net.start()
+            device = {
+                "host": "localhost",
+                "username": "test",
+                "password": "test",
+                "port": port,
+                "device_type": NETMIKO_DEVICE_TYPE_MAP.get(device_type, device_type),
+            }
+            with ConnectHandler(**device) as conn:
+
+                def check(cmds: list[tuple[str, str]], phase: str) -> None:
+                    for cmd, expected in cmds:
+                        output = conn.send_command(cmd, read_timeout=15)
+                        assert output.strip() == expected.strip(), (
+                            f"{device_type}: '{cmd}' ({phase}) returned unexpected output.\n"
+                            f"  expected: {expected.strip()!r}\n"
+                            f"  actual:   {output.strip()!r}"
+                        )
+
+                check(initial_cmds, "initial prompt")
+                if enable_cmds:
+                    conn.enable()
+                    check(enable_cmds, "enable mode")
+        finally:
+            net.stop()
+
+
+class TestClassifyCallableCommands:
+    """Pin the classification contract of `_classify_callable_commands`.
+
+    The e2e sweep above only exercises the current 3 py platforms'
+    happy path; these tests pin the maintenance contract directly with
+    a synthetic Nos (same pattern as tests/plugins/test_tap_test_helpers.py)
+    so a future helper change fails here first, not via silent coverage
+    shrinkage in the sweep.
+    """
+
+    @staticmethod
+    def _synthetic_nos(commands: dict) -> Nos:
+        """Build a minimal Nos with the standard 3-mode prompt set."""
+        return Nos(
+            dict_args={
+                "name": "synth",
+                "initial_prompt": "{base_prompt}>",
+                "enable_prompt": "{base_prompt}#",
+                "config_prompt": "{base_prompt}(config)#",
+                "commands": commands,
+            }
+        )
+
+    def test_config_only_str_callable_fails_loudly(self):
+        """A str-returning callable outside the sweep phases is coverage loss."""
+        nos = self._synthetic_nos(
+            {
+                "weird": {
+                    "output": lambda device, **kwargs: "static",
+                    "help": "config-only str callable",
+                    "prompt": "{base_prompt}(config)#",
+                }
+            }
+        )
+        with pytest.raises(AssertionError, match=r"outside the initial/enable\s+sweep phases: \['weird'\]"):
+            _classify_callable_commands(nos, "synth", HOSTNAME)
+
+    def test_config_only_dict_callable_is_unit_scope(self):
+        """Dict-returning mode callables are excluded at ANY prompt, no fail."""
+        nos = self._synthetic_nos(
+            {
+                "modey": {
+                    "output": lambda device, **kwargs: {"exit": True},
+                    "help": "config-only dict callable",
+                    "prompt": "{base_prompt}(config)#",
+                }
+            }
+        )
+        initial_cmds, enable_cmds = _classify_callable_commands(nos, "synth", HOSTNAME)
+        assert initial_cmds == []
+        assert enable_cmds == []
+
+    def test_denylist_is_platform_qualified(self):
+        """Another platform's deterministic 'show clock' stays in the sweep."""
+        nos = self._synthetic_nos(
+            {
+                "show clock": {
+                    "output": lambda device, **kwargs: "deterministic",
+                    "help": "deterministic clock on a synthetic platform",
+                    "prompt": "{base_prompt}>",
+                }
+            }
+        )
+        initial_cmds, enable_cmds = _classify_callable_commands(nos, "synth", HOSTNAME)
+        assert initial_cmds == [("show clock", "deterministic")]
+        assert enable_cmds == []
+
+    def test_bucketing_and_expected_format(self):
+        """initial / enable / dual-prompt (-> initial) bucketing + .format step."""
+        nos = self._synthetic_nos(
+            {
+                "init only": {
+                    "output": lambda device, **kwargs: "from init",
+                    "help": "initial-prompt only",
+                    "prompt": "{base_prompt}>",
+                },
+                "enable only": {
+                    "output": lambda device, **kwargs: "hostname {base_prompt}",
+                    "help": "enable-prompt only, with format placeholder",
+                    "prompt": "{base_prompt}#",
+                },
+                "dual prompt": {
+                    "output": lambda device, **kwargs: "from dual",
+                    "help": "both prompts -> initial bucket wins",
+                    "prompt": ["{base_prompt}#", "{base_prompt}>"],
+                },
+            }
+        )
+        initial_cmds, enable_cmds = _classify_callable_commands(nos, "synth", HOSTNAME)
+        assert initial_cmds == [("init only", "from init"), ("dual prompt", "from dual")]
+        assert enable_cmds == [("enable only", f"hostname {HOSTNAME}")]
 
 
 class TestShutdownEOF:

--- a/tests/plugins/nos/device_helpers.py
+++ b/tests/plugins/nos/device_helpers.py
@@ -1,0 +1,24 @@
+"""
+Shared helpers for the device-class unit tests in this package (T-14 / #230).
+
+Each test_<nos>.py invokes plugin callables with the same 4-arg contract
+as `cmd_shell.default` (device, base_prompt=, current_prompt=, command=);
+this module holds that invocation and the common base_prompt so the
+per-platform files stay focused on their pins.
+"""
+
+from simnos.core.nos import Nos
+
+__all__ = ["BASE_PROMPT", "call_command"]
+
+BASE_PROMPT = "router"
+
+
+def call_command(nos: Nos, command: str, current_prompt: str, base_prompt: str = BASE_PROMPT):
+    """Invoke a callable command with the cmd_shell 4-arg contract."""
+    return nos.commands[command]["output"](
+        nos.device,
+        base_prompt=base_prompt,
+        current_prompt=current_prompt,
+        command=command,
+    )

--- a/tests/plugins/nos/test_arista_eos.py
+++ b/tests/plugins/nos/test_arista_eos.py
@@ -8,6 +8,8 @@ pinned per current_prompt branch — the consumer side of those dicts is
 pinned separately in tests/plugins/test_cmd_shell.py.
 """
 
+import re
+
 import pytest
 
 from simnos.core.nos import Nos
@@ -30,9 +32,15 @@ def nos() -> Nos:
     return Nos(filename=nos_plugins["arista_eos"])
 
 
-def test_show_clock_static_parts(nos):
-    """Time-dependent output (e2e denylist): pin the static render tail."""
+def test_show_clock_format(nos):
+    """Time-dependent output (e2e denylist): pin time-line shape + static tail.
+
+    The first line renders time.strftime("%a %b %d %H:%M:%S %Y"), e.g.
+    'Sat Apr 16 11:54:03 2022' (same shape as tests/core/test_netmiko.py
+    pins for the test-asset show clock).
+    """
     out = call_command(nos, "show clock", ENABLE)
+    assert re.match(r"^\w{3} \w{3} \d{2} \d{2}:\d{2}:\d{2} \d{4}$", out.splitlines()[0])
     assert "Timezone: UTC" in out
     assert "Clock source: local" in out
 
@@ -49,8 +57,10 @@ def test_show_running_config_content(nos):
     assert "{" not in out
 
 
-def test_show_ip_int_brief_content(nos):
-    out = call_command(nos, "show ip int brief", ENABLE)
+@pytest.mark.parametrize("command", ["show ip int brief", "show ip interface brief"])
+def test_show_ip_int_brief_content(nos, command):
+    """Both spellings are distinct entries backed by the same make_show_ip_int_br."""
+    out = call_command(nos, command, ENABLE)
     assert "Interface" in out
     assert "Ethernet1" in out
     assert "{" not in out

--- a/tests/plugins/nos/test_arista_eos.py
+++ b/tests/plugins/nos/test_arista_eos.py
@@ -1,0 +1,73 @@
+"""
+Device-class unit tests for the arista_eos Python plugin (T-14 / #230).
+
+Producer-side pins for the callable outputs: str-returning make_* are
+pinned on meaningful invariants (key substrings + `{{base_prompt}}`
+resolution), and the dict-returning mode callable (`make_exit`) is
+pinned per current_prompt branch — the consumer side of those dicts is
+pinned separately in tests/plugins/test_cmd_shell.py.
+"""
+
+import pytest
+
+from simnos.core.nos import Nos
+from simnos.plugins.nos import nos_plugins
+from simnos.plugins.nos.platforms_py.arista_eos import (
+    CONFIG_PROMPT,
+    ENABLE_PROMPT,
+    INITIAL_PROMPT,
+)
+from tests.plugins.nos.device_helpers import BASE_PROMPT, call_command
+
+INITIAL = INITIAL_PROMPT.format(base_prompt=BASE_PROMPT)
+ENABLE = ENABLE_PROMPT.format(base_prompt=BASE_PROMPT)
+CONFIG = CONFIG_PROMPT.format(base_prompt=BASE_PROMPT)
+
+
+@pytest.fixture(scope="module")
+def nos() -> Nos:
+    """Merged Nos via the same wiring the server uses (Host.start equivalent)."""
+    return Nos(filename=nos_plugins["arista_eos"])
+
+
+def test_show_clock_static_parts(nos):
+    """Time-dependent output (e2e denylist): pin the static render tail."""
+    out = call_command(nos, "show clock", ENABLE)
+    assert "Timezone: UTC" in out
+    assert "Clock source: local" in out
+
+
+def test_show_version_content(nos):
+    out = call_command(nos, "show version", ENABLE)
+    assert "cEOSLab" in out
+    assert "{" not in out
+
+
+def test_show_running_config_content(nos):
+    out = call_command(nos, "show running-config", ENABLE)
+    assert f"hostname {BASE_PROMPT}" in out  # {{base_prompt}} resolved
+    assert "{" not in out
+
+
+def test_show_ip_int_brief_content(nos):
+    out = call_command(nos, "show ip int brief", ENABLE)
+    assert "Interface" in out
+    assert "Ethernet1" in out
+    assert "{" not in out
+
+
+class TestMakeExit:
+    """Pin the per-prompt branches of the dict-returning `make_exit`."""
+
+    def test_initial_prompt_exits(self, nos):
+        assert call_command(nos, "exit", INITIAL) == {"exit": True}
+
+    def test_enable_prompt_exits(self, nos):
+        assert call_command(nos, "exit", ENABLE) == {"exit": True}
+
+    def test_config_prompt_drops_to_enable(self, nos):
+        assert call_command(nos, "exit", CONFIG) == {"output": "", "new_prompt": ENABLE_PROMPT}
+
+    def test_unknown_prompt_raises(self, nos):
+        with pytest.raises(RuntimeError, match=r"make_exit does not know how to handle 'bogus\$' prompt"):
+            call_command(nos, "exit", "bogus$")

--- a/tests/plugins/nos/test_arista_eos.py
+++ b/tests/plugins/nos/test_arista_eos.py
@@ -3,9 +3,10 @@ Device-class unit tests for the arista_eos Python plugin (T-14 / #230).
 
 Producer-side pins for the callable outputs: str-returning make_* are
 pinned on meaningful invariants (key substrings + `{{base_prompt}}`
-resolution), and the dict-returning mode callable (`make_exit`) is
-pinned per current_prompt branch — the consumer side of those dicts is
-pinned separately in tests/plugins/test_cmd_shell.py.
+resolution, and the time-line shape for the time-dependent show clock),
+and the dict-returning mode callable (`make_exit`) is pinned per
+current_prompt branch — the consumer side of those dicts is pinned
+separately in tests/plugins/test_cmd_shell.py.
 """
 
 import re

--- a/tests/plugins/nos/test_cisco_ios.py
+++ b/tests/plugins/nos/test_cisco_ios.py
@@ -1,0 +1,49 @@
+"""
+Device-class unit tests for the cisco_ios Python plugin (T-14 / #230).
+
+Producer-side pins for the callable outputs: each callable is invoked
+with the same 4-arg contract as `cmd_shell.default` (device,
+base_prompt=, current_prompt=, command=). Full render comparison would
+be a tautology against the Jinja2 template, so these tests pin
+meaningful invariants instead: key substrings, `{{base_prompt}}`
+resolution, and (for time-dependent outputs) the format shape.
+"""
+
+import re
+
+import pytest
+
+from simnos.core.nos import Nos
+from simnos.plugins.nos import nos_plugins
+from simnos.plugins.nos.platforms_py.cisco_ios import ENABLE_PROMPT
+from tests.plugins.nos.device_helpers import BASE_PROMPT, call_command
+
+ENABLE = ENABLE_PROMPT.format(base_prompt=BASE_PROMPT)
+
+
+@pytest.fixture(scope="module")
+def nos() -> Nos:
+    """Merged Nos via the same wiring the server uses (Host.start equivalent)."""
+    return Nos(filename=nos_plugins["cisco_ios"])
+
+
+def test_show_clock_format(nos):
+    """Time-dependent output (e2e denylist): pin the strftime shape.
+
+    Example: '*11:54:03.000 UTC Sat Apr 16 2022'.
+    """
+    out = call_command(nos, "show clock", ENABLE)
+    assert re.match(r"^\*\d{2}:\d{2}:\d{2}\.000 .+ \d{4}$", out)
+
+
+def test_show_version_content(nos):
+    out = call_command(nos, "show version", ENABLE)
+    assert "Cisco IOS XE Software" in out
+    assert f"{BASE_PROMPT} uptime is" in out  # {{base_prompt}} resolved
+    assert "{" not in out  # no unresolved placeholder survives rendering
+
+
+def test_show_running_config_content(nos):
+    out = call_command(nos, "show running-config", ENABLE)
+    assert f"hostname {BASE_PROMPT}" in out
+    assert "{" not in out

--- a/tests/plugins/nos/test_huawei_smartax.py
+++ b/tests/plugins/nos/test_huawei_smartax.py
@@ -1,0 +1,104 @@
+"""
+Device-class unit tests for the huawei_smartax Python plugin (T-14 / #230).
+
+This platform's e2e all-commands test is xfail'd (mode-changing
+callables cause netmiko ReadTimeout), so these unit tests are its only
+content-level verification. Producer-side pins: `make_display_board`
+table structure, the per-prompt branches of the dict-returning mode
+callables (`_return` / `disable` / `quit`), the `_add_whitespaces`
+alignment helper, and the DEFAULT_CONFIGURATION (yaml.j2) wiring.
+"""
+
+import pytest
+
+from simnos.core.nos import Nos
+from simnos.plugins.nos import nos_plugins
+from simnos.plugins.nos.platforms_py.huawei_smartax import ENABLE_PROMPT, INITIAL_PROMPT
+from tests.plugins.nos.device_helpers import BASE_PROMPT, call_command
+
+INITIAL = INITIAL_PROMPT.format(base_prompt=BASE_PROMPT)
+ENABLE = ENABLE_PROMPT.format(base_prompt=BASE_PROMPT)
+
+
+@pytest.fixture(scope="module")
+def nos() -> Nos:
+    """Merged Nos via the same wiring the server uses (Host.start equivalent).
+
+    `Nos._from_module` instantiates the device with DEFAULT_CONFIGURATION
+    (configurations/huawei_smartax.yaml.j2), so the j2 -> yaml -> dict
+    loading path of BaseDevice.load_configurations is covered too.
+    """
+    return Nos(filename=nos_plugins["huawei_smartax"])
+
+
+def test_default_configuration_provides_boards(nos):
+    """DEFAULT_CONFIGURATION (yaml.j2) wiring: boards data is loaded."""
+    assert "boards" in nos.device.configurations
+    assert nos.device.configurations["boards"]["num"] > 0
+
+
+def test_display_board_table_structure(nos):
+    out = call_command(nos, "display board", INITIAL)
+    lines = out.splitlines()
+    header_lines = [line for line in lines if "SlotID" in line]
+    assert len(header_lines) == 1
+    header = header_lines[0]
+    assert "BoardName" in header
+    # One data row per configured slot (empty slots render as a bare SlotID).
+    data_rows = [line for line in lines if line.strip() and line.strip()[0].isdigit()]
+    assert len(data_rows) == nos.device.configurations["boards"]["num"]
+    # _add_whitespaces pads every column to its max width, so the header
+    # and all data rows share one length and SlotID sits at a fixed column.
+    slot_col = header.index("SlotID")
+    assert all(len(row) == len(header) for row in data_rows)
+    assert all(row[slot_col].isdigit() for row in data_rows)
+
+
+class TestModeCallables:
+    """Pin the per-prompt branches of the dict-returning mode callables.
+
+    The branches dispatch on the current_prompt *suffix* ('>' / '#' /
+    other), so 'bogus$' exercises the fallback branch.
+    """
+
+    def test_return_from_initial_prompt(self, nos):
+        assert call_command(nos, "return", INITIAL) == {"output": "", "new_prompt": INITIAL_PROMPT}
+
+    def test_return_from_enable_prompt(self, nos):
+        assert call_command(nos, "return", ENABLE) == {"output": "", "new_prompt": ENABLE_PROMPT}
+
+    def test_return_from_other_prompt(self, nos):
+        assert call_command(nos, "return", "bogus$") == {"output": "", "new_prompt": INITIAL_PROMPT}
+
+    def test_disable_from_enable_prompt(self, nos):
+        assert call_command(nos, "disable", ENABLE) == {"output": "", "new_prompt": INITIAL_PROMPT}
+
+    def test_disable_from_other_prompt_keeps_prompt(self, nos):
+        assert call_command(nos, "disable", "bogus$") == {"output": "", "new_prompt": "bogus$"}
+
+    def test_quit_exits(self, nos):
+        assert call_command(nos, "quit", INITIAL) == {"exit": True}
+
+
+class TestAddWhitespaces:
+    """Pin the column alignment helper, including boundary cases."""
+
+    def test_pads_to_longest_element(self, nos):
+        result = nos.device._add_whitespaces(["a", "bbb", "cc"])
+        assert result == ["a  ", "bbb", "cc "]
+
+    def test_single_element_is_unpadded(self, nos):
+        assert nos.device._add_whitespaces(["abc"]) == ["abc"]
+
+    def test_equal_length_elements_are_unpadded(self, nos):
+        assert nos.device._add_whitespaces(["aa", "bb"]) == ["aa", "bb"]
+
+    def test_empty_column_raises(self, nos):
+        """Current behavior: max() on an empty column raises ValueError.
+
+        Unreachable via make_display_board (the column always includes
+        its title), pinned as a guard so a future formatting change that
+        alters this contract is visible here first.
+        """
+        with pytest.raises(ValueError, match=r"empty"):
+            nos.device._add_whitespaces([])

--- a/tests/plugins/test_cmd_shell.py
+++ b/tests/plugins/test_cmd_shell.py
@@ -270,6 +270,61 @@ class TestCmdShell(TestCase):
         shell.default("show clock")
         shell.writeline.assert_called_once_with(time.ctime())
 
+    def _make_callable_dict_shell(self, output_callable):
+        """Build a shell whose 'cmd' command is a dict-returning callable.
+
+        Consumer-side pins for the callable-dict dispatch branch of
+        `default()` (new_prompt update / exit / output extraction),
+        the counterpart of the producer-side device-class tests in
+        tests/plugins/nos/ (T-14 / #230). The str-returning branch is
+        covered by test_default_command_is_function above.
+        """
+        self.arguments["is_running"].set()
+        self.arguments["nos"] = Nos(
+            dict_args={
+                "name": "synth",
+                "initial_prompt": "{base_prompt}>",
+                "commands": {
+                    "cmd": {
+                        "output": output_callable,
+                        "help": "dict-returning callable",
+                        "prompt": "{base_prompt}>",
+                    },
+                    "_default_": {
+                        "output": "% Unknown",
+                        "help": "default",
+                        "prompt": "{base_prompt}>",
+                    },
+                },
+            }
+        )
+        shell = CMDShell(**self.arguments)
+        shell.writeline = Mock()
+        return shell
+
+    def test_default_callable_dict_new_prompt(self):
+        """Callable dict with new_prompt updates the prompt (formatted)."""
+        shell = self._make_callable_dict_shell(lambda device, **kwargs: {"output": "", "new_prompt": "{base_prompt}#"})
+        stop = shell.default("cmd")
+        self.assertFalse(stop)
+        self.assertEqual(shell.prompt, "test#")
+        shell.writeline.assert_called_once_with("")
+
+    def test_default_callable_dict_exit(self):
+        """Callable dict with exit=True signals shell termination."""
+        shell = self._make_callable_dict_shell(lambda device, **kwargs: {"exit": True})
+        stop = shell.default("cmd")
+        self.assertTrue(stop)
+        shell.writeline.assert_not_called()
+
+    def test_default_callable_dict_output_only(self):
+        """Callable dict with output only writes it, prompt unchanged."""
+        shell = self._make_callable_dict_shell(lambda device, **kwargs: {"output": "dynamic body"})
+        stop = shell.default("cmd")
+        self.assertFalse(stop)
+        self.assertEqual(shell.prompt, "test>")
+        shell.writeline.assert_called_once_with("dynamic body")
+
     def test_default_command_not_matching_prompt(self):
         """Test that the default method does nothing."""
         self.arguments["is_running"].set()

--- a/tests/plugins/test_platforms.py
+++ b/tests/plugins/test_platforms.py
@@ -5,7 +5,6 @@ in the yaml and python files.
 """
 
 from importlib import import_module
-import os
 import re
 import types
 from typing import Any
@@ -17,25 +16,13 @@ import yaml
 from simnos.core.nos import available_platforms
 from simnos.core.simnos import SimNOS
 from simnos.plugins.nos import nos_plugins
-from tests.utils import NETMIKO_DEVICE_TYPE_MAP, get_free_port, get_host_commands
+from tests.utils import NETMIKO_DEVICE_TYPE_MAP, get_free_port, get_host_commands, get_py_platforms
 
 
 def get_yaml_only_platforms() -> list[str]:
     """Return platforms that have YAML definitions but no Python module."""
-    py_modules = set(get_py_nos_modules())
+    py_modules = set(get_py_platforms())
     return [p for p in sorted(nos_plugins) if p not in py_modules]
-
-
-def get_py_nos_modules() -> list[str]:
-    """
-    It returns the list of all the python files
-    that are in the nos directory.
-    """
-    return [
-        f.split(".py", 1)[0]
-        for f in os.listdir("simnos/plugins/nos/platforms_py")
-        if f.endswith(".py") and f != "__init__.py" and f != "base_template.py"
-    ]
 
 
 def has_single_curly_brackets(text: Any, exceptions: list[str]) -> bool:
@@ -109,7 +96,7 @@ class TestPlatforms:
                 assert "prompt" in values
                 assert not has_single_curly_brackets(values["prompt"], exceptions)
 
-    @pytest.mark.parametrize("platform", get_py_nos_modules())
+    @pytest.mark.parametrize("platform", get_py_platforms())
     def test_platforms_py_has_correct_format(self, platform: str):
         """
         It checks if the platform python file can be imported correctly.
@@ -125,7 +112,7 @@ class TestPlatforms:
         assert hasattr(module, "DEVICE_NAME")
         assert hasattr(module, module.DEVICE_NAME)
 
-    @pytest.mark.parametrize("platform", get_py_nos_modules())
+    @pytest.mark.parametrize("platform", get_py_platforms())
     def test_platforms_py_commands_has_correct_format(self, platform: str):
         """
         It checks if the platform has the commands correctly set.
@@ -215,7 +202,7 @@ class TestPlatforms:
                         assert isinstance(output, str)
 
     @pytest.mark.timeout(600)
-    @pytest.mark.parametrize("platform", get_py_nos_modules())
+    @pytest.mark.parametrize("platform", get_py_platforms())
     def test_platforms_py_all_commands_are_running(self, platform: str):
         """
         Test that all the platforms commands can

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -7,6 +7,7 @@ import socket
 import string
 
 from simnos.core.host import Host
+from simnos.plugins.nos import nos_plugins
 
 # Mapping for platforms where simnos name differs from netmiko device_type
 NETMIKO_DEVICE_TYPE_MAP: dict[str, str] = {
@@ -64,6 +65,17 @@ def get_platforms_from_md() -> list[str]:
                 platform = stripped.split("[")[1].split("]")[0]
                 platforms.append(platform)
     return platforms
+
+
+def get_py_platforms() -> list[str]:
+    """Return platforms that have a Python plugin module (sorted).
+
+    Derived from the `nos_plugins` registry (the same source the server
+    uses): values are lists of absolute plugin file paths, and
+    `base_template.py` is already excluded at registry build time, so
+    no manual listdir filtering is needed here.
+    """
+    return sorted(p for p, files in nos_plugins.items() if any(f.endswith(".py") for f in files))
 
 
 def get_host_commands(host: Host) -> tuple[list[str], list[str], list[str]]:


### PR DESCRIPTION
🐙claude:

Closes #230

## 概要

e2e trace 持ち越し Q16 (T-14) の対応。py plugin の callable output (動的出力) は `_get_test_command` の `isinstance(output, str)` と prompt check で content 検証から系統的に逃れていた — py plugin 持ち 3 platform (arista_eos / cisco_ios / huawei_smartax) で実際に検証されていたのは dormant な YAML 静的 command のみ。e2e sweep + device class unit tests の 2 層で coverage gap を埋める。**production code 変更なし** (test-only)。

## 変更内容

### A. e2e callable sweep (`tests/core/test_netmiko_init_compat.py`)
- `test_send_command_returns_callable_output`: py platform ごとに 1 session で適格 callable (str 戻り、時刻依存 denylist 外) を全件 sweep。expected は test process 内で同じ callable を `cmd_shell.default` と同じ 4 引数 contract で呼んで計算 (server と同じ merged Nos + device 生成経路)
- `TIME_DEPENDENT_COMMANDS`: (platform, command) 組の明示 denylist — 別 platform の決定的な同名 command が silent に除外されるのを防ぐ
- `_get_callable_test_commands` (lookup wrapper) + `_classify_callable_commands` (純粋分類関数): 未分類の **str 戻り** callable (config-only 等) は AssertionError で明示 fail (silent coverage 縮退の防止)。dict 戻り (mode/exit 系) は prompt を問わず unit scope として probe 判定で除外
- `TestClassifyCallableCommands` ×4: 分類契約を合成 Nos で直接 pin (`tests/plugins/test_tap_test_helpers.py` と同 pattern)

### B. device class unit tests (`tests/plugins/nos/` 新設)
- `test_cisco_ios.py` / `test_arista_eos.py` / `test_huawei_smartax.py` + 共通 `device_helpers.py`
- make_* の content 不変条件 (key substring + `{{base_prompt}}` 解決 + 構造)、時刻依存 format regex (e2e denylist 分の補完)、mode 分岐 dict (make_exit / _return / disable / quit 全分岐)、`_add_whitespaces` 境界 case
- **xfail で e2e ゼロの huawei_smartax に唯一の content 検証が付く** (display board の table 構造 + 列整列)

### 付随
- `cmd_shell.default` の callable-dict 消費分岐 (new_prompt / exit / output) を `test_cmd_shell.py` に focused unit test ×3 で pin — producer (device tests) / consumer (dispatch) で contract の両端を押さえる
- `get_py_nos_modules` (os.listdir 直叩き) を `tests/utils.py::get_py_platforms()` (registry 由来) に一元化 (4 call site)

## 検証

- 実機観測: arista_eos の netmiko 接続直後 prompt = `router>` (initial、auto-enable なし) / enable 後 `router#` を実 SSH で確認してから実装
- e2e sweep ×3 platform + 新規 unit 全 green、full suite **846 passed** (`pytest -n auto`)
- ruff check / ruff format / yamllint / bandit clean
- local fail 2 件は `test_docker.py` の既存ローカル環境依存 (main でも再現、CI の docker 環境では実行される)

## レビュー

- 設計 doc (local): cross-review design 2 round (🦊 SHOULD FIX → 全解消 / 🐳 SUGGESTION / 🐙 SUGGESTION)
- code cross-review 1 round: 🦊 SHOULD FIX (arista show clock の format pin 非対称 → 取り込み) / 🐳 SUGGESTION / 🐙 SUGGESTION — 取り込み 3 件、不採用 1 件 (assert message 形式は既存 #76 test との一貫性を優先)

## 備考

- 既存 flaky を発見 (本 PR 無関係): `test_cmd_shell.py::HotReloadTest::test_hot_reload_integration_py_jinja` が clean tree (main) でも単独実行で fail する order/timing 依存 (おそらく hot reload の mtime 粒度)。`-n auto` full suite では pass。別 issue 起票候補
- CLAUDE.md の plugin 規約 path 表記の追従は、同 file が untracked (local 専用) のため本 PR には含まれない

🤖 Generated with [Claude Code](https://claude.com/claude-code)