### PR TITLE
feat: cmd_shell の format 経路を _safe_format に集約 — FORMAT_ERRORS 統一 + strict build-time check + CI yaml sweep (#171, #172)

### DIFF
--- a/docs/development/creating_new_platforms.ja.md
+++ b/docs/development/creating_new_platforms.ja.md
@@ -11,7 +11,7 @@ YAML ファイルは `simnos/plugins/nos/platforms_yaml` ディレクトリに�
 
 ### テンプレート記法のルール
 
-YAML 内の文字列フィールド (`initial_prompt`、`enable_prompt`、`config_prompt`、および各コマンドの `output` / `prompt` / `new_prompt`) は Python の `str.format()` でレンダリングされます。サポートされる記法は次の 2 つだけです:
+YAML 内の文字列フィールド (`initial_prompt` および各コマンドの `output` / `prompt` / `new_prompt`) は、ランタイムで Python の `str.format()` によりレンダリングされます。top-level の `enable_prompt` / `config_prompt` は現状ランタイム shell からは消費されません (Python plugin は自前の module 定数を使用) が、同じテンプレート記法で書かれるため CI sweep が予防的に検証します。サポートされる記法は次の 2 つだけです:
 
 - `{base_prompt}` — デバイスのベースプロンプト (ホスト名) に置換されます:
 
@@ -25,7 +25,7 @@ YAML 内の文字列フィールド (`initial_prompt`、`enable_prompt`、`confi
     output: "{{master:0}}"   # 出力: {master:0}
     ```
 
-format ミニ言語のそれ以外の記法は**非サポート**であり、記述ミスとして扱われます: attribute access (`{base_prompt.foo}`)、index access (`{base_prompt[0]}`)、format spec (`{base_prompt:d}`)、positional placeholder (`{}` / `{0}`)、未知の名前 (`{hostname}`)。
+format ミニ言語のそれ以外の記法は**非サポート**であり、記述ミスとして扱われます: attribute access (`{base_prompt.foo}`)、index access (`{base_prompt[0]}`)、format spec (`{base_prompt:d}`)、positional placeholder (`{}` / `{0}`)、未知の名前 (`{hostname}`)。`str.format()` が例外を投げずにレンダリングしてしまう記法 — 例えば `{base_prompt!r}` や `{base_prompt:>20}` — も同様で、ビルド時チェックが明示的に reject します。
 
 テンプレートが不正な場合の挙動:
 

--- a/docs/development/creating_new_platforms.ja.md
+++ b/docs/development/creating_new_platforms.ja.md
@@ -9,6 +9,29 @@ SIMNOS は容易に拡張できるように設計されています。新しい�
 
 YAML ファイルは `simnos/plugins/nos/platforms_yaml` ディレクトリに配置されています。
 
+### テンプレート記法のルール
+
+YAML 内の文字列フィールド (`initial_prompt`、`enable_prompt`、`config_prompt`、および各コマンドの `output` / `prompt` / `new_prompt`) は Python の `str.format()` でレンダリングされます。サポートされる記法は次の 2 つだけです:
+
+- `{base_prompt}` — デバイスのベースプロンプト (ホスト名) に置換されます:
+
+    ```yaml
+    initial_prompt: "{base_prompt}>"
+    ```
+
+- `{{` / `}}` — リテラルの `{` / `}` を出力するためのエスケープ:
+
+    ```yaml
+    output: "{{master:0}}"   # 出力: {master:0}
+    ```
+
+format ミニ言語のそれ以外の記法は**非サポート**であり、記述ミスとして扱われます: attribute access (`{base_prompt.foo}`)、index access (`{base_prompt[0]}`)、format spec (`{base_prompt:d}`)、positional placeholder (`{}` / `{0}`)、未知の名前 (`{hostname}`)。
+
+テンプレートが不正な場合の挙動:
+
+- **ランタイム**は lenient — エラーはログに記録され、セッションはクラッシュせず安全に縮退します: 不正な `output` は未整形のまま送信、不正な `prompt` 候補は match しない (コマンドが到達不能になる)、不正な `new_prompt` は現在のプロンプトを維持。
+- **ビルド時**は loud — `invoke gen_docs_platform_commands` と CI のテンプレート sweep (`tests/test_gen_docs_platform_commands.py`) が platform / command / field を明示した `RuntimeError` を raise します。
+
 
 ## Python モジュール
 この方法は YAML ファイル方式よりも柔軟です。動的な動作を実装でき、Python のフルパワーを活用できます。ただし、実装はやや難しくなります。Python モジュールは `simnos/plugins/nos/platforms_py` パッケージに配置されています。

--- a/docs/development/creating_new_platforms.md
+++ b/docs/development/creating_new_platforms.md
@@ -16,6 +16,39 @@ as it is not possible to implement dynamic behavior.
 
 The YAML files are located in the `simnos/plugins/nos/platforms_yaml` directory.
 
+### Templating rules
+
+String fields in the YAML (`initial_prompt`, `enable_prompt`, `config_prompt`,
+and per-command `output` / `prompt` / `new_prompt`) are rendered with Python's
+`str.format()`. Only two constructs are supported:
+
+- `{base_prompt}` — replaced with the device's base prompt (hostname):
+
+    ```yaml
+    initial_prompt: "{base_prompt}>"
+    ```
+
+- `{{` / `}}` — escapes for a literal `{` / `}` in the output:
+
+    ```yaml
+    output: "{{master:0}}"   # renders as: {master:0}
+    ```
+
+Anything else from the format mini-language is **not supported** and is
+treated as an authoring error: attribute access (`{base_prompt.foo}`), index
+access (`{base_prompt[0]}`), format specs (`{base_prompt:d}`), positional
+placeholders (`{}` / `{0}`), and unknown names (`{hostname}`).
+
+On a malformed template:
+
+- **Runtime** is lenient — the error is logged and the session degrades
+  safely instead of crashing: a broken `output` is sent unformatted, a broken
+  `prompt` candidate never matches (the command becomes unreachable), a
+  broken `new_prompt` keeps the current prompt.
+- **Build time** is loud — `invoke gen_docs_platform_commands` and the CI
+  template sweep (`tests/test_gen_docs_platform_commands.py`) raise a
+  `RuntimeError` naming the platform / command / field.
+
 
 ## Python modules
 This method is more flexible than the YAML files method. It is possible to implement

--- a/docs/development/creating_new_platforms.md
+++ b/docs/development/creating_new_platforms.md
@@ -18,9 +18,12 @@ The YAML files are located in the `simnos/plugins/nos/platforms_yaml` directory.
 
 ### Templating rules
 
-String fields in the YAML (`initial_prompt`, `enable_prompt`, `config_prompt`,
-and per-command `output` / `prompt` / `new_prompt`) are rendered with Python's
-`str.format()`. Only two constructs are supported:
+String fields in the YAML (`initial_prompt` and per-command `output` /
+`prompt` / `new_prompt`) are rendered with Python's `str.format()` at
+runtime. Top-level `enable_prompt` / `config_prompt` are not consumed by the
+runtime shell today (Python plugins use their own module constants), but they
+are written in the same template style and validated preventively by the CI
+sweep. Only two constructs are supported:
 
 - `{base_prompt}` — replaced with the device's base prompt (hostname):
 
@@ -37,7 +40,10 @@ and per-command `output` / `prompt` / `new_prompt`) are rendered with Python's
 Anything else from the format mini-language is **not supported** and is
 treated as an authoring error: attribute access (`{base_prompt.foo}`), index
 access (`{base_prompt[0]}`), format specs (`{base_prompt:d}`), positional
-placeholders (`{}` / `{0}`), and unknown names (`{hostname}`).
+placeholders (`{}` / `{0}`), and unknown names (`{hostname}`). This includes
+constructs that `str.format()` would render without raising — e.g.
+`{base_prompt!r}` or `{base_prompt:>20}` — the build-time check rejects them
+explicitly.
 
 On a malformed template:
 

--- a/simnos/plugins/shell/cmd_shell.py
+++ b/simnos/plugins/shell/cmd_shell.py
@@ -138,11 +138,12 @@ class CMDShell(Cmd):
 
         The runtime shell is intentionally lenient: yaml templating errors
         are logged but never crash the session nor leak tracebacks to the
-        wire. The build-time counterpart `tasks.render_template` raises
-        `RuntimeError` for the same failure modes; the asymmetry is "raise
-        vs silent" only — the catch set `FORMAT_ERRORS` is shared. Yaml
-        authors may use only `{base_prompt}` substitution and `{{` / `}}`
-        escapes; see docs/development/creating_new_platforms.md.
+        wire. The build-time counterpart `tasks.render_template` shares the
+        `FORMAT_ERRORS` catch set but raises `RuntimeError` — and is
+        additionally strict about unsupported constructs that would render
+        fine (e.g. `{base_prompt!r}`). Yaml authors may use only
+        `{base_prompt}` substitution and `{{` / `}}` escapes; see
+        docs/development/creating_new_platforms.md.
 
         :param template: format template string from yaml / plugin data
         :param where: caller context for the error log; include the command

--- a/simnos/plugins/shell/cmd_shell.py
+++ b/simnos/plugins/shell/cmd_shell.py
@@ -181,6 +181,17 @@ class CMDShell(Cmd):
                 return True
         return False
 
+    def _apply_new_prompt(self, template: str, command: str) -> None:
+        """Transition the prompt; a broken template keeps the current one.
+
+        Shared by the callable-dict and cmd_data `new_prompt` paths of
+        `default()`: a format failure means no prompt transition (the
+        session stays on the current prompt); see `_safe_format`.
+        """
+        new_prompt = self._safe_format(template, where=f"new_prompt for command {command!r}")
+        if new_prompt is not None:
+            self.prompt = new_prompt
+
     def default(self, line):
         """Method called if no do_xyz methods found"""
         log.debug("shell.default '%s' running command '%s'", self.base_prompt, [line])
@@ -202,18 +213,12 @@ class CMDShell(Cmd):
                     )
                     if isinstance(ret, dict):
                         if "new_prompt" in ret:
