### PR TITLE
chore: #199/G1 defer の follow-up 小粒 6 件を一括消化 — helper 抽出 / port range 復元 / double-start guard 等 (#237)

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -56,6 +56,11 @@ jobs:
           image-ref: "${{ env.IMAGE_NAME }}:scan"
           format: "sarif"
           output: "trivy-results.sarif"
+        env:
+          # Reuse the vulnerability DB the table scan above just downloaded
+          # (same runner cache dir) instead of fetching it a second time (#237).
+          TRIVY_SKIP_DB_UPDATE: "true"
+          TRIVY_SKIP_JAVA_DB_UPDATE: "true"
       - name: "Upload Trivy SARIF to GitHub Code Scanning"
         # SARIF upload is a security observability channel, not a release gate.
         # `continue-on-error: true` keeps a transient Code Scanning outage from

--- a/.gitignore
+++ b/.gitignore
@@ -144,7 +144,6 @@ act
 inventory.yaml
 # local work artifacts
 design/
-workslog/
 worklogs/
 
 # Claude Code settings

--- a/simnos/core/host.py
+++ b/simnos/core/host.py
@@ -61,12 +61,15 @@ class Host:
     def start(self):
         """Method to start server instance for this host.
 
-        No-op if the server is already running (``self.running``); this
-        guards against a double-start spawning a duplicate server instance
-        (and orphaning the first one), symmetric with the double-stop
-        guard in ``stop()``.
+        No-op if the server is already running (``self.running``),
+        symmetric with the double-stop guard in ``stop()``. This protects
+        direct ``host.start()`` callers from spawning a duplicate server
+        instance (and orphaning the first one); the SimNOS-level
+        orchestration already filters on ``host_running=False`` and never
+        double-starts.
         """
         if self.running:
+            log.debug("Host %s is already running; start() is a no-op", self.name)
             return
         self.server_plugin = self.simnos.servers_plugins[self.server_inventory["plugin"]]
         self.shell_plugin = self.simnos.shell_plugins[self.shell_inventory["plugin"]]

