### PR TITLE
test: suite 全体の default pytest timeout 300s を導入 — hang を 5 分で fail 化 (#233)

### DIFF
--- a/docs/development/conventions.ja.md
+++ b/docs/development/conventions.ja.md
@@ -18,6 +18,9 @@ Pytest は Python のテストフレームワークで、シンプルかつス�
 pytest
 ```
 
+!!! note
+    suite には test ごとの global timeout 300 秒 ([pytest-timeout](https://pypi.org/project/pytest-timeout/)) が設定されています。hang したテストは CI job timeout まで run をブロックする代わりに数分で fail します。個々のテストは `@pytest.mark.timeout(...)` で override できます — loop リスクのあるテストには厳しめの pin、遅い all-commands sweep には緩めの margin を指定します。
+
 ## セキュリティチェック: Bandit
 Bandit は Python コードのセキュリティツールで、一般的なセキュリティ問題や脆弱性を検出します。Python コードを静的に分析し、モジュールの安全でない使用、安全でない関数呼び出し、潜在的なセキュリティリスクなどのセキュリティ上の脅威を特定します。Bandit はさまざまなセキュリティ問題をチェックするプラグインセットを提供し、開発ワークフローに簡単に統合できるため、開発者が開発プロセスの早い段階でセキュリティ問題を特定して修正するのに役立ちます。Python アプリケーションやライブラリのセキュリティ体制を改善するための貴重なツールです。
 

--- a/docs/development/conventions.ja.md
+++ b/docs/development/conventions.ja.md
@@ -19,7 +19,7 @@ pytest
 ```
 
 !!! note
-    suite には test ごとの global timeout 300 秒 ([pytest-timeout](https://pypi.org/project/pytest-timeout/)) が設定されています。hang したテストは CI job timeout まで run をブロックする代わりに数分で fail します。個々のテストは `@pytest.mark.timeout(...)` で override できます — loop リスクのあるテストには厳しめの pin、遅い all-commands sweep には緩めの margin を指定します。
+    suite には test ごとの global timeout 300 秒 ([pytest-timeout](https://pypi.org/project/pytest-timeout/)) が設定されています。hang したテストは CI job timeout まで run をブロックする代わりに数分で fail します。個々のテストは `@pytest.mark.timeout(...)` で override できます — loop リスクのあるテストには厳しめの pin、遅い all-commands sweep と docker テストには緩めの margin を指定します。
 
 ## セキュリティチェック: Bandit
 Bandit は Python コードのセキュリティツールで、一般的なセキュリティ問題や脆弱性を検出します。Python コードを静的に分析し、モジュールの安全でない使用、安全でない関数呼び出し、潜在的なセキュリティリスクなどのセキュリティ上の脅威を特定します。Bandit はさまざまなセキュリティ問題をチェックするプラグインセットを提供し、開発ワークフローに簡単に統合できるため、開発者が開発プロセスの早い段階でセキュリティ問題を特定して修正するのに役立ちます。Python アプリケーションやライブラリのセキュリティ体制を改善するための貴重なツールです。

--- a/docs/development/conventions.md
+++ b/docs/development/conventions.md
@@ -19,7 +19,7 @@ pytest
 ```
 
 !!! note
-    The suite has a global timeout of 300 seconds per test ([pytest-timeout](https://pypi.org/project/pytest-timeout/)): a hung test fails in minutes instead of blocking the run until the CI job timeout. Individual tests may override it with `@pytest.mark.timeout(...)` — tighter pins for loop-risk tests, looser margins for the slow all-commands sweeps.
+    The suite has a global timeout of 300 seconds per test ([pytest-timeout](https://pypi.org/project/pytest-timeout/)): a hung test fails in minutes instead of blocking the run until the CI job timeout. Individual tests may override it with `@pytest.mark.timeout(...)` — tighter pins for loop-risk tests, looser margins for the slow all-commands sweeps and the docker tests.
 
 ## Security check: Bandit
 Bandit is a security tool for Python code that detects common security issues and vulnerabilities. It analyzes Python code statically to identify potential security threats such as insecure use of modules, unsafe function calls, and potential security risks. Bandit provides a set of plugins that check for various security issues and can be easily integrated into development workflows, helping developers identify and fix security issues early in the development process. It's a valuable tool for improving the security posture of Python applications and libraries.

--- a/docs/development/conventions.md
+++ b/docs/development/conventions.md
@@ -18,6 +18,9 @@ To run the tests do the following:
 pytest
 ```
 
+!!! note
+    The suite has a global timeout of 300 seconds per test ([pytest-timeout](https://pypi.org/project/pytest-timeout/)): a hung test fails in minutes instead of blocking the run until the CI job timeout. Individual tests may override it with `@pytest.mark.timeout(...)` — tighter pins for loop-risk tests, looser margins for the slow all-commands sweeps.
+
 ## Security check: Bandit
 Bandit is a security tool for Python code that detects common security issues and vulnerabilities. It analyzes Python code statically to identify potential security threats such as insecure use of modules, unsafe function calls, and potential security risks. Bandit provides a set of plugins that check for various security issues and can be easily integrated into development workflows, helping developers identify and fix security issues early in the development process. It's a valuable tool for improving the security posture of Python applications and libraries.
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -135,6 +135,13 @@ testpaths = ["tests"]
 # --dist loadgroup: behaves like the default `load` scheduling, except tests
 # sharing an `xdist_group` mark run on one worker (hot-reload fs tests, #232).
 addopts = "-vv -n auto --dist loadgroup -m 'not compatibility'"
+# Suite-wide safety net (#233): a hung loop/SSH test fails in 5 minutes
+# instead of sitting silent until the CI job timeout. Per-test
+# `@pytest.mark.timeout(...)` marks override this — tighter pins (30/60/200)
+# for loop-risk tests, looser margins (600) for the all-commands sweeps and
+# docker tests. The timeout method is left unset on purpose: POSIX uses
+# `signal` (the worker survives the failure), Windows falls back to `thread`.
+timeout = 300
 markers = [
     "compatibility: requires the `compatibility` dep group (netmiko/scrapli/ansible-core) and is run only via the compatibility CI workflow",
     "xdist_group: serialize tests sharing external state onto one xdist worker (pytest-xdist marker, honored via --dist loadgroup; hot-reload fs tests, #232)",

--- a/tests/core/test_docker.py
+++ b/tests/core/test_docker.py
@@ -76,6 +76,7 @@ def setup():
 
 
 @pytest.mark.skipif(_skip_docker_tests(), reason="Docker is not available or in CI.")
+@pytest.mark.timeout(600)  # cold `docker compose up` (image build) can exceed the global 300s (#233)
 def test_container(setup):
     """
     Test that we can connect to the device and run a command
@@ -96,6 +97,7 @@ def test_container(setup):
 
 
 @pytest.mark.skipif(_skip_docker_tests(), reason="Docker is not available or in CI.")
+@pytest.mark.timeout(600)  # cold `docker compose up` (image build) can exceed the global 300s (#233)
 def test_container_multiple_connections(setup):
     """
     Similar to test_container, but it runs multiple

--- a/tests/test_pytest_config.py
+++ b/tests/test_pytest_config.py
@@ -14,3 +14,15 @@ def test_global_timeout_configured(request):
     silently disappear from pyproject.toml.
     """
     assert float(request.config.getini("timeout")) == 300.0
+
+
+def test_timeout_method_left_to_auto(request):
+    """`timeout_method` stays unset on purpose (#233).
+
+    Pinning a method would break portability: POSIX uses `signal` (the
+    worker survives the failure) while Windows — covered by the weekly
+    full-matrix — has no SIGALRM and needs the `thread` fallback. An
+    explicit method appearing in pyproject.toml should be a conscious,
+    reviewed decision, not a drive-by edit.
+    """
+    assert not request.config.getini("timeout_method")

--- a/tests/test_pytest_config.py
+++ b/tests/test_pytest_config.py
@@ -1,0 +1,16 @@
+"""
+Pins for the pytest suite configuration itself (pyproject.toml
+``[tool.pytest.ini_options]``) — guards safety-net settings that no
+functional test would catch if they were silently removed.
+"""
+
+
+def test_global_timeout_configured(request):
+    """The suite-wide hang safety net stays armed (#233).
+
+    A hung loop/SSH test must fail in minutes instead of sitting silent
+    until the CI job timeout. Per-test `@pytest.mark.timeout(...)` marks
+    may override the default, but the global default itself must not
+    silently disappear from pyproject.toml.
+    """
+    assert float(request.config.getini("timeout")) == 300.0


### PR DESCRIPTION
🐙claude:

Closes #233

## 概要

suite 全体の default pytest timeout (300s) を導入し、loop/SSH 対話系 regression が **hang として現れたとき CI job timeout (6h) まで沈黙する穴**を「5 分での timeout fail」として可視化する (T-9 #228 からの継続検討事項)。

調査の結果、実態は issue 記載と異なり「導入済み・未設定」だった:

- `pytest-timeout` は**既に dev dependency** (installed 2.4.0)
- 個別 `@pytest.mark.timeout` も **11 箇所存在** (30s ×7 / 60s ×1 / 200s ×1 / 600s ×2)
- 欠けていたのは `[tool.pytest.ini_options]` の **global default のみ**

## 変更内容 (XS、+52 行)

- **`pyproject.toml`**: `timeout = 300` + rationale コメント
  - 値の根拠: durations 実測で mark なし最遅 12.9s (local) → >10x margin、誤爆リスク実質ゼロ
  - `timeout_method` は**意図的に未指定** — POSIX は `signal` (test fail 後も worker 生存)、Windows (週次 full-matrix) は SIGALRM なしのため `thread` に自動 fallback。明示固定は portability を壊す
  - unit/integration の値分離はしない — 既存個別 mark が「厳しい pin (30/60/200)」「緩い margin (600)」の例外指定として既に機能しており、default + 例外の構図が完成する
- **`tests/core/test_docker.py`**: 両 test に `timeout(600)` — cold `docker compose up` (image build) が global 300s を超えうる唯一の誤爆候補 (CI では skip、local 専用)
- **`tests/test_pytest_config.py`** (新規): config pin ×2 — `timeout = 300` が黙って消えると safety net 失効が不可視になる穴 + `timeout_method` unset (auto) が意図的判断であることを pin
- **`docs/development/conventions.md` / `.ja.md`**: Pytest 節に suite-wide timeout の note

## 検証

- **故意 hang test の実証**: `time.sleep(3600)` の demo test が `Failed: Timeout (>5.0s) from pytest-timeout` で fail 化
- header: `timeout: 300.0s / method: signal` (xdist `-n auto --dist loadgroup` 併用で正常動作)
- full suite: **923 passed, 7 skipped, 1 xfailed**、所要 ~3 分で導入前と変化なし = 誤爆ゼロ (docker ×2 はローカル環境依存、CI green 実績)
- `invoke ruff` / `invoke yamllint`: clean

## レビュー

cross-review 1 round (🦊codex / 🐳gemini / 🐙claude): 3 者とも **SUGGESTION** (MUST/SHOULD = 0、実装本体は全 GOOD)。全 3 件取り込み済:

- 🐳 `timeout_method` unset の pin test 追加
- 🦊 docs の 600s 例外例に docker tests を明示
- 🐙/🐳 worklog の既存 mark 件数を実測値 (11) に訂正

## AI Transparency

🤖 AI-assisted development (Claude Code)。全変更は human maintainer のレビューを経て merge されます。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