-                            # Failure means no prompt transition (the session
-                            # stays on the current prompt); see _safe_format.
-                            new_prompt = self._safe_format(ret["new_prompt"], where=f"new_prompt for command {line!r}")
-                            if new_prompt is not None:
-                                self.prompt = new_prompt
+                            self._apply_new_prompt(ret["new_prompt"], line)
                         if ret.get("exit"):
                             return True
                         ret = ret.get("output")
                 if "new_prompt" in cmd_data:
-                    new_prompt = self._safe_format(cmd_data["new_prompt"], where=f"new_prompt for command {line!r}")
-                    if new_prompt is not None:
-                        self.prompt = new_prompt
+                    self._apply_new_prompt(cmd_data["new_prompt"], line)
             else:
                 log.warning(
                     "'%s' command prompt '%s' not matching current prompt '%s'",

--- a/simnos/plugins/shell/cmd_shell.py
+++ b/simnos/plugins/shell/cmd_shell.py
@@ -22,6 +22,12 @@ BASIC_COMMANDS: dict = {
     },
 }
 
+# `str.format()` failure modes caused by a malformed template. Shared as the
+# single source of truth between the lenient runtime shell (`_safe_format`)
+# and the loud build-time docs gen (`tasks.render_template`); the two sides
+# differ only in "raise vs silent".
+FORMAT_ERRORS = (KeyError, IndexError, ValueError, AttributeError, TypeError)
+
 
 class CMDShell(Cmd):
     """
@@ -48,7 +54,10 @@ class CMDShell(Cmd):
         self.intro = intro
         self.base_prompt = base_prompt
         self.newline = newline
-        self.prompt = nos.initial_prompt.format(base_prompt=base_prompt)
+        # Lenient: a malformed initial_prompt template must not kill every
+        # connection to this host; fall back to the raw template and log.
+        formatted = self._safe_format(nos.initial_prompt, where="initial_prompt")
+        self.prompt = formatted if formatted is not None else nos.initial_prompt
         self.is_running = is_running
 
         # form commands
@@ -113,7 +122,7 @@ class CMDShell(Cmd):
             if cmd.startswith("_") and cmd.endswith("_"):
                 continue
             # skip commands that does not match current prompt
-            if not self._check_prompt(cmd_data.get("prompt")):
+            if not self._check_prompt(cmd_data.get("prompt"), command=cmd):
                 continue
             lines[cmd] = cmd_data.get("help", "")
             width = max(width, len(cmd))
@@ -124,18 +133,53 @@ class CMDShell(Cmd):
             help_msg.append(f"{k}{padding}{v}")
         self.writeline(self.newline.join(help_msg))
 
-    def _check_prompt(self, prompt_: str | list[str] | None):
+    def _safe_format(self, template: str, *, where: str) -> str | None:
+        """Format `template` with `base_prompt`; return None on failure.
+
+        The runtime shell is intentionally lenient: yaml templating errors
+        are logged but never crash the session nor leak tracebacks to the
+        wire. The build-time counterpart `tasks.render_template` raises
+        `RuntimeError` for the same failure modes; the asymmetry is "raise
+        vs silent" only — the catch set `FORMAT_ERRORS` is shared. Yaml
+        authors may use only `{base_prompt}` substitution and `{{` / `}}`
+        escapes; see docs/development/creating_new_platforms.md.
+
+        :param template: format template string from yaml / plugin data
+        :param where: caller context for the error log; include the command
+            name when available (e.g. ``f"output for command {line!r}"``)
+        """
+        try:
+            return template.format(base_prompt=self.base_prompt)
+        except FORMAT_ERRORS as e:
+            log.error(
+                "shell '%s' error formatting %s %r: %r",
+                self.base_prompt,
+                where,
+                template,
+                e,
+            )
+            return None
+
+    def _check_prompt(self, prompt_: str | list[str] | None, command: str = ""):
         """
         Helper method to check if prompt_ matches current prompt
 
         :param prompt_: (string, list of strings, or None) prompt to check