--- a/simnos/core/host.py
+++ b/simnos/core/host.py
@@ -99,6 +99,7 @@ class Host:
         (``self.server is None``); this guards against double-stop calls.
         """
         if self.server is None:
+            log.debug("Host %s has no running server; stop() is a no-op", self.name)
             return
         self.server.stop()
         self.server = None

--- a/simnos/core/host.py
+++ b/simnos/core/host.py
@@ -7,8 +7,9 @@ It also validates the host object using pydantic.
 import logging
 from typing import TYPE_CHECKING
 
-from simnos.core.nos import Nos, available_platforms
+from simnos.core.nos import Nos
 from simnos.core.pydantic_models import ModelHost
+from simnos.plugins.nos import assert_platform_supported
 
 if TYPE_CHECKING:
     from simnos.core.simnos import SimNOS
@@ -58,7 +59,15 @@ class Host:
         self._validate()
 
     def start(self):
-        """Method to start server instance for this host."""
+        """Method to start server instance for this host.
+
+        No-op if the server is already running (``self.running``); this
+        guards against a double-start spawning a duplicate server instance
+        (and orphaning the first one), symmetric with the double-stop
+        guard in ``stop()``.
+        """
+        if self.running:
+            return
         self.server_plugin = self.simnos.servers_plugins[self.server_inventory["plugin"]]
         self.shell_plugin = self.simnos.shell_plugins[self.shell_inventory["plugin"]]
         self.nos_plugin = self.simnos.nos_plugins.get(self.nos_inventory["plugin"], self.nos_inventory["plugin"])
@@ -99,7 +108,9 @@ class Host:
         ModelHost(**self.__dict__)
 
     def _check_if_platform_is_supported(self, platform: str):
-        """Check if the platform is supported"""
-        if platform not in available_platforms:
-            msg = f"Platform {platform} is not supported by SIMNOS. Supported platforms are: {available_platforms}"
-            raise ValueError(msg)
+        """Check if the platform is supported.
+
+        Thin wrapper around the registry-level helper; kept as a method
+        because tests patch / call it as the Host-level seam (#237).
+        """
+        assert_platform_supported(platform)

--- a/simnos/core/pydantic_models.py
+++ b/simnos/core/pydantic_models.py
@@ -3,17 +3,22 @@ File to contain pydantic models for plugins input/output data validation
 """
 
 from collections.abc import Callable
-from typing import Literal
+from typing import Annotated, Literal
 
 from pydantic import (
     BaseModel,
     ConfigDict,
+    Field,
     IPvAnyAddress,
     StrictBool,
     StrictInt,
     StrictStr,
     model_validator,
 )
+
+# Valid TCP port. Restores the range constraint lost in the pydantic v1 -> v2
+# migration (v1 used `conint(strict=True, gt=0, le=65535)`); #237 / #199 C-15.
+Port = Annotated[StrictInt, Field(ge=1, le=65535)]
 
 # ---------------------------------------------------------------------------------------
 # NOS plugin commands model
@@ -54,7 +59,7 @@ class ModelHost(BaseModel):
     name: StrictStr
     username: StrictStr
     password: StrictStr
-    port: StrictInt
+    port: Port
     platform: StrictStr | None = None
 
 
@@ -152,7 +157,7 @@ class InventoryDefaultSection(BaseModel):
 
     username: StrictStr | None = None
     password: StrictStr | None = None
-    port: StrictInt | list[StrictInt] | None = None
+    port: Port | list[Port] | None = None
     configuration_file: StrictStr | None = None
     platform: StrictStr | None = None
     server: ParamikoSshServerPlugin | TelnetServerPlugin | None = None

--- a/simnos/core/simnos.py
+++ b/simnos/core/simnos.py
@@ -475,7 +475,6 @@ def simnos(platform: str | None = None, inventory: dict | None = None, return_in
         raise ValueError("platform or inventory must be set")
     if platform:
         assert_platform_supported(platform)
-    if platform:
         inventory = {
             "hosts": {
                 "SimNOS": {

--- a/simnos/core/simnos.py
+++ b/simnos/core/simnos.py
@@ -24,7 +24,7 @@ from simnos.core.timeouts import (
     SHUTDOWN_SAFETY_NET_PER_THREAD,
 )
 from simnos.core.utils import _is_in_docker
-from simnos.plugins.nos import available_platforms, nos_plugins
+from simnos.plugins.nos import assert_platform_supported, nos_plugins
 from simnos.plugins.servers import servers_plugins
 from simnos.plugins.shell import shell_plugins
 
@@ -473,10 +473,8 @@ def simnos(platform: str | None = None, inventory: dict | None = None, return_in
         raise ValueError("platform and inventory cannot be used together")
     if not platform and not inventory:
         raise ValueError("platform or inventory must be set")
-    if platform and platform not in available_platforms:
-        raise ValueError(
-            f"Platform {platform} is not supported by SIMNOS. Supported platforms are: {available_platforms}"
-        )
+    if platform:
+        assert_platform_supported(platform)
     if platform:
         inventory = {
             "hosts": {

--- a/simnos/plugins/nos/__init__.py
+++ b/simnos/plugins/nos/__init__.py
@@ -46,5 +46,19 @@ for file in py_files:
 
 # Single source of truth for "supported platform" — derived from `nos_plugins`
 # so that adding a yaml/py file under platforms_yaml/ or platforms_py/ is the
-# only step needed to extend the registry. Sorted for deterministic order.
-available_platforms: list[str] = sorted(nos_plugins.keys())
+# only step needed to extend the registry. Sorted for deterministic order;
+# a tuple so consumers cannot mutate the registry view in place (#237).
+available_platforms: tuple[str, ...] = tuple(sorted(nos_plugins.keys()))
+
+
+def assert_platform_supported(platform: str) -> None:
+    """Raise ValueError if `platform` is not a registered NOS plugin.
+
+    Shared by `Host._validate` and the `@simnos` test decorator so the
+    check and its error message live next to the registry they guard
+    (#237, G1 follow-up).
+    """
+    if platform not in available_platforms:
+        raise ValueError(
+            f"Platform {platform} is not supported by SIMNOS. Supported platforms are: {available_platforms}"
+        )

--- a/simnos/plugins/nos/__init__.py
+++ b/simnos/plugins/nos/__init__.py
@@ -59,6 +59,8 @@ def assert_platform_supported(platform: str) -> None:
     (#237, G1 follow-up).
     """
     if platform not in available_platforms:
+        # Join the names so the user-facing message does not leak the
+        # registry container type (tuple vs list repr).
         raise ValueError(
-            f"Platform {platform} is not supported by SIMNOS. Supported platforms are: {available_platforms}"
+            f"Platform {platform} is not supported by SIMNOS. Supported platforms are: {', '.join(available_platforms)}"
         )

--- a/tests/core/test_host.py
+++ b/tests/core/test_host.py
@@ -56,6 +56,20 @@ class TestHost:
         assert host.running
         host.server.start.assert_called_once()
 
+    def test_start_twice_is_noop(self, host):
+        """A second start() while running does not spawn a new server.
+
+        Pins the double-start guard (#237, #199 C-23 follow-up): without
+        it, start() built and started a second server instance, orphaning
+        the first. Symmetric with the double-stop guard in stop().
+        """
+        host.start()
+        first_server = host.server
+        host.start()
+        assert host.server is first_server
+        first_server.start.assert_called_once()
+        assert host.running
+
     def test_stop(self, host):
         """
         It test that when the host is called the stop,

--- a/tests/core/test_host.py
+++ b/tests/core/test_host.py
@@ -60,8 +60,9 @@ class TestHost:
         """A second start() while running does not spawn a new server.
 
         Pins the double-start guard (#237, #199 C-23 follow-up): without
-        it, start() built and started a second server instance, orphaning
-        the first. Symmetric with the double-stop guard in stop().
+        it, a direct start() call built and started a second server
+        instance, orphaning the first. Symmetric with the double-stop
+        guard in stop().
         """
         host.start()
         first_server = host.server
@@ -69,6 +70,25 @@ class TestHost:
         assert host.server is first_server
         first_server.start.assert_called_once()
         assert host.running
+
+    def test_restart_after_stop_creates_new_server(self, host):
+        """start() after stop() builds and starts a fresh server.
+
+        Separates the restartable semantics from the idempotent no-op
+        (#237 cross-review 🦊#5): the guard gates on `self.running`, so
+        a regression in stop()'s state update would silently turn
+        restarts into no-ops — this pin catches that.
+        """
+        host.start()
+        host.stop()
+        host.start()
+        assert host.running
+        assert host.server is not None
+        # The plugin factory ran twice = a fresh server was built for the
+        # restart (the mock factory returns the same object both times,
+        # so instance identity cannot be asserted here).
+        assert host.server_plugin.call_count == 2
+        assert host.server.start.call_count == 2
 
     def test_stop(self, host):
         """

--- a/tests/core/test_pydantic_models.py
+++ b/tests/core/test_pydantic_models.py
@@ -22,17 +22,21 @@ class TestPortRange:
 
     @pytest.mark.parametrize("port", [1, 22, 65535])
     def test_model_host_accepts_valid_ports(self, port):
+        """Boundary and typical in-range ports pass validation."""
         assert ModelHost(**self.HOST_KWARGS, port=port).port == port
 
     @pytest.mark.parametrize("port", [0, -1, 65536])
     def test_model_host_rejects_out_of_range_ports(self, port):
+        """Zero, negative and > 65535 ports are rejected."""
         with pytest.raises(ValidationError, match="port"):
             ModelHost(**self.HOST_KWARGS, port=port)
 
     def test_inventory_default_accepts_valid_port_list(self):
+        """The replicas-style list[Port] variant accepts in-range ports."""
         assert InventoryDefaultSection(port=[6000, 6001]).port == [6000, 6001]
 
     @pytest.mark.parametrize("ports", [[6000, 0], [65536]])
     def test_inventory_default_rejects_out_of_range_port_list(self, ports):
+        """A single out-of-range element fails the whole list."""
         with pytest.raises(ValidationError, match="port"):
             InventoryDefaultSection(port=ports)

--- a/tests/core/test_pydantic_models.py
+++ b/tests/core/test_pydantic_models.py
@@ -1,0 +1,38 @@
+"""
+Test module for simnos.core.pydantic_models.
+This module can be found at simnos/core/pydantic_models.py
+"""
+
+from pydantic import ValidationError
+import pytest
+
+from simnos.core.pydantic_models import InventoryDefaultSection, ModelHost
+
+
+class TestPortRange:
+    """Pins for the TCP port range constraint on the `Port` type (#237).
+
+    The pydantic v1 -> v2 migration silently dropped the v1-era
+    `conint(strict=True, gt=0, le=65535)` range, leaving bare `StrictInt`
+    fields that accepted 0, negatives and > 65535. These tests pin the
+    restored 1-65535 range on both port-bearing models.
+    """
+
+    HOST_KWARGS = {"name": "r1", "username": "u", "password": "p"}
+
+    @pytest.mark.parametrize("port", [1, 22, 65535])
+    def test_model_host_accepts_valid_ports(self, port):
+        assert ModelHost(**self.HOST_KWARGS, port=port).port == port
+
+    @pytest.mark.parametrize("port", [0, -1, 65536])
+    def test_model_host_rejects_out_of_range_ports(self, port):
+        with pytest.raises(ValidationError, match="port"):
+            ModelHost(**self.HOST_KWARGS, port=port)
+
+    def test_inventory_default_accepts_valid_port_list(self):
+        assert InventoryDefaultSection(port=[6000, 6001]).port == [6000, 6001]
+
+    @pytest.mark.parametrize("ports", [[6000, 0], [65536]])
+    def test_inventory_default_rejects_out_of_range_port_list(self, ports):
+        with pytest.raises(ValidationError, match="port"):
+            InventoryDefaultSection(port=ports)

--- a/tests/core/test_simnos.py
+++ b/tests/core/test_simnos.py
@@ -537,7 +537,15 @@ class TestPlatformsManifest:
         Test if the available platforms in the platforms.py file
         are ordered alphabetically.
         """
-        assert available_platforms == sorted(available_platforms)
+        assert list(available_platforms) == sorted(available_platforms)
+
+    def test_available_platforms_is_read_only(self):
+        """Pin that `available_platforms` is an immutable tuple (#237).
+
+        A mutable list let consumers mutate the registry view in place;
+        the tuple makes the derived view read-only at the type level.
+        """
+        assert isinstance(available_platforms, tuple)
 
     def test_available_platforms_in_docs_are_ordered(self):
         """
@@ -600,7 +608,7 @@ class TestPlatformsManifest:
         (`nos_plugins`) and the public symbol breaks this test immediately,
         catching the failure mode that issue #206 (G1) eliminated.
         """
-        assert available_platforms == sorted(nos_plugins.keys())
+        assert list(available_platforms) == sorted(nos_plugins.keys())
 
     def test_available_platforms_excludes_base_template(self):
         """Pin that `base_template` is filtered out of both registry and manifest.


### PR DESCRIPTION
🐙claude:

Closes #237

## 概要

umbrella #199 / G1 で defer された follow-up 小粒 6 件を一括消化する bundle。いずれも起票時 (2026-06-05) にコード実態で現存を再検証済み。これで **#199 系の未起票 defer backlog がゼロ**になる。

## 変更内容 (6 件、9 files +140/-19)

| # | 項目 | 内容 |
|---|---|---|
| 1 | helper 抽出 (G1 defer) | `assert_platform_supported` を registry の home (`plugins/nos/__init__.py`) に新設 — `host.py` / `simnos.py` の同一エラー message 重複を解消。`Host._check_if_platform_is_supported` は tests が patch する seam なので thin wrapper として維持。message は `", ".join` 整形 (container 型の repr を user-facing に漏らさない) |
| 2 | `available_platforms` 読み取り専用化 (G1 defer) | `tuple[str, ...]` 化 + immutability pin。全 caller (indexing / `random.choice` / parametrize / sorted 比較) の tuple 互換を確認済 |
| 3 | port range 復元 (#199 C-15) | `Port = Annotated[StrictInt, Field(ge=1, le=65535)]` を `ModelHost` / `InventoryDefaultSection` に適用。**pydantic v1→v2 migration で消えていた range 制約の復元** — docs (`simnos_inventory.md` en/ja) は既に「1-65535」を明記しており、コードが docs の claim に追いついた形。pin 9 cases (境界 1/65535、拒否 0/-1/65536、list 変種) |
| 4 | `Host.start()` double-start guard (#199 C-23) | `stop()` と対称の no-op + `log.debug`。直呼び経路での重複 server 生成 (先行 instance の orphan 化) を防止 — orchestration 経路は `host_running=False` filter で既に防御済であることを docstring に明記。restart 経路 (`start→stop→start` で再生成) も pin |
| 5 | Trivy DB 二重 download 軽減 (#199 Bundle F defer) | SARIF scan step に `TRIVY_SKIP_DB_UPDATE` / `TRIVY_SKIP_JAVA_DB_UPDATE` — 同一 runner で table scan が DL 済の DB を再利用 |
| 6 | `.gitignore` typo 削除 (#199 Bundle F defer) | `workslog/` typo entry 削除。local の旧 worklog 10 本は `worklogs/` へ移動済 (Bundle F で割れた互換性懸念を dir ごと解消) |

## 検証

- full suite: **935 passed, 7 skipped, 1 xfailed** (+13 pin tests。docker ×2 はローカル環境依存、CI green 実績)
- `invoke ruff` / `invoke yamllint`: clean

## レビュー

cross-review 1 round (🦊codex / 🐳gemini / 🐙claude): 3 者とも **SUGGESTION** (MUST/SHOULD = 0、6 項目の本体は全 GOOD)。取り込み 4 件:

- 🐙 error message の `", ".join` 整形 / guard docstring の実効範囲精緻化
- 🐳 guard 時の `log.debug` (final-refactor で `stop()` 側も対称化)
- 🦊 restart 経路の pin (冪等 no-op と restartable の semantics 分離)
- 🦊 Trivy action 更新時の前提コメント維持は現 diff で要件満足 (worklog 記録)

## AI Transparency

🤖 AI-assisted development (Claude Code)。全変更は human maintainer のレビューを経て merge されます。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
