### PR TITLE
refactor: 縮小 G5 PR2 — 27 platform の _default_ を vendor 実文言に補充 + dlink flat CLI fix (Closes #244)

### DIFF
--- a/platform_yaml_lint_baseline.yaml
+++ b/platform_yaml_lint_baseline.yaml
@@ -13,46 +13,19 @@
 # is that the frozen set never grows back.
 missing_default:
 - simnos/plugins/nos/platforms_yaml/alcatel_aos.yaml
-- simnos/plugins/nos/platforms_yaml/alcatel_sros.yaml
-- simnos/plugins/nos/platforms_yaml/allied_telesis_awplus.yaml
-- simnos/plugins/nos/platforms_yaml/arista_eos.yaml
 - simnos/plugins/nos/platforms_yaml/aruba_os.yaml
-- simnos/plugins/nos/platforms_yaml/avaya_ers.yaml
-- simnos/plugins/nos/platforms_yaml/avaya_vsp.yaml
-- simnos/plugins/nos/platforms_yaml/broadcom_icos.yaml
-- simnos/plugins/nos/platforms_yaml/brocade_fastiron.yaml
-- simnos/plugins/nos/platforms_yaml/brocade_netiron.yaml
-- simnos/plugins/nos/platforms_yaml/checkpoint_gaia.yaml
 - simnos/plugins/nos/platforms_yaml/ciena_saos.yaml
-- simnos/plugins/nos/platforms_yaml/cisco_asa.yaml
 - simnos/plugins/nos/platforms_yaml/cisco_ftd.yaml
-- simnos/plugins/nos/platforms_yaml/cisco_ios.yaml
-- simnos/plugins/nos/platforms_yaml/cisco_nxos.yaml
-- simnos/plugins/nos/platforms_yaml/cisco_s300.yaml
 - simnos/plugins/nos/platforms_yaml/cisco_xr.yaml
-- simnos/plugins/nos/platforms_yaml/dell_force10.yaml
 - simnos/plugins/nos/platforms_yaml/dell_powerconnect.yaml
-- simnos/plugins/nos/platforms_yaml/dlink_ds.yaml
 - simnos/plugins/nos/platforms_yaml/eltex.yaml
 - simnos/plugins/nos/platforms_yaml/ericsson_ipos.yaml
-- simnos/plugins/nos/platforms_yaml/extreme_exos.yaml
 - simnos/plugins/nos/platforms_yaml/fortinet.yaml
-- simnos/plugins/nos/platforms_yaml/hp_comware.yaml
-- simnos/plugins/nos/platforms_yaml/hp_procurve.yaml
 - simnos/plugins/nos/platforms_yaml/huawei_smartax.yaml
-- simnos/plugins/nos/platforms_yaml/huawei_vrp.yaml
 - simnos/plugins/nos/platforms_yaml/ipinfusion_ocnos.yaml
-- simnos/plugins/nos/platforms_yaml/juniper_junos.yaml
 - simnos/plugins/nos/platforms_yaml/juniper_screenos.yaml
 - simnos/plugins/nos/platforms_yaml/linux.yaml
-- simnos/plugins/nos/platforms_yaml/mikrotik_routeros.yaml
 - simnos/plugins/nos/platforms_yaml/paloalto_panos.yaml
-- simnos/plugins/nos/platforms_yaml/ruckus_fastiron.yaml
-- simnos/plugins/nos/platforms_yaml/ubiquiti_edgerouter.yaml
-- simnos/plugins/nos/platforms_yaml/ubiquiti_edgeswitch.yaml
-- simnos/plugins/nos/platforms_yaml/vyatta_vyos.yaml
-- simnos/plugins/nos/platforms_yaml/yamaha.yaml
-- simnos/plugins/nos/platforms_yaml/zyxel_os.yaml
 stub_help:
   simnos/plugins/nos/platforms_yaml/alcatel_aos.yaml:
   - show chassis

--- a/simnos/plugins/nos/platforms_yaml/alcatel_sros.yaml
+++ b/simnos/plugins/nos/platforms_yaml/alcatel_sros.yaml
@@ -1060,3 +1060,7 @@ commands:
       -------------------------------------------------------------------------------\n\
       Matching Services : 8\n-------------------------------------------------------------------------------\n\
       ===============================================================================\n"
+  # source: https://documentation.nokia.com/html/0_add-h-f/93-0070-10-01/7750_SR_OS_System_Basics_Guide/CLI%20Usage.html (retrieved 2026-06-07)
+  _default_:
+    output: "Error: Bad command."
+    help: default output for unknown commands

--- a/simnos/plugins/nos/platforms_yaml/allied_telesis_awplus.yaml
+++ b/simnos/plugins/nos/platforms_yaml/allied_telesis_awplus.yaml
@@ -336,3 +336,7 @@ commands:
     prompt:
     - "{base_prompt}>"
     - "{base_prompt}#"
+  # source: https://www.alliedtelesis.com/sites/default/files/getting_started_with_alliedware_plus.pdf (retrieved 2026-06-07)
+  _default_:
+    output: "% Invalid input detected at '^' marker."
+    help: default output for unknown commands

--- a/simnos/plugins/nos/platforms_yaml/arista_eos.yaml
+++ b/simnos/plugins/nos/platforms_yaml/arista_eos.yaml
@@ -1713,3 +1713,7 @@ commands:
       (S,G): True\n      No interfaces in inherited olist (S,G): True\n"
     help: execute the command "show ip mroute vrf all detail"
     prompt: *id001
+  # source: https://www.arista.com/en/um-eos/eos-command-line-interface-cli (retrieved 2026-06-07)
+  _default_:
+    output: "% Invalid input"
+    help: default output for unknown commands

--- a/simnos/plugins/nos/platforms_yaml/avaya_ers.yaml
+++ b/simnos/plugins/nos/platforms_yaml/avaya_ers.yaml
@@ -334,6 +334,8 @@ commands:
     - "{base_prompt}>"
     - "{base_prompt}#"
   # source: https://shrubbery.net/pipermail/rancid-discuss/2023-April/011289.html (retrieved 2026-06-07)
+  #   note: one real-device capture covering both VSP and ERS in the same
+  #   thread (shared with avaya_vsp); not two independent captures.
   _default_:
     output: "% Invalid input detected at '^' marker."
     help: default output for unknown commands

--- a/simnos/plugins/nos/platforms_yaml/avaya_ers.yaml
+++ b/simnos/plugins/nos/platforms_yaml/avaya_ers.yaml
@@ -333,3 +333,7 @@ commands:
     prompt:
     - "{base_prompt}>"
     - "{base_prompt}#"
+  # source: https://shrubbery.net/pipermail/rancid-discuss/2023-April/011289.html (retrieved 2026-06-07)
+  _default_:
+    output: "% Invalid input detected at '^' marker."
+    help: default output for unknown commands

--- a/simnos/plugins/nos/platforms_yaml/avaya_vsp.yaml
+++ b/simnos/plugins/nos/platforms_yaml/avaya_vsp.yaml
@@ -24,3 +24,7 @@ commands:
     prompt:
     - "{base_prompt}>"
     - "{base_prompt}#"
+  # source: https://shrubbery.net/pipermail/rancid-discuss/2023-April/011289.html (retrieved 2026-06-07)
+  _default_:
+    output: "% Invalid input detected at '^' marker."
+    help: default output for unknown commands

--- a/simnos/plugins/nos/platforms_yaml/avaya_vsp.yaml
+++ b/simnos/plugins/nos/platforms_yaml/avaya_vsp.yaml
@@ -25,6 +25,8 @@ commands:
     - "{base_prompt}>"
     - "{base_prompt}#"
   # source: https://shrubbery.net/pipermail/rancid-discuss/2023-April/011289.html (retrieved 2026-06-07)
+  #   note: one real-device capture covering both VSP and ERS in the same
+  #   thread (shared with avaya_ers); not two independent captures.
   _default_:
     output: "% Invalid input detected at '^' marker."
     help: default output for unknown commands

--- a/simnos/plugins/nos/platforms_yaml/broadcom_icos.yaml
+++ b/simnos/plugins/nos/platforms_yaml/broadcom_icos.yaml
@@ -240,3 +240,7 @@ commands:
     prompt:
     - "{base_prompt}>"
     - "{base_prompt}#"
+  # source: https://netbergtw.com/wp-content/uploads/Files/ICOS_cli_guide.pdf (retrieved 2026-06-07)
+  _default_:
+    output: "% Invalid input detected at '^' marker."
+    help: default output for unknown commands

--- a/simnos/plugins/nos/platforms_yaml/brocade_fastiron.yaml
+++ b/simnos/plugins/nos/platforms_yaml/brocade_fastiron.yaml
@@ -857,3 +857,9 @@ commands:
     - "{base_prompt}>"
     - "{base_prompt}#"
     - "{base_prompt}(config)#"
+  # source: https://smhk.net/note/2023/11/configuring-a-brocade-fastiron-switch/ (retrieved 2026-06-07)
+  _default_:
+    output: |-
+      Invalid input ->
+      Type ? for a list
+    help: default output for unknown commands

--- a/simnos/plugins/nos/platforms_yaml/brocade_netiron.yaml
+++ b/simnos/plugins/nos/platforms_yaml/brocade_netiron.yaml
@@ -560,3 +560,9 @@ commands:
     prompt:
     - "{base_prompt}>"
     - "{base_prompt}#"
+  # source: https://github.com/ktbyers/netmiko/issues/2924 (retrieved 2026-06-07)
+  _default_:
+    output: |-
+      Invalid input ->
+      Type ? for a list
+    help: default output for unknown commands

--- a/simnos/plugins/nos/platforms_yaml/checkpoint_gaia.yaml
+++ b/simnos/plugins/nos/platforms_yaml/checkpoint_gaia.yaml
@@ -206,3 +206,7 @@ commands:
     prompt:
     - "{base_prompt}>"
     - "{base_prompt}#"
+  # source: https://supportcenter.checkpoint.com/supportcenter/portal?eventSubmit_doGoviewsolutiondetails=&solutionid=sk108033 (retrieved 2026-06-07)
+  _default_:
+    output: "CLINFR0329 Invalid command:"
+    help: default output for unknown commands

--- a/simnos/plugins/nos/platforms_yaml/cisco_asa.yaml
+++ b/simnos/plugins/nos/platforms_yaml/cisco_asa.yaml
@@ -1423,3 +1423,7 @@ commands:
     new_prompt: "{base_prompt}#"
     help: exit configuration mode
     prompt: "{base_prompt}(config)#"
+  # source: https://community.cisco.com/t5/security-knowledge-base/the-quot-error-invalid-input-detected-at-marker-quot-error/ta-p/3121294 (retrieved 2026-06-07)
+  _default_:
+    output: "ERROR: % Invalid input detected at '^' marker."
+    help: default output for unknown commands

--- a/simnos/plugins/nos/platforms_yaml/cisco_ios.yaml
+++ b/simnos/plugins/nos/platforms_yaml/cisco_ios.yaml
@@ -5000,3 +5000,7 @@ commands:
     prompt:
     - "{base_prompt}>"
     - "{base_prompt}#"
+  # source: https://www.connecteddots.online/resources/cisco-reference/invalid-input-detected-at-marker (retrieved 2026-06-07)
+  _default_:
+    output: "% Invalid input detected at '^' marker."
+    help: default output for unknown commands

--- a/simnos/plugins/nos/platforms_yaml/cisco_nxos.yaml
+++ b/simnos/plugins/nos/platforms_yaml/cisco_nxos.yaml
@@ -5093,3 +5093,7 @@ commands:
       \ : DOWN [vrf-id: 0] [L3VNI: 0]\n\n"
     help: execute the command "show nve vni interface nve 1 detail"
     prompt: *id001
+  # source: https://github.com/ktbyers/netmiko/issues/2682 (retrieved 2026-06-07)
+  _default_:
+    output: "% Invalid command at '^' marker."
+    help: default output for unknown commands

--- a/simnos/plugins/nos/platforms_yaml/cisco_s300.yaml
+++ b/simnos/plugins/nos/platforms_yaml/cisco_s300.yaml
@@ -252,3 +252,7 @@ commands:
     prompt:
     - "{base_prompt}>"
     - "{base_prompt}#"
+  # source: https://community.cisco.com/t5/switches-small-business/why-am-i-getting-unrecognized-command-when-i-run-quot-ip-routing/td-p/2595094 (retrieved 2026-06-07)
+  _default_:
+    output: "Unrecognized command"
+    help: default output for unknown commands

--- a/simnos/plugins/nos/platforms_yaml/dell_force10.yaml
+++ b/simnos/plugins/nos/platforms_yaml/dell_force10.yaml
@@ -203,3 +203,7 @@ commands:
     prompt:
     - "{base_prompt}>"
     - "{base_prompt}#"
+  # source: https://github.com/ktbyers/netmiko/issues/1283 (retrieved 2026-06-07)
+  _default_:
+    output: "% Error: Invalid input at \"^\" marker."
+    help: default output for unknown commands

--- a/simnos/plugins/nos/platforms_yaml/dlink_ds.yaml
+++ b/simnos/plugins/nos/platforms_yaml/dlink_ds.yaml
@@ -1,6 +1,5 @@
 name: dlink_ds
 initial_prompt: "{base_prompt}#"
-enable_prompt: "{base_prompt}(config)#"
 commands:
   enable:
     output: null
@@ -34,3 +33,14 @@ commands:
     help: execute the command "show arpentry"
     prompt:
     - "{base_prompt}#"
+  # source: https://www.dlink.com/en/-/media/business_products/des/des-3526/manual/des_3526_cli_manual_v5_1.pdf (retrieved 2026-06-07)
+  _default_:
+    output: |-
+      Available commands:
+      ..                  ?                   cable_diag          clear
+      config              create              delete              dir
+      disable             download            drv                 enable
+      login               logout              ping                reboot
+      reconfig            reset               save                show
+      telnet              upload
+    help: default output for unknown commands

--- a/simnos/plugins/nos/platforms_yaml/extreme_exos.yaml
+++ b/simnos/plugins/nos/platforms_yaml/extreme_exos.yaml
@@ -425,3 +425,7 @@ commands:
       ARP Sender-Mac Learning   :   Disabled
 
       '
+  # source: https://community.extremenetworks.com/t5/extremeswitching-exos-switch/invalid-input-detected-at-marker-when-portforwarding/td-p/27455 (retrieved 2026-06-07)
+  _default_:
+    output: "%% Invalid input detected at '^' marker."
+    help: default output for unknown commands

--- a/simnos/plugins/nos/platforms_yaml/hp_comware.yaml
+++ b/simnos/plugins/nos/platforms_yaml/hp_comware.yaml
@@ -504,3 +504,7 @@ commands:
       \ Bridge-Aggregation25\nPort Number: 97 \nPort Priority: 32768\nOper-Key: 3\n\
       \nFortyGigE1/0/26: \nAggregate Interface: Bridge-Aggregation25\nPort Number:\
       \ 101 \nPort Priority: 32768\nOper-Key: 3"
+  # source: https://github.com/ktbyers/netmiko/issues/1548 (retrieved 2026-06-07)
+  _default_:
+    output: "% Unrecognized command found at '^' position."
+    help: default output for unknown commands

--- a/simnos/plugins/nos/platforms_yaml/hp_procurve.yaml
+++ b/simnos/plugins/nos/platforms_yaml/hp_procurve.yaml
@@ -573,3 +573,7 @@ commands:
       Serial Number    : SN0000005A\nUptime           : 454d 7h 42m\nCPU Utilization\
       \  : 0%\nMemory - Total   : 338,285,056 bytes\nFree             : 247,712,468\
       \ bytes\nVSF Links -\n#1 : Active, Peer member 1\n#2 : Active, Peer member 2\n"
+  # source: https://www.manualslib.com/manual/1638710/Hp-Aruba-Jl253a.html?page=462 (retrieved 2026-06-07)
+  _default_:
+    output: "Invalid input: "
+    help: default output for unknown commands

--- a/simnos/plugins/nos/platforms_yaml/huawei_vrp.yaml
+++ b/simnos/plugins/nos/platforms_yaml/huawei_vrp.yaml
@@ -822,3 +822,7 @@ commands:
       D state: Ok\nInfo: The test result is only for reference."
     help: execute the command "virtual-cable-test"
     prompt: *id001
+  # source: https://support.huawei.com/enterprise/en/doc/EDOC1100082539/941a7a88/interpreting-command-line-error-messages (retrieved 2026-06-07)
+  _default_:
+    output: "Error: Unrecognized command found at '^' position."
+    help: default output for unknown commands

--- a/simnos/plugins/nos/platforms_yaml/juniper_junos.yaml
+++ b/simnos/plugins/nos/platforms_yaml/juniper_junos.yaml
@@ -748,3 +748,7 @@ commands:
       24931 root         20    0    14M  3636K CPU5     5   0:00   0.00% top\n"
     help: execute the command "show system processes summary"
     prompt: *id001
+  # source: https://www.juniper.net/documentation/us/en/software/junos/user-access/topics/topic-map/junos-os-access-privileges.html (retrieved 2026-06-07)
+  _default_:
+    output: "unknown command."
+    help: default output for unknown commands

--- a/simnos/plugins/nos/platforms_yaml/juniper_junos.yaml
+++ b/simnos/plugins/nos/platforms_yaml/juniper_junos.yaml
@@ -749,6 +749,8 @@ commands:
     help: execute the command "show system processes summary"
     prompt: *id001
   # source: https://www.juniper.net/documentation/us/en/software/junos/user-access/topics/topic-map/junos-os-access-privileges.html (retrieved 2026-06-07)
+  #   note: indirect — the doc shows the `unknown command.` parse error in an
+  #   access-privileges example rather than a dedicated CLI-error page.
   _default_:
     output: "unknown command."
     help: default output for unknown commands

--- a/simnos/plugins/nos/platforms_yaml/mikrotik_routeros.yaml
+++ b/simnos/plugins/nos/platforms_yaml/mikrotik_routeros.yaml
@@ -796,3 +796,7 @@ commands:
       \               full                      jul/18/2023 05:12:46\n"
     help: execute the command "user print"
     prompt: "[admin@{base_prompt}] >"
+  # source: https://forum.mikrotik.com/t/bad-command-name-dude-line-1-column-1/100423 (retrieved 2026-06-07)
+  _default_:
+    output: "bad command name (line 1 column 1)"
+    help: default output for unknown commands

--- a/simnos/plugins/nos/platforms_yaml/ruckus_fastiron.yaml
+++ b/simnos/plugins/nos/platforms_yaml/ruckus_fastiron.yaml
@@ -634,3 +634,9 @@ commands:
     prompt:
     - "{base_prompt}>"
     - "{base_prompt}#"
+  # source: https://community.ruckuswireless.com/t5/ICX-Switches/ICX6610-invalid-input-when-trying-to-creating-ve-interface/m-p/43638 (retrieved 2026-06-07)
+  _default_:
+    output: |-
+      Invalid input ->
+      Type ? for a list
+    help: default output for unknown commands

--- a/simnos/plugins/nos/platforms_yaml/ubiquiti_edgerouter.yaml
+++ b/simnos/plugins/nos/platforms_yaml/ubiquiti_edgerouter.yaml
@@ -188,3 +188,7 @@ commands:
     prompt:
     - "{base_prompt}~$"
     - "{base_prompt}#"
+  # source: https://forum.vyos.io/t/all-specific-vyos-commands-are-invalid/7005 (retrieved 2026-06-07)
+  _default_:
+    output: "Invalid command: [ ]"
+    help: default output for unknown commands

--- a/simnos/plugins/nos/platforms_yaml/ubiquiti_edgeswitch.yaml
+++ b/simnos/plugins/nos/platforms_yaml/ubiquiti_edgeswitch.yaml
@@ -73,3 +73,7 @@ commands:
     prompt:
     - "{base_prompt}>"
     - "{base_prompt}#"
+  # source: https://www.manualslib.com/manual/858408/Ubiquiti-Edgeswitch-Es-24-250w.html?page=34 (retrieved 2026-06-07)
+  _default_:
+    output: "% Invalid input detected at '^' marker."
+    help: default output for unknown commands

--- a/simnos/plugins/nos/platforms_yaml/vyatta_vyos.yaml
+++ b/simnos/plugins/nos/platforms_yaml/vyatta_vyos.yaml
@@ -83,3 +83,7 @@ commands:
     prompt:
     - "{base_prompt}~$"
     - "{base_prompt}#"
+  # source: https://forum.vyos.io/t/all-specific-vyos-commands-are-invalid/7005 (retrieved 2026-06-07)
+  _default_:
+    output: "Invalid command: [ ]"
+    help: default output for unknown commands

--- a/simnos/plugins/nos/platforms_yaml/yamaha.yaml
+++ b/simnos/plugins/nos/platforms_yaml/yamaha.yaml
@@ -43,3 +43,7 @@ commands:
     prompt:
     - "{base_prompt}>"
     - "{base_prompt}#"
+  # source: https://www.rtpro.yamaha.co.jp/RT/docs/cli/vamh.html (retrieved 2026-06-07)
+  _default_:
+    output: "Error: Invalid command name"
+    help: default output for unknown commands

--- a/simnos/plugins/nos/platforms_yaml/zyxel_os.yaml
+++ b/simnos/plugins/nos/platforms_yaml/zyxel_os.yaml
@@ -253,3 +253,7 @@ commands:
     prompt:
     - "{base_prompt}>"
     - "{base_prompt}#"
+  # source: https://github.com/ktbyers/netmiko/issues/3299 (retrieved 2026-06-07)
+  _default_:
+    output: "Unknown command"
+    help: default output for unknown commands

--- a/tests/plugins/test_platforms.py
+++ b/tests/plugins/test_platforms.py
@@ -216,17 +216,59 @@ class TestPlatforms:
                         output = conn.send_command(command)
                         assert isinstance(output, str)
 
+    # Vendor-signature literal pins (#244 / D6): the wire test below reads
+    # its expectation from the yaml (SSoT), so it confirms the plumbing but
+    # NOT that the wording itself stays vendor-accurate — a regression that
+    # also rewrites the yaml would pass it (cross-review 🦊#5). These
+    # literals guard the distinctive signatures that are easy to drift back
+    # to a Cisco-style copy: "command" vs "input" (NX-OS), the `%%` double
+    # percent (EXOS), the `"^"` double-quoted caret (Force10), the two-line
+    # IronWare block (Brocade) and the multi-line listing (D-Link flat CLI).
+    # An intentional wording change updates both this map and the yaml.
+    _VENDOR_SIGNATURE_DEFAULTS = {
+        "cisco_nxos": "% Invalid command at '^' marker.",
+        "extreme_exos": "%% Invalid input detected at '^' marker.",
+        "dell_force10": '% Error: Invalid input at "^" marker.',
+        "brocade_netiron": "Invalid input ->\nType ? for a list",
+        "dlink_ds": (
+            "Available commands:\n"
+            "..                  ?                   cable_diag          clear\n"
+            "config              create              delete              dir\n"
+            "disable             download            drv                 enable\n"
+            "login               logout              ping                reboot\n"
+            "reconfig            reset               save                show\n"
+            "telnet              upload"
+        ),
+    }
+
+    @pytest.mark.parametrize("platform", sorted(_VENDOR_SIGNATURE_DEFAULTS))
+    def test_default_wording_keeps_vendor_signature(self, platform: str):
+        """The `_default_` output keeps its distinctive vendor signature (#244 / D6).
+
+        Literal guard against drifting a vendor-specific message back to a
+        generic Cisco-style one — the wire test reads from the yaml so it
+        cannot catch that (cross-review 🦊#5). A deliberate wording change
+        must update both this expectation and the yaml.
+        """
+        with open(f"simnos/plugins/nos/platforms_yaml/{platform}.yaml", encoding="utf-8") as file:
+            actual = yaml.safe_load(file)["commands"]["_default_"]["output"]
+        assert actual == self._VENDOR_SIGNATURE_DEFAULTS[platform]
+
     @pytest.mark.timeout(300)
-    @pytest.mark.parametrize("platform", ["cisco_ios", "juniper_junos", "brocade_netiron"])
+    # cisco_ios: single Cisco-style line / juniper_junos: lowercase + trailing
+    # period / brocade_netiron: two-line block / dell_force10: escaped `"^"`
+    # caret (the one wire pin that exercises a backslash-escaped scalar over
+    # the SSH channel, cross-review 🐙#5).
+    @pytest.mark.parametrize("platform", ["cisco_ios", "juniper_junos", "brocade_netiron", "dell_force10"])
     def test_platforms_yaml_default_wording_reaches_the_wire(self, platform: str):
         """The yaml-authored `_default_` answers an unknown command verbatim (#244 / D6).
 
         Pins the wording PR end to end over a real netmiko session, one
-        platform per output shape: single Cisco-style line (cisco_ios),
-        lowercase + trailing period (juniper_junos) and a two-line block
-        (brocade_netiron). The expected text is read from the platform
-        yaml itself (SSoT) so the pin survives future wording refinements
-        without duplicating data.
+        platform per output shape (see the parametrize comment). The
+        expected text is read from the platform yaml itself (SSoT) so the
+        pin survives future wording refinements without duplicating data;
+        the vendor-signature literals are guarded separately by
+        test_default_wording_keeps_vendor_signature.
         """
         with open(f"simnos/plugins/nos/platforms_yaml/{platform}.yaml", encoding="utf-8") as file:
             expected = yaml.safe_load(file)["commands"]["_default_"]["output"]

--- a/tests/plugins/test_platforms.py
+++ b/tests/plugins/test_platforms.py
@@ -78,7 +78,7 @@ class TestPlatforms:
         At least all the commands need to have the following with any conflict:
         - output
         - help
-        - prompt
+        - prompt (except `_default_`, see below)
         """
         with open(f"simnos/plugins/nos/platforms_yaml/{platform}.yaml", encoding="utf-8") as file:
             data = yaml.safe_load(file)
@@ -87,14 +87,22 @@ class TestPlatforms:
                 exceptions.append(data["enable_prompt"])
             if "config_prompt" in data:
                 exceptions.append(data["config_prompt"])
-            for values in data["commands"].values():
+            for command, values in data["commands"].items():
                 assert "output" in values or "exit" in values
                 if "output" in values:
                     assert not has_single_curly_brackets(values["output"], exceptions)
                 assert "help" in values
                 assert not has_single_curly_brackets(values["help"], exceptions)
-                assert "prompt" in values
-                assert not has_single_curly_brackets(values["prompt"], exceptions)
+                # `_default_` is the unknown-command fallback: the shell
+                # answers with its output regardless of the current prompt
+                # (mismatch path), so a `prompt` key is meaningless there —
+                # BASIC_COMMANDS' own `_default_` carries none either. The
+                # #244 / D6 wording entries are authored minimal (no prompt);
+                # pre-#244 entries that still carry one stay valid.
+                if command != "_default_":
+                    assert "prompt" in values
+                if "prompt" in values:
+                    assert not has_single_curly_brackets(values["prompt"], exceptions)
 
     @pytest.mark.parametrize("platform", get_py_platforms())
     def test_platforms_py_has_correct_format(self, platform: str):

--- a/tests/plugins/test_platforms.py
+++ b/tests/plugins/test_platforms.py
@@ -216,6 +216,44 @@ class TestPlatforms:
                         output = conn.send_command(command)
                         assert isinstance(output, str)
 
+    @pytest.mark.timeout(300)
+    @pytest.mark.parametrize("platform", ["cisco_ios", "juniper_junos", "brocade_netiron"])
+    def test_platforms_yaml_default_wording_reaches_the_wire(self, platform: str):
+        """The yaml-authored `_default_` answers an unknown command verbatim (#244 / D6).
+
+        Pins the wording PR end to end over a real netmiko session, one
+        platform per output shape: single Cisco-style line (cisco_ios),
+        lowercase + trailing period (juniper_junos) and a two-line block
+        (brocade_netiron). The expected text is read from the platform
+        yaml itself (SSoT) so the pin survives future wording refinements
+        without duplicating data.
+        """
+        with open(f"simnos/plugins/nos/platforms_yaml/{platform}.yaml", encoding="utf-8") as file:
+            expected = yaml.safe_load(file)["commands"]["_default_"]["output"]
+        device_type = NETMIKO_DEVICE_TYPE_MAP.get(platform, platform)
+        free_port: int = get_free_port()
+        credentials: dict = {
+            "host": "localhost",
+            "username": "test_user",
+            "password": "test_password",
+            "port": free_port,
+            "device_type": device_type,
+        }
+        inventory: dict = {
+            "hosts": {
+                "test_device": {
+                    "username": credentials["username"],
+                    "password": credentials["password"],
+                    "port": credentials["port"],
+                    "platform": platform,
+                }
+            }
+        }
+        with SimNOS(inventory=inventory) as net:  # noqa: F841
+            with ConnectHandler(**credentials) as conn:
+                output = conn.send_command("simnos pin unknown command")
+                assert expected in output
+
     @pytest.mark.timeout(600)
     @pytest.mark.parametrize("platform", get_py_platforms())
     def test_platforms_py_all_commands_are_running(self, platform: str):


### PR DESCRIPTION
🐙claude: issue #244 (縮小 G5) の PR2 (文言補充)。**Closes #244**。PR1 (#245、lint 基盤 + validation 再設計) merge 済みの上に乗る。code cross-review 1 round (🦊 SUGGESTION / 🐳 LGTM / 🐙 SUGGESTION、MUST/SHOULD なし)。

## 概要

PR1 で `_default_` 必須 lint を baseline ratchet として導入したのを受け、internet 調査で確証 (H/M-H) が取れた **27 platform** の `_default_` を vendor 実機の unknown-command エラーに補充し、baseline を縮める。**device 別 output を統一しない** (P-28/P-14 不採用方針) — むしろ各 vendor の署名を保存する。

## 変更内容 (D6)

### `_default_` 文言補充 (27 platform)
- 各 entry 直上に `# source: <URL> (retrieved 2026-06-07)` の出典コメント (in-repo 証跡 SSoT)。全 URL 到達性を機械確認 (community 系の bot 403 は browser UA で 200、dell_force10 は netmiko #1283 の verbatim capture)
- **vendor 署名を保存** (copy-paste 統一なし): NX-OS `% Invalid command at '^' marker.` (IOS の "input" と別語) / ASA `ERROR:` prefix / EXOS `%%` 二重 / Force10 `"^"` double-quote / Junos 小文字+period / Brocade 2 行 `Invalid input -> / Type ? for a list` / D-Link `Available commands:` + command 一覧 (flat CLI)
- token-echo 型は各機種の実機形に最も近い static form (vyos `[ ]` placeholder / procurve 末尾 space / mikrotik echo 省略)

### dlink_ds の flat CLI 修正 (付録 C)
- `enable_prompt: (config)#` は authoring ミス (D-Link DES/DGS は flat CLI、公式 manual 確証) → key 削除。`enable` command の no-op (`#`→`#`) 遷移は維持

### baseline 縮小
- `missing_default` 41 → **14** (補充 27 と 1:1、lint rule 5 が縮め忘れを強制)。残 14 は L/M confidence で **generic 維持** (確証なき文言は書かない)

### test
- contract test (`test_platforms_yaml_commands_has_correct_format`): `_default_` の `prompt` 必須を免除 (unknown/mismatch 経路は prompt 非依存で output を返す)
- `test_platforms_yaml_default_wording_reaches_the_wire`: 4 形状 (cisco_ios 1 行 / junos 小文字+period / brocade 2 行 / dell_force10 escape `"^"`) を実 SSH で wire 検証、期待値は yaml を SSoT として読む
- `test_default_wording_keeps_vendor_signature`: vendor 署名 5 件 (NX-OS/EXOS/Force10/brocade/dlink) の literal guard — yaml と test 両方を直さないと通らず、generic への drift を検出 (cross-review 🦊#5/🐙#5)

## テスト

- 997 passed (full suite, integration 込み) + signature pin 5 + wire pin 4
- 実 SSH wire 検証: cisco_ios / juniper_junos / brocade_netiron / dell_force10 で新文言の到達確認 ✅
- ruff / ty / yamllint / lint-platform-yaml 全 green

## レビュー

code cross-review 1 round: 3 者とも baseline 14==14 を機械確認、vendor 署名取り違えゼロを独立検証。SUGGESTION 2 件 (wire pin の wording-drift 死角 / juniper・avaya 出典の追跡可能性) を取り込み済 (literal signature pin + source コメント provenance note)。

## defer (worklog 記録)

- 旧 `_default_` 持ち 9 platform (zte/aruba_cx 等) の文言再検証 + prompt key 統一: 正文言の調査未実施のため「確証なき文言は書かない」原則で見送り (再調査時に同時実施)
- 残 14 platform (L/M confidence): generic 維持、出典が確証レベルに達したら将来補充

> [!NOTE]
> AI-assisted development (Claude Code)。全変更は human maintainer のレビューを経て merge してください。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