+        :param command: command name for the error log; callers without it
+            keep working (the log just omits the command context)
         """
         # prompt_ is None if no 'prompt' key defined for command
         if prompt_ is None:
             return True
-        if isinstance(prompt_, str):
-            return self.prompt == prompt_.format(base_prompt=self.base_prompt)
-        return any(self.prompt == i.format(base_prompt=self.base_prompt) for i in prompt_)
+        candidates = [prompt_] if isinstance(prompt_, str) else prompt_
+        where = f"prompt for command {command!r}" if command else "prompt"
+        # A broken candidate is just a non-match; the remaining candidates
+        # are still evaluated independently.
+        for candidate in candidates:
+            formatted = self._safe_format(candidate, where=where)
+            if formatted is not None and self.prompt == formatted:
+                return True
+        return False
 
     def default(self, line):
         """Method called if no do_xyz methods found"""
@@ -145,7 +189,7 @@ class CMDShell(Cmd):
             cmd_data = self.commands[line]
             if "alias" in cmd_data:
                 cmd_data = {**self.commands[cmd_data["alias"]], **cmd_data}
-            if self._check_prompt(cmd_data.get("prompt")):
+            if self._check_prompt(cmd_data.get("prompt"), command=line):
                 if cmd_data.get("exit"):
                     return True
                 ret = cmd_data.get("output")
@@ -158,12 +202,18 @@ class CMDShell(Cmd):
                     )
                     if isinstance(ret, dict):
                         if "new_prompt" in ret:
-                            self.prompt = ret["new_prompt"].format(base_prompt=self.base_prompt)
+                            # Failure means no prompt transition (the session
+                            # stays on the current prompt); see _safe_format.
+                            new_prompt = self._safe_format(ret["new_prompt"], where=f"new_prompt for command {line!r}")
+                            if new_prompt is not None:
+                                self.prompt = new_prompt
                         if ret.get("exit"):
                             return True
                         ret = ret.get("output")
                 if "new_prompt" in cmd_data:
-                    self.prompt = cmd_data["new_prompt"].format(base_prompt=self.base_prompt)
+                    new_prompt = self._safe_format(cmd_data["new_prompt"], where=f"new_prompt for command {line!r}")
+                    if new_prompt is not None:
+                        self.prompt = new_prompt
             else:
                 log.warning(
                     "'%s' command prompt '%s' not matching current prompt '%s'",
@@ -189,24 +239,8 @@ class CMDShell(Cmd):
         if not self.is_running.is_set():
             return True
         if ret is not None:
-            try:
-                ret = ret.format(base_prompt=self.base_prompt)
-            except (KeyError, IndexError, ValueError) as e:
-                # Runtime shell is intentionally lenient: yaml format errors
-                # are logged but do not crash the shell session. The build-
-                # time counterpart `tasks.render_template` raises RuntimeError
-                # for the same situation; the asymmetry is "raise vs silent",
-                # but the catch set is kept aligned (`(KeyError, IndexError,
-                # ValueError)`) so both paths cover the same `str.format()`
-                # failure modes. The yaml author is expected to use only
-                # `{base_prompt}` substitution; the `{x.attr}` / `{x[k]}` /
-                # format-spec mini-language is unsupported and may surface
-                # as `AttributeError` / `TypeError` outside this catch set.
-                log.error(
-                    "shell.default '%s' error formatting output for command '%s': %r",
-                    self.base_prompt,
-                    [line],
-                    e,
-                )
-            self.writeline(ret)
+            # Failure falls back to the raw template (information beats
+            # dropping the whole output); lenient policy in _safe_format.
+            formatted = self._safe_format(ret, where=f"output for command {line!r}")
+            self.writeline(formatted if formatted is not None else ret)
         return False

--- a/simnos/plugins/shell/cmd_shell.py
+++ b/simnos/plugins/shell/cmd_shell.py
@@ -24,8 +24,9 @@ BASIC_COMMANDS: dict = {
 
 # `str.format()` failure modes caused by a malformed template. Shared as the
 # single source of truth between the lenient runtime shell (`_safe_format`)
-# and the loud build-time docs gen (`tasks.render_template`); the two sides
-# differ only in "raise vs silent".
+# and the loud build-time docs gen (`tasks.render_template`); the runtime
+# logs and degrades while build time raises (and additionally strict-rejects
+# unsupported constructs that would render fine).
 FORMAT_ERRORS = (KeyError, IndexError, ValueError, AttributeError, TypeError)
 
 

--- a/tasks.py
+++ b/tasks.py
@@ -104,8 +104,9 @@ def render_template(template: str, platform: str, command: str, field: str) -> s
             if field_name != "base_prompt" or conversion is not None or format_spec:
                 raise RuntimeError(
                     f"Failed to format {field} for {platform}/{command!r}: unsupported template "
-                    f"construct. Only '{{base_prompt}}' substitution and '{{{{' / '}}}}' escapes "
-                    f"are supported."
+                    f"construct (field_name={field_name!r}, conversion={conversion!r}, "
+                    f"format_spec={format_spec!r}). Only '{{base_prompt}}' substitution and "
+                    f"'{{{{' / '}}}}' escapes are supported."
                 )
         return template.format(base_prompt=platform)
     except FORMAT_ERRORS as exc:

--- a/tasks.py
+++ b/tasks.py
@@ -8,6 +8,7 @@ local docs serving (`docs`), platform docs generation
 
 from collections.abc import Iterable
 import os
+import string
 import time
 
 from invoke import task
@@ -79,17 +80,33 @@ def render_template(template: str, platform: str, command: str, field: str) -> s
     substitutes `{base_prompt}` and unescapes `{{` / `}}` literals from
     `sync_ntc_commands.escape_format_braces` preventive escape.
 
-    Re-raises any formatting failure (the `FORMAT_ERRORS` catch set shared
-    with the lenient runtime `cmd_shell._safe_format`; the asymmetry is
-    "raise vs silent" only) as `RuntimeError` carrying the platform /
-    command / field context, so CI failures pinpoint the offending YAML
-    entry instead of dumping a contextless stack trace.
+    Build time is strict: besides re-raising the `FORMAT_ERRORS` catch set
+    shared with the lenient runtime `cmd_shell._safe_format`, this rejects
+    unsupported constructs that `str.format()` would happily render (e.g.
+    `{base_prompt!r}` or `{base_prompt:>20}`) — only a plain
+    `{base_prompt}` field and `{{` / `}}` escapes are supported. Every
+    failure surfaces as `RuntimeError` carrying the platform / command /
+    field context, so CI failures pinpoint the offending YAML entry
+    instead of dumping a contextless stack trace.
     """
     # Lazy import: keep `invoke --list` / lint-only tasks fast (the existing
     # tasks.py convention, see netmiko_check); cached after the first call.
     from simnos.plugins.shell.cmd_shell import FORMAT_ERRORS
 
     try:
+        # Strict authoring check first: a malformed template raises ValueError
+        # out of parse() (caught below); a well-formed but unsupported
+        # construct (conversion / format spec / non-base_prompt field) would
+        # render silently, so it must be rejected explicitly.
+        for _, field_name, format_spec, conversion in string.Formatter().parse(template):
+            if field_name is None:
+                continue
+            if field_name != "base_prompt" or conversion is not None or format_spec:
+                raise RuntimeError(
+                    f"Failed to format {field} for {platform}/{command!r}: unsupported template "
+                    f"construct. Only '{{base_prompt}}' substitution and '{{{{' / '}}}}' escapes "
+                    f"are supported."
+                )
         return template.format(base_prompt=platform)
     except FORMAT_ERRORS as exc:
         raise RuntimeError(

--- a/tasks.py
+++ b/tasks.py
@@ -79,13 +79,19 @@ def render_template(template: str, platform: str, command: str, field: str) -> s
     substitutes `{base_prompt}` and unescapes `{{` / `}}` literals from
     `sync_ntc_commands.escape_format_braces` preventive escape.
 
-    Re-raises any formatting failure as `RuntimeError` carrying the
-    platform / command / field context, so CI failures pinpoint the
-    offending YAML entry instead of dumping a contextless stack trace.
+    Re-raises any formatting failure (the `FORMAT_ERRORS` catch set shared
+    with the lenient runtime `cmd_shell._safe_format`; the asymmetry is
+    "raise vs silent" only) as `RuntimeError` carrying the platform /
+    command / field context, so CI failures pinpoint the offending YAML
+    entry instead of dumping a contextless stack trace.
     """
+    # Lazy import: keep `invoke --list` / lint-only tasks fast (the existing
+    # tasks.py convention, see netmiko_check); cached after the first call.
+    from simnos.plugins.shell.cmd_shell import FORMAT_ERRORS
+
     try:
         return template.format(base_prompt=platform)
-    except (KeyError, IndexError, ValueError) as exc:
+    except FORMAT_ERRORS as exc:
         raise RuntimeError(
             f"Failed to format {field} for {platform}/{command!r}: {exc!r}. "
             f"Check that any literal '{{' / '}}' in YAML is escaped as '{{{{' / '}}}}'."

--- a/tests/plugins/test_cmd_shell.py
+++ b/tests/plugins/test_cmd_shell.py
@@ -454,7 +454,7 @@ class TestCmdShell(TestCase):
     def test_default_silent_fallback_on_typeerror(self):
         """`TypeError` failure mode of `.format()` is silently logged.
 
-        Pins #171: index access on the str argument (`{base_prompt[bad]}`)
+        Pins #171: item access on the str argument (`{base_prompt[bad]}`)
         raises `TypeError` ("string indices must be integers"), the fifth
         and last member of `FORMAT_ERRORS`. Together the five fallback
         tests pin every member of the catch set shared with
@@ -463,14 +463,14 @@ class TestCmdShell(TestCase):
         self.arguments["is_running"].set()
         shell = CMDShell(**self.arguments)
         shell.writeline = Mock()
-        shell.commands["broken_index_cmd"] = {
+        shell.commands["broken_item_cmd"] = {
             "output": "value is {base_prompt[bad]}",
             "prompt": ["{base_prompt}>"],
         }
         with self.assertLogs("simnos.plugins.shell.cmd_shell", level="ERROR") as captured:
-            shell.default("broken_index_cmd")
+            shell.default("broken_item_cmd")
         self.assertEqual(len(captured.output), 1)
-        self.assertTrue(any("error formatting output" in msg and "broken_index_cmd" in msg for msg in captured.output))
+        self.assertTrue(any("error formatting output" in msg and "broken_item_cmd" in msg for msg in captured.output))
         shell.writeline.assert_called_once_with("value is {base_prompt[bad]}")
 
     def test_default_new_prompt_format_failure_keeps_prompt(self):

--- a/tests/plugins/test_cmd_shell.py
+++ b/tests/plugins/test_cmd_shell.py
@@ -148,6 +148,27 @@ class TestCmdShell(TestCase):
                 base_prompt="test",
             )
 
+    def test_init_broken_initial_prompt_falls_back_to_raw(self):
+        """A malformed initial_prompt template must not crash construction.
+
+        Pins #172: `__init__` used to call `.format()` unguarded, so a
+        broken template killed every connection to the host. The lenient
+        fallback keeps the session usable (raw template as prompt) and
+        logs the error for diagnosis.
+        """
+        self.arguments["nos"] = Nos(
+            dict_args={
+                "name": "synth",
+                "initial_prompt": "{base_prompt.foo}>",
+                "commands": {"_default_": {"output": "% Unknown", "help": "default"}},
+            }
+        )
+        with self.assertLogs("simnos.plugins.shell.cmd_shell", level="ERROR") as captured:
+            shell = CMDShell(**self.arguments)
+        self.assertEqual(shell.prompt, "{base_prompt.foo}>")
+        self.assertEqual(len(captured.output), 1)
+        self.assertTrue(any("error formatting initial_prompt" in msg for msg in captured.output))
+
     def test_start(self):
         """Test that the start method calls cmdloop."""
         shell = CMDShell(**self.arguments)
@@ -407,6 +428,156 @@ class TestCmdShell(TestCase):
         self.assertEqual(len(captured.output), 1)
         self.assertTrue(any("error formatting output" in msg and "broken_pos_cmd" in msg for msg in captured.output))
         shell.writeline.assert_called_once_with("value is {}")
+
+    def test_default_silent_fallback_on_attributeerror(self):
+        """`AttributeError` failure mode of `.format()` is silently logged.
+
+        Pins #171: attribute access (`{base_prompt.foo}`) used to escape
+        the 3-tuple catch set — and the output format sits *outside* the
+        broad try block of `default()`, so this crashed the whole shell
+        session instead of just leaking a traceback. Now covered by the
+        shared 5-tuple `FORMAT_ERRORS`.
+        """
+        self.arguments["is_running"].set()
+        shell = CMDShell(**self.arguments)
+        shell.writeline = Mock()
+        shell.commands["broken_attr_cmd"] = {
+            "output": "value is {base_prompt.foo}",
+            "prompt": ["{base_prompt}>"],
+        }
+        with self.assertLogs("simnos.plugins.shell.cmd_shell", level="ERROR") as captured:
+            shell.default("broken_attr_cmd")
+        self.assertEqual(len(captured.output), 1)
+        self.assertTrue(any("error formatting output" in msg and "broken_attr_cmd" in msg for msg in captured.output))
+        shell.writeline.assert_called_once_with("value is {base_prompt.foo}")
+
+    def test_default_silent_fallback_on_typeerror(self):
+        """`TypeError` failure mode of `.format()` is silently logged.
+
+        Pins #171: index access on the str argument (`{base_prompt[bad]}`)
+        raises `TypeError` ("string indices must be integers"), the fifth
+        and last member of `FORMAT_ERRORS`. Together the five fallback
+        tests pin every member of the catch set shared with
+        `tasks.render_template`.
+        """
+        self.arguments["is_running"].set()
+        shell = CMDShell(**self.arguments)
+        shell.writeline = Mock()
+        shell.commands["broken_index_cmd"] = {
+            "output": "value is {base_prompt[bad]}",
+            "prompt": ["{base_prompt}>"],
+        }
+        with self.assertLogs("simnos.plugins.shell.cmd_shell", level="ERROR") as captured:
+            shell.default("broken_index_cmd")
+        self.assertEqual(len(captured.output), 1)
+        self.assertTrue(any("error formatting output" in msg and "broken_index_cmd" in msg for msg in captured.output))
+        shell.writeline.assert_called_once_with("value is {base_prompt[bad]}")
+
+    def test_default_new_prompt_format_failure_keeps_prompt(self):
+        """A broken cmd_data new_prompt does not transition the prompt.
+
+        Pins #172: the new_prompt format used to bubble into the broad
+        `except Exception`, leaking a traceback into the user output.
+        Now the failure is a silent log, the session stays on the current
+        prompt, and the command output is still written normally.
+        """
+        self.arguments["is_running"].set()
+        shell = CMDShell(**self.arguments)
+        shell.writeline = Mock()
+        shell.commands["broken_np_cmd"] = {
+            "output": "mode change attempted",
+            "prompt": ["{base_prompt}>"],
+            "new_prompt": "{base_prompt.foo}#",
+        }
+        with self.assertLogs("simnos.plugins.shell.cmd_shell", level="ERROR") as captured:
+            stop = shell.default("broken_np_cmd")
+        self.assertFalse(stop)
+        self.assertEqual(shell.prompt, "test>")
+        self.assertEqual(len(captured.output), 1)
+        self.assertTrue(any("error formatting new_prompt" in msg and "broken_np_cmd" in msg for msg in captured.output))
+        shell.writeline.assert_called_once_with("mode change attempted")
+
+    def test_default_callable_dict_new_prompt_format_failure(self):
+        """A broken callable-dict new_prompt does not transition the prompt.
+
+        Pins #172 (callable dict path, symmetric to the cmd_data path
+        above): format failure is a silent log + no transition, and no
+        traceback reaches the wire. The callable's own exceptions are
+        out of scope here (still the broad-except path, see G4).
+        """
+        shell = self._make_callable_dict_shell(
+            lambda device, **kwargs: {"output": "body", "new_prompt": "{base_prompt.foo}#"}
+        )
+        with self.assertLogs("simnos.plugins.shell.cmd_shell", level="ERROR") as captured:
+            stop = shell.default("cmd")
+        self.assertFalse(stop)
+        self.assertEqual(shell.prompt, "test>")
+        self.assertEqual(len(captured.output), 1)
+        self.assertTrue(any("error formatting new_prompt" in msg and "'cmd'" in msg for msg in captured.output))
+        shell.writeline.assert_called_once_with("body")
+
+    def test_default_broken_prompt_treated_as_non_match(self):
+        """A command with a broken prompt template is just unreachable.
+
+        Pins #172: `_check_prompt` used to leak the format error into the
+        broad `except Exception` (traceback in output). Now the broken
+        candidate is a logged non-match and the shell answers with the
+        unknown-command output, session intact.
+        """
+        self.arguments["is_running"].set()
+        shell = CMDShell(**self.arguments)
+        shell.writeline = Mock()
+        shell.commands["broken_prompt_cmd"] = {
+            "output": "should not appear",
+            "prompt": "{base_prompt.foo}>",
+        }
+        with self.assertLogs("simnos.plugins.shell.cmd_shell", level="ERROR") as captured:
+            shell.default("broken_prompt_cmd")
+        self.assertEqual(len(captured.output), 1)
+        self.assertTrue(any("error formatting prompt" in msg and "broken_prompt_cmd" in msg for msg in captured.output))
+        shell.writeline.assert_called_once_with("% Invalid input detected at '^' marker.")
+
+    def test_do_help_broken_prompt_command_hidden(self):
+        """`do_help` survives a broken prompt template (command hidden).
+
+        Pins #172: the `do_help` -> `_check_prompt` path had *no* guard at
+        all — a single broken prompt yaml crashed the session on `help`.
+        Now the broken command is silently omitted from the help listing.
+        """
+        self.arguments["is_running"].set()
+        shell = CMDShell(**self.arguments)
+        shell.writeline = Mock()
+        shell.commands["broken_prompt_cmd"] = {
+            "output": "x",
+            "prompt": "{base_prompt.foo}>",
+            "help": "never listed",
+        }
+        with self.assertLogs("simnos.plugins.shell.cmd_shell", level="ERROR") as captured:
+            shell.do_help("")
+        self.assertEqual(len(captured.output), 1)
+        help_text = shell.writeline.call_args[0][0]
+        self.assertNotIn("broken_prompt_cmd", help_text)
+        self.assertIn("show clock", help_text)  # healthy commands still listed
+
+    def test_default_list_prompt_partial_breakage_still_matches(self):
+        """A broken candidate in a prompt list does not poison the rest.
+
+        Pins the per-candidate independent evaluation of `_check_prompt`
+        (#172 design improvement): previously one broken element raised
+        out of the `any()` generator and failed the whole match; now the
+        healthy element still matches and the command works.
+        """
+        self.arguments["is_running"].set()
+        shell = CMDShell(**self.arguments)
+        shell.writeline = Mock()
+        shell.commands["partial_prompt_cmd"] = {
+            "output": "reached",
+            "prompt": ["{base_prompt.foo}>", "{base_prompt}>"],
+        }
+        with self.assertLogs("simnos.plugins.shell.cmd_shell", level="ERROR") as captured:
+            shell.default("partial_prompt_cmd")
+        self.assertEqual(len(captured.output), 1)  # the broken candidate, once
+        shell.writeline.assert_called_once_with("reached")
 
     def test_default_command_new_prompt(self):
         """Test that the default method does nothing."""

--- a/tests/plugins/test_cmd_shell.py
+++ b/tests/plugins/test_cmd_shell.py
@@ -516,6 +516,22 @@ class TestCmdShell(TestCase):
         self.assertTrue(any("error formatting new_prompt" in msg and "'cmd'" in msg for msg in captured.output))
         shell.writeline.assert_called_once_with("body")
 
+    def test_default_callable_dict_broken_output_falls_back_raw(self):
+        """A broken template in a callable-dict output is raw-passthrough.
+
+        Pins the callable -> dict -> output -> `_safe_format` chain
+        end-to-end (1st code review 反映): the dict's output str flows
+        into the same lenient output path as yaml strings — silent log +
+        raw template on the wire, session intact.
+        """
+        shell = self._make_callable_dict_shell(lambda device, **kwargs: {"output": "value is {base_prompt.foo}"})
+        with self.assertLogs("simnos.plugins.shell.cmd_shell", level="ERROR") as captured:
+            stop = shell.default("cmd")
+        self.assertFalse(stop)
+        self.assertEqual(len(captured.output), 1)
+        self.assertTrue(any("error formatting output" in msg and "'cmd'" in msg for msg in captured.output))
+        shell.writeline.assert_called_once_with("value is {base_prompt.foo}")
+
     def test_default_broken_prompt_treated_as_non_match(self):
         """A command with a broken prompt template is just unreachable.
 

--- a/tests/plugins/test_shell_utils.py
+++ b/tests/plugins/test_shell_utils.py
@@ -8,6 +8,7 @@ import time
 from unittest import TestCase
 from unittest.mock import patch
 
+from simnos.plugins.shell import utils as shell_utils
 from simnos.plugins.shell.utils import (
     change_jinja_to_corresponding_py,
     get_files_changed,
@@ -55,14 +56,27 @@ class ShellUtilsTest(TestCase):
     Test class for the shell utils
     """
 
+    def setUp(self):
+        """Reset the stateful get_files_changed cache before each test.
+
+        Other tests in the same pytest-xdist worker (e.g. the hot-reload
+        integration tests, which exercise `get_files_changed` via `precmd`
+        with the absolute `nos.__path__[0]`) may have primed the
+        module-level `_files_lasttime_changed_old` snapshot; without a
+        reset, the relative-path calls below would treat every file as
+        "new" and the first-call-returns-empty contract breaks.
+        """
+        shell_utils._files_lasttime_changed_old.clear()
+
     def tearDown(self):
+        """Avoid leaking the stateful cache to other tests.
+
+        Note: the previous implementation deleted the function attribute
+        `get_files_changed.files_lasttime_changed_old`, which silently
+        became a no-op when the cache moved to the module-level
+        `_files_lasttime_changed_old` (ty adoption, M-9).
         """
-        Set up for the tests.
-        We want to avoid side-effect as get_files_changed
-        it is stateful.
-        """
-        if hasattr(get_files_changed, "files_lasttime_changed_old"):
-            del get_files_changed.files_lasttime_changed_old
+        shell_utils._files_lasttime_changed_old.clear()
 
     def test_get_files_under_directory(self):
         """

--- a/tests/test_gen_docs_platform_commands.py
+++ b/tests/test_gen_docs_platform_commands.py
@@ -75,6 +75,17 @@ class TestRenderTemplate:
         with pytest.raises(RuntimeError, match=r"escape"):
             render_template("{oops}", "p", "c", "output")
 
+    def test_raises_runtime_error_on_positional_placeholder(self):
+        """`{}` (IndexError) must surface a contextual error.
+
+        Pins #171: IndexError was already in the catch set since #162 but
+        had no contextual-RuntimeError pin on this side; added so each
+        `FORMAT_ERRORS` member is pinned symmetrically with the runtime
+        fallback tests in tests/plugins/test_cmd_shell.py.
+        """
+        with pytest.raises(RuntimeError, match=r"Failed to format output for platformE/'cmd5'"):
+            render_template("value is {}", "platformE", "cmd5", "output")
+
     def test_raises_runtime_error_on_attribute_access(self):
         """`{base_prompt.foo}` (AttributeError) must surface a contextual error.
 
@@ -85,12 +96,12 @@ class TestRenderTemplate:
         with pytest.raises(RuntimeError, match=r"Failed to format output for platformC/'cmd3'"):
             render_template("{base_prompt.foo}", "platformC", "cmd3", "output")
 
-    def test_raises_runtime_error_on_index_access(self):
+    def test_raises_runtime_error_on_item_access(self):
         """`{base_prompt[bad]}` (TypeError) must surface a contextual error.
 
-        Pins #171: TypeError is the fifth member of `FORMAT_ERRORS`;
-        together with the three pre-existing tests above, every member of
-        the shared catch set has a contextual-RuntimeError pin.
+        Pins #171: TypeError is the fifth member of `FORMAT_ERRORS`; with
+        the KeyError / ValueError pins above and the IndexError pin, every
+        member of the shared catch set has a contextual-RuntimeError pin.
         """
         with pytest.raises(RuntimeError, match=r"Failed to format prompt for platformD/'cmd4'"):
             render_template("{base_prompt[bad]}", "platformD", "cmd4", "prompt")

--- a/tests/test_gen_docs_platform_commands.py
+++ b/tests/test_gen_docs_platform_commands.py
@@ -15,11 +15,25 @@ for platforms that contain literal braces (e.g. `{master:0}` in
 Also pin the sweep semantics so that deleting a yaml causes the matching
 markdown to be removed on the next regeneration, while hand-authored
 `index.md` / `index.ja.md` are preserved.
+
+Since #171/#172 the catch set is the 5-tuple `FORMAT_ERRORS` shared with
+the lenient runtime (`cmd_shell._safe_format`), and the platform-yaml
+template sweep below keeps the "build-time loud" side CI-resident.
 """
 
+import os
+
 import pytest
+import yaml
 
 from tasks import render_template, sweep_orphaned_platform_docs
+
+PLATFORMS_YAML_DIR = "simnos/plugins/nos/platforms_yaml"
+
+
+def _yaml_platforms() -> list[str]:
+    """Platform names from the yaml dir (the same source gen_docs lists)."""
+    return sorted(f.removesuffix(".yaml") for f in os.listdir(PLATFORMS_YAML_DIR) if f.endswith(".yaml"))
 
 
 class TestRenderTemplate:
@@ -60,6 +74,72 @@ class TestRenderTemplate:
         """Error message should point users at the escape rule."""
         with pytest.raises(RuntimeError, match=r"escape"):
             render_template("{oops}", "p", "c", "output")
+
+    def test_raises_runtime_error_on_attribute_access(self):
+        """`{base_prompt.foo}` (AttributeError) must surface a contextual error.
+
+        Pins #171: AttributeError joined the catch set when it became the
+        shared 5-tuple `FORMAT_ERRORS`; previously this dumped a
+        contextless stack trace at docs-gen time.
+        """
+        with pytest.raises(RuntimeError, match=r"Failed to format output for platformC/'cmd3'"):
+            render_template("{base_prompt.foo}", "platformC", "cmd3", "output")
+
+    def test_raises_runtime_error_on_index_access(self):
+        """`{base_prompt[bad]}` (TypeError) must surface a contextual error.
+
+        Pins #171: TypeError is the fifth member of `FORMAT_ERRORS`;
+        together with the three pre-existing tests above, every member of
+        the shared catch set has a contextual-RuntimeError pin.
+        """
+        with pytest.raises(RuntimeError, match=r"Failed to format prompt for platformD/'cmd4'"):
+            render_template("{base_prompt[bad]}", "platformD", "cmd4", "prompt")
+
+
+class TestPlatformYamlTemplateSweep:
+    """CI-resident loud counterpart of the lenient runtime (#171/#172).
+
+    The runtime shell silently logs malformed `{base_prompt}` templates
+    (`cmd_shell._safe_format`), so a yaml authoring mistake in this repo
+    would otherwise surface only as a runtime log line. This sweep renders
+    every str template field of every platform yaml through
+    `render_template`, turning such a mistake into a contextual
+    RuntimeError in CI.
+
+    Covered fields: top-level initial_prompt / enable_prompt /
+    config_prompt (the latter two are not formatted by cmd_shell today,
+    but are written as `{base_prompt}` templates in yaml — covered
+    preventively) + per-command output (str only; callable outputs are
+    covered by the T-14 / #230 device-class tests) / prompt (each list
+    candidate gets an indexed field name like `prompt[0]`) / new_prompt.
+    """
+
+    TOP_LEVEL_FIELDS = ("initial_prompt", "enable_prompt", "config_prompt")
+
+    @pytest.mark.parametrize("platform", _yaml_platforms())
+    def test_all_templates_render(self, platform):
+        """Every `{base_prompt}` template field in the yaml must render."""
+        with open(f"{PLATFORMS_YAML_DIR}/{platform}.yaml", encoding="utf-8") as file:
+            data = yaml.safe_load(file)
+
+        for field in self.TOP_LEVEL_FIELDS:
+            template = data.get(field)
+            if isinstance(template, str):
+                render_template(template, platform, "-", field)
+
+        for command, details in data.get("commands", {}).items():
+            output = details.get("output")
+            if isinstance(output, str):
+                render_template(output, platform, command, "output")
+            prompts = details.get("prompt", [])
+            if isinstance(prompts, str):
+                render_template(prompts, platform, command, "prompt")
+            else:
+                for i, prompt in enumerate(prompts):
+                    render_template(prompt, platform, command, f"prompt[{i}]")
+            new_prompt = details.get("new_prompt")
+            if isinstance(new_prompt, str):
+                render_template(new_prompt, platform, command, "new_prompt")
 
 
 class TestSweepOrphanedPlatformDocs:

--- a/tests/test_gen_docs_platform_commands.py
+++ b/tests/test_gen_docs_platform_commands.py
@@ -129,6 +129,17 @@ class TestRenderTemplate:
         with pytest.raises(RuntimeError, match=r"Failed to format prompt for platformG/'cmd7'.*unsupported"):
             render_template("{base_prompt:>20}", "platformG", "cmd7", "prompt")
 
+    def test_raises_runtime_error_on_nested_format_spec(self):
+        """`{base_prompt:{base_prompt}}` (nested replacement field) is rejected.
+
+        Pins the format_spec boundary of the strict authoring check (2nd
+        code review 反映): any non-empty spec — including a nested
+        replacement field — is unsupported, so a future relaxation of the
+        spec handling must consciously revisit this pin.
+        """
+        with pytest.raises(RuntimeError, match=r"Failed to format output for platformH/'cmd8'.*unsupported"):
+            render_template("{base_prompt:{base_prompt}}", "platformH", "cmd8", "output")
+
 
 class TestPlatformYamlTemplateSweep:
     """CI-resident loud counterpart of the lenient runtime (#171/#172).
@@ -165,7 +176,8 @@ class TestPlatformYamlTemplateSweep:
             output = details.get("output")
             if isinstance(output, str):
                 render_template(output, platform, command, "output")
-            prompts = details.get("prompt", [])
+            # `or []` also guards a degenerate `prompt:` entry (explicit null)
+            prompts = details.get("prompt") or []
             if isinstance(prompts, str):
                 render_template(prompts, platform, command, "prompt")
             else:

--- a/tests/test_gen_docs_platform_commands.py
+++ b/tests/test_gen_docs_platform_commands.py
@@ -5,7 +5,8 @@ Pin the formatter semantics that `gen_docs_platform_commands` relies on:
 - unescapes `{{` / `}}` literals (preventive escape from
   `sync_ntc_commands.escape_format_braces`)
 - raises `RuntimeError` with platform / command / field context on any
-  formatting failure (escape漏れ など)
+  formatting failure (escape漏れ など) and on unsupported-but-renderable
+  constructs (strict authoring check, e.g. `{base_prompt!r}`)
 
 Without these tests, a future refactor switching `.format()` back to
 `.replace()` (or any other formatter) would silently break docs rendering
@@ -76,35 +77,57 @@ class TestRenderTemplate:
             render_template("{oops}", "p", "c", "output")
 
     def test_raises_runtime_error_on_positional_placeholder(self):
-        """`{}` (IndexError) must surface a contextual error.
+        """`{}` must surface a contextual error.
 
-        Pins #171: IndexError was already in the catch set since #162 but
-        had no contextual-RuntimeError pin on this side; added so each
-        `FORMAT_ERRORS` member is pinned symmetrically with the runtime
+        Pins #171: would raise IndexError via `str.format()`; rejected by
+        the strict authoring check (empty field name). Added so each
+        unsupported-input family is pinned symmetrically with the runtime
         fallback tests in tests/plugins/test_cmd_shell.py.
         """
         with pytest.raises(RuntimeError, match=r"Failed to format output for platformE/'cmd5'"):
             render_template("value is {}", "platformE", "cmd5", "output")
 
     def test_raises_runtime_error_on_attribute_access(self):
-        """`{base_prompt.foo}` (AttributeError) must surface a contextual error.
+        """`{base_prompt.foo}` must surface a contextual error.
 
-        Pins #171: AttributeError joined the catch set when it became the
-        shared 5-tuple `FORMAT_ERRORS`; previously this dumped a
+        Pins #171: would raise AttributeError via `str.format()` (a member
+        of the shared 5-tuple `FORMAT_ERRORS`); rejected by the strict
+        authoring check (compound field name). Previously this dumped a
         contextless stack trace at docs-gen time.
         """
         with pytest.raises(RuntimeError, match=r"Failed to format output for platformC/'cmd3'"):
             render_template("{base_prompt.foo}", "platformC", "cmd3", "output")
 
     def test_raises_runtime_error_on_item_access(self):
-        """`{base_prompt[bad]}` (TypeError) must surface a contextual error.
+        """`{base_prompt[bad]}` must surface a contextual error.
 
-        Pins #171: TypeError is the fifth member of `FORMAT_ERRORS`; with
-        the KeyError / ValueError pins above and the IndexError pin, every
-        member of the shared catch set has a contextual-RuntimeError pin.
+        Pins #171: would raise TypeError via `str.format()`, the fifth
+        member of `FORMAT_ERRORS`; rejected by the strict authoring check.
+        With the KeyError / ValueError / IndexError pins above, every
+        unsupported-input family has a contextual-RuntimeError pin.
         """
         with pytest.raises(RuntimeError, match=r"Failed to format prompt for platformD/'cmd4'"):
             render_template("{base_prompt[bad]}", "platformD", "cmd4", "prompt")
+
+    def test_raises_runtime_error_on_conversion(self):
+        """`{base_prompt!r}` must be rejected even though it renders fine.
+
+        Pins the strict authoring check (1st code review 反映): conversion
+        specifiers raise no exception via `str.format()` (they would render
+        a quoted hostname), so without the explicit parse-time check the
+        "only two constructs supported" spec would silently erode.
+        """
+        with pytest.raises(RuntimeError, match=r"Failed to format output for platformF/'cmd6'.*unsupported"):
+            render_template("{base_prompt!r}", "platformF", "cmd6", "output")
+
+    def test_raises_runtime_error_on_format_spec(self):
+        """`{base_prompt:>20}` must be rejected even though it renders fine.
+
+        Pins the strict authoring check: str-valid format specs render
+        without raising, so the parse-time check is the only guard.
+        """
+        with pytest.raises(RuntimeError, match=r"Failed to format prompt for platformG/'cmd7'.*unsupported"):
+            render_template("{base_prompt:>20}", "platformG", "cmd7", "prompt")
 
 
 class TestPlatformYamlTemplateSweep:


### PR DESCRIPTION
🐙claude:

## Summary

#171 (catch 集合の `AttributeError` / `TypeError` 拡張) と #172 (`new_prompt` / `_check_prompt` 経路の lenient 化) の統合対応。`CMDShell._safe_format` helper に `.format(base_prompt=...)` 全 6 call site を集約し、yaml 著者の記述ミスが shell session crash / traceback 漏れにならないようにする。

設計 doc (local) は cross-review design 2 round、実装は cross-review code 2 round + pre/final-refactor 済。

### 事前調査での追加発見 (issue 記載より実害が大きかった点)

- output 経路の `AttributeError` / `TypeError` は broad try の**外**で発生 → traceback 漏れではなく **session crash**
- `do_help` → `_check_prompt` 経路は unguarded → 不正 prompt yaml 1 つで `help` コマンドが session crash
- `__init__` の initial_prompt format も unguarded → その platform への全接続が失敗
- **CI は build-time check (`gen_docs_platform_commands`) を実行していない** → 「runtime silent / build-time loud」の loud 側が手元実行頼みだった

### 変更内容

**production**
- `cmd_shell.py`: `FORMAT_ERRORS` 5-tuple (`KeyError/IndexError/ValueError/AttributeError/TypeError`) を module 定数化、`_safe_format(template, *, where) -> str | None` helper に全 6 call site を集約。`where` は command context 込み (既存 log pin を無変更で維持)
- 経路別 fallback: `__init__` → raw template / `_check_prompt` → 非 match (list は**要素ごと独立判定**に改善) / `new_prompt` → 遷移しない (`_apply_new_prompt` helper) / output → raw passthrough (現行維持)
- `tasks.py` `render_template`: `FORMAT_ERRORS` を lazy import 共有 + **strict authoring check** (`string.Formatter().parse()`) — `{base_prompt!r}` / `{base_prompt:>20}` のような「例外を投げず render される非サポート記法」も build-time で reject (runtime は lenient のまま)

**test (+15 件)**
- runtime: 5-tuple 全 member の silent fallback pin + 経路別 fallback pin (new_prompt ×2 / broken prompt ×2 / list 部分破損 / init raw fallback / callable dict broken output)
- build-time: contextual RuntimeError pin (Attr/Type/Index/conversion/spec/nested spec) + **実 yaml 全数 template sweep** (per-platform parametrize、list prompt は `prompt[i]` index 込み field 名) — 「build-time loud」を CI 常駐化

**docs**
- `creating_new_platforms.md` (+ja): Templating rules 節 — サポート記法 (実例付き) / 非サポート一覧 / runtime・build-time の失敗時挙動。`enable_prompt`/`config_prompt` は runtime 未消費で CI sweep が予防検証する旨を明記

### 挙動変化

crash → 安全縮退 ×3 経路 (`__init__` / `do_help` / output Attr・Type)、traceback 漏れ → silent log ×3 経路 (format 起因のみ — callable 自体の例外は従来通り、G4 scope)。**正常系の挙動変化なし** (production 変更直後に既存 57 test が無変更で全 pass することを確認済)。

## Test plan

- [x] `pytest -n auto` full suite: **911 passed** / 7 skipped / 1 xfailed (fail 2 件は既知の docker ローカル環境依存、CI では green 実績 — T-9/T-14 と同判断)
- [x] `invoke ruff` / `invoke yamllint` / `invoke bandit` green
- [x] 既存 yaml 全数を strict check で事前走査 → violation 0 件
- [x] cross-review 2 round (codex / gemini / claude): 最終 round 全員 blocking なし

## 備考

- `{base_prompt:d}` の例外型は設計時想定 (TypeError) と異なり **ValueError** だった (実機確認、TypeError は `{base_prompt[bad]}`) — test は実態に合わせて pin
- `output_variants` field (yaml 56 箇所) は runtime 未参照 + pydantic 未定義の純粋データ — 扱いは G5 (YAML 規約) で再訪候補 (レビューで確認済、本 PR scope 外)

Closes #171
Closes #172

🤖 Generated with [Claude Code](https://claude.com/claude-code)
