### PR TITLE
refactor: G6 PR1 — test conftest 基盤一元化 + platform quirks 集約 (T-1 + T-15) (#247)

### DIFF
--- a/tests/_platform_quirks.py
+++ b/tests/_platform_quirks.py
@@ -1,0 +1,54 @@
+"""Centralized registry of platform-specific test quirks.
+
+Each entry pairs a platform with a :class:`Quirk` recording *why* the quirk
+exists (`reason`), the tracking issue if any (`issue`), and when it was last
+reviewed (`last_reviewed`). Keeping these together -- instead of scattering
+bare sets/dicts across test modules -- makes it visible at a glance which
+quirks could be retired next.
+
+Consumers test membership (``platform in QUIRK_DICT``); the reason is surfaced
+in the skip/xfail message so failures explain themselves.
+"""
+
+from dataclasses import dataclass
+
+
+@dataclass(frozen=True)
+class Quirk:
+    """A known platform-specific deviation exercised by the test suite."""
+
+    reason: str
+    issue: str | None  # "#NNN" or a URL; None means not yet tracked
+    last_reviewed: str  # "YYYY-MM-DD"
+
+
+# Platforms where netmiko's session_preparation() emits "Unknown command"
+# during init because of a missing command definition. Fix individually.
+INIT_UNKNOWN_CMD_ALLOWED: dict[str, Quirk] = {
+    "aruba_os": Quirk("no paging command", None, "2026-06-08"),
+    "brocade_fastiron": Quirk("enable (repeated)", None, "2026-06-08"),
+    "dlink_ds": Quirk("disable clipaging", None, "2026-06-08"),
+    "huawei_smartax": Quirk("enable password", "#70", "2026-06-08"),
+    "ruckus_fastiron": Quirk("enable (repeated), skip-page-display", None, "2026-06-08"),
+    "vyatta_vyos": Quirk("set terminal width 512", None, "2026-06-08"),
+}
+
+# Platforms where enable()/config_mode() cannot be exercised because they need
+# a secret or sudo. Their initial (show) commands are still tested.
+SKIP_ENABLE: dict[str, Quirk] = {
+    "alcatel_sros": Quirk("requires enable-admin with secret", None, "2026-06-08"),
+    "cisco_apic": Quirk("Linux-based, requires sudo -s for enable", None, "2026-06-08"),
+    "edgecore": Quirk("Linux-based (SONiC), requires sudo -s for enable", None, "2026-06-08"),
+    "ericsson_ipos": Quirk("requires administrator with secret", None, "2026-06-08"),
+    "linux": Quirk("Linux-based, requires sudo -s for enable", None, "2026-06-08"),
+    "yamaha": Quirk("requires enable with secret", None, "2026-06-08"),
+}
+
+# Python-plugin platforms whose "all commands" sweep is xfailed.
+XFAIL_PY_ALL_COMMANDS: dict[str, Quirk] = {
+    "huawei_smartax": Quirk(
+        "callable commands (return/disable) dynamically change the prompt, causing netmiko ReadTimeout",
+        None,
+        "2026-06-08",
+    ),
+}

--- a/tests/compatibility/conftest.py
+++ b/tests/compatibility/conftest.py
@@ -9,25 +9,19 @@ CI; they are skipped by default in the normal test suite via
 import pytest
 
 from simnos import SimNOS
-from tests.utils import get_free_port
+from tests.utils import TEST_PASSWORD, TEST_USERNAME, build_inventory, get_free_port
 
 
 @pytest.fixture
 def cisco_ios_simnos():
     """Start a simnos cisco_ios instance on a free port; yield connection creds."""
+    port = get_free_port()
+    inventory = build_inventory("cisco_ios", port=port)
     creds = {
         "host": "localhost",
-        "username": "test_user",
-        "password": "test_pass",
-        "port": get_free_port(),
-    }
-    inventory = {
-        "hosts": {
-            "test_device": {
-                **{k: creds[k] for k in ("username", "password", "port")},
-                "platform": "cisco_ios",
-            }
-        }
+        "username": TEST_USERNAME,
+        "password": TEST_PASSWORD,
+        "port": port,
     }
     with SimNOS(inventory=inventory) as _net:
         yield creds

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,29 @@
+"""Top-level pytest fixtures shared across the suite.
+
+`simnos_factory` is the auto-lifecycle counterpart to the `build_inventory`
+pure function in `tests.utils`: use the factory when a test wants a started
+SimNOS that is torn down automatically, and the pure function when the test
+manages start/stop itself (e.g. tests that stop mid-body or pre-allocate the
+port for a client before starting).
+"""
+
+import pytest
+
+from simnos.core.simnos import SimNOS
+from tests.utils import build_inventory
+
+
+@pytest.fixture
+def simnos_factory():
+    """Factory fixture: start a SimNOS for a platform, auto-stop on teardown."""
+    started: list[SimNOS] = []
+
+    def _make(platform: str, **overrides) -> SimNOS:
+        net = SimNOS(inventory=build_inventory(platform, **overrides))
+        net.start()
+        started.append(net)
+        return net
+
+    yield _make
+    for net in started:
+        net.stop()

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -9,7 +9,7 @@ port for a client before starting).
 
 import pytest
 
-from simnos.core.simnos import SimNOS
+from simnos import SimNOS
 from tests.utils import build_inventory
 
 
@@ -20,8 +20,10 @@ def simnos_factory():
 
     def _make(platform: str, **overrides) -> SimNOS:
         net = SimNOS(inventory=build_inventory(platform, **overrides))
-        net.start()
+        # Register before start() so a mid-start failure (partly-started hosts)
+        # is still torn down. SimNOS.stop() is a no-op for unstarted hosts.
         started.append(net)
+        net.start()
         return net
 
     yield _make

--- a/tests/core/test_netmiko_init_compat.py
+++ b/tests/core/test_netmiko_init_compat.py
@@ -20,36 +20,33 @@ import pytest
 from simnos import SimNOS
 from simnos.core.nos import Nos
 from simnos.plugins.nos import nos_plugins
-from tests.utils import NETMIKO_DEVICE_TYPE_MAP, get_free_port, get_platforms_from_md, get_py_platforms
+from tests._platform_quirks import INIT_UNKNOWN_CMD_ALLOWED
+from tests.utils import (
+    TEST_PASSWORD,
+    TEST_USERNAME,
+    build_inventory,
+    get_free_port,
+    get_platforms_from_md,
+    get_py_platforms,
+    netmiko_device,
+)
 
 HOSTNAME = "router"  # Inventory host key; also used as base_prompt in output formatting
 
-# Platforms where "Unknown command" is expected during init due to
-# missing command definitions for netmiko's session_preparation().
-# These should be fixed individually as separate issues.
-INIT_UNKNOWN_CMD_ALLOWED = {
-    "aruba_os",  # no paging
-    "brocade_fastiron",  # enable (repeated)
-    "dlink_ds",  # disable clipaging
-    "huawei_smartax",  # enable password (#70)
-    "ruckus_fastiron",  # enable (repeated), skip-page-display
-    "vyatta_vyos",  # set terminal width 512
-}
-
 
 def _make_simnos(device_type, port):
-    """Create a SimNOS instance for a single device."""
-    inventory = {
-        "hosts": {
-            HOSTNAME: {
-                "username": "test",
-                "password": "test",
-                "port": port,
-                "platform": device_type,
-            }
-        }
-    }
-    return SimNOS(inventory=inventory)
+    """Create a SimNOS instance for a single device.
+
+    `HOSTNAME` is kept as the host key because it doubles as the base_prompt
+    used in the output-formatting assertions below.
+    """
+    return SimNOS(inventory=build_inventory(device_type, host_key=HOSTNAME, port=port))
+
+
+def _device(device_type, port, **extra):
+    """Build netmiko ConnectHandler kwargs for a single-device SimNOS on `port`."""
+    creds = {"username": TEST_USERNAME, "password": TEST_PASSWORD, "port": port}
+    return netmiko_device(device_type, creds, **extra)
 
 
 class TestNetmikoInitCompat:
@@ -60,21 +57,14 @@ class TestNetmikoInitCompat:
     def test_no_unknown_command_on_init(self, device_type, tmp_path):
         """ConnectHandler init should not produce 'Unknown command'."""
         if device_type in INIT_UNKNOWN_CMD_ALLOWED:
-            pytest.skip(f"{device_type} is in the init exclusion list (#70)")
+            pytest.skip(f"{device_type}: {INIT_UNKNOWN_CMD_ALLOWED[device_type].reason}")
 
         port = get_free_port()
         log_file = tmp_path / f"session_{device_type}.log"
         net = _make_simnos(device_type, port)
         try:
             net.start()
-            device = {
-                "host": "localhost",
-                "username": "test",
-                "password": "test",
-                "port": port,
-                "device_type": NETMIKO_DEVICE_TYPE_MAP.get(device_type, device_type),
-                "session_log": str(log_file),
-            }
+            device = _device(device_type, port, session_log=str(log_file))
             with ConnectHandler(**device):
                 pass
             session_output = log_file.read_text()
@@ -92,13 +82,7 @@ class TestNetmikoInitCompat:
         net = _make_simnos(device_type, port)
         try:
             net.start()
-            device = {
-                "host": "localhost",
-                "username": "test",
-                "password": "test",
-                "port": port,
-                "device_type": NETMIKO_DEVICE_TYPE_MAP.get(device_type, device_type),
-            }
+            device = _device(device_type, port)
             with ConnectHandler(**device) as conn:
                 output = conn.send_command(
                     "this_command_does_not_exist_12345",
@@ -286,13 +270,7 @@ class TestSendCommandResponse:
         net = _make_simnos(device_type, port)
         try:
             net.start()
-            device = {
-                "host": "localhost",
-                "username": "test",
-                "password": "test",
-                "port": port,
-                "device_type": NETMIKO_DEVICE_TYPE_MAP.get(device_type, device_type),
-            }
+            device = _device(device_type, port)
             with ConnectHandler(**device) as conn:
                 output = conn.send_command(cmd, read_timeout=15)
                 assert output.strip() == expected.strip(), (
@@ -332,13 +310,7 @@ class TestSendCommandResponse:
         net = _make_simnos(device_type, port)
         try:
             net.start()
-            device = {
-                "host": "localhost",
-                "username": "test",
-                "password": "test",
-                "port": port,
-                "device_type": NETMIKO_DEVICE_TYPE_MAP.get(device_type, device_type),
-            }
+            device = _device(device_type, port)
             with ConnectHandler(**device) as conn:
 
                 def check(cmds: list[tuple[str, str]], phase: str) -> None:
@@ -474,13 +446,7 @@ class TestShutdownEOF:
         net = _make_simnos("cisco_ios", port)
         try:
             net.start()
-            device = {
-                "host": "localhost",
-                "username": "test",
-                "password": "test",
-                "port": port,
-                "device_type": "cisco_ios",
-            }
+            device = _device("cisco_ios", port)
             with ConnectHandler(**device):
                 pass
         finally:
@@ -497,13 +463,7 @@ class TestShutdownEOF:
         net = _make_simnos("cisco_ios", port)
         net.start()
         try:
-            device = {
-                "host": "localhost",
-                "username": "test",
-                "password": "test",
-                "port": port,
-                "device_type": "cisco_ios",
-            }
+            device = _device("cisco_ios", port)
             conn = ConnectHandler(**device)
             # Stop server while connection is still open
             net.stop()

--- a/tests/plugins/test_platforms.py
+++ b/tests/plugins/test_platforms.py
@@ -14,9 +14,9 @@ import pytest
 import yaml
 
 from simnos.core.nos import _find_device_classes, available_platforms
-from simnos.core.simnos import SimNOS
 from simnos.plugins.nos import nos_plugins
-from tests.utils import NETMIKO_DEVICE_TYPE_MAP, get_free_port, get_host_commands, get_py_platforms
+from tests._platform_quirks import SKIP_ENABLE, XFAIL_PY_ALL_COMMANDS
+from tests.utils import creds_from_host, get_host_commands, get_py_platforms, netmiko_device
 
 
 def get_yaml_only_platforms() -> list[str]:
@@ -164,57 +164,30 @@ class TestPlatforms:
 
     @pytest.mark.timeout(600)
     @pytest.mark.parametrize("platform", get_yaml_only_platforms())
-    def test_platforms_yaml_all_commands_are_running(self, platform: str):
+    def test_platforms_yaml_all_commands_are_running(self, platform: str, simnos_factory):
         """
         Test that all YAML-only platform commands can
         run without any error via netmiko.
         """
-        # Platforms where enable() or config_mode() fails due to missing secret/sudo/commands.
-        # Initial (show) commands are still tested for these platforms.
-        skip_enable_platforms = {
-            "alcatel_sros": "requires enable-admin with secret",
-            "cisco_apic": "Linux-based, requires sudo -s for enable",
-            "edgecore": "Linux-based (SONiC), requires sudo -s for enable",
-            "ericsson_ipos": "requires administrator with secret",
-            "linux": "Linux-based, requires sudo -s for enable",
-            "yamaha": "requires enable with secret",
-        }
-        device_type = NETMIKO_DEVICE_TYPE_MAP.get(platform, platform)
-        free_port: int = get_free_port()
-        credentials: dict = {
-            "host": "localhost",
-            "username": "test_user",
-            "password": "test_password",
-            "port": free_port,
-            "device_type": device_type,
-        }
-        inventory: dict = {
-            "hosts": {
-                "test_device": {
-                    "username": credentials["username"],
-                    "password": credentials["password"],
-                    "port": credentials["port"],
-                    "platform": platform,
-                }
-            }
-        }
-        with SimNOS(inventory=inventory) as net:
-            host = next(iter(net.hosts.values()))
-            initial_commands, enable_commands, config_commands = get_host_commands(host)
-            with ConnectHandler(**credentials) as conn:
-                for command in initial_commands:
+        net = simnos_factory(platform)
+        host = next(iter(net.hosts.values()))
+        initial_commands, enable_commands, config_commands = get_host_commands(host)
+        with ConnectHandler(**netmiko_device(platform, creds_from_host(host))) as conn:
+            for command in initial_commands:
+                output = conn.send_command(command)
+                assert isinstance(output, str)
+            # SKIP_ENABLE platforms cannot enter enable()/config_mode() (need a
+            # secret or sudo); their initial (show) commands above still run.
+            if enable_commands and platform not in SKIP_ENABLE:
+                conn.enable()
+                for command in enable_commands:
                     output = conn.send_command(command)
                     assert isinstance(output, str)
-                if enable_commands and platform not in skip_enable_platforms:
-                    conn.enable()
-                    for command in enable_commands:
-                        output = conn.send_command(command)
-                        assert isinstance(output, str)
-                if config_commands and platform not in skip_enable_platforms:
-                    conn.config_mode()
-                    for command in config_commands:
-                        output = conn.send_command(command)
-                        assert isinstance(output, str)
+            if config_commands and platform not in SKIP_ENABLE:
+                conn.config_mode()
+                for command in config_commands:
+                    output = conn.send_command(command)
+                    assert isinstance(output, str)
 
     # Vendor-signature literal pins (#244 / D6): the wire test below reads
     # its expectation from the yaml (SSoT), so it confirms the plumbing but
@@ -260,7 +233,7 @@ class TestPlatforms:
     # caret (the one wire pin that exercises a backslash-escaped scalar over
     # the SSH channel, cross-review 🐙#5).
     @pytest.mark.parametrize("platform", ["cisco_ios", "juniper_junos", "brocade_netiron", "dell_force10"])
-    def test_platforms_yaml_default_wording_reaches_the_wire(self, platform: str):
+    def test_platforms_yaml_default_wording_reaches_the_wire(self, platform: str, simnos_factory):
         """The yaml-authored `_default_` answers an unknown command verbatim (#244 / D6).
 
         Pins the wording PR end to end over a real netmiko session, one
@@ -272,74 +245,35 @@ class TestPlatforms:
         """
         with open(f"simnos/plugins/nos/platforms_yaml/{platform}.yaml", encoding="utf-8") as file:
             expected = yaml.safe_load(file)["commands"]["_default_"]["output"]
-        device_type = NETMIKO_DEVICE_TYPE_MAP.get(platform, platform)
-        free_port: int = get_free_port()
-        credentials: dict = {
-            "host": "localhost",
-            "username": "test_user",
-            "password": "test_password",
-            "port": free_port,
-            "device_type": device_type,
-        }
-        inventory: dict = {
-            "hosts": {
-                "test_device": {
-                    "username": credentials["username"],
-                    "password": credentials["password"],
-                    "port": credentials["port"],
-                    "platform": platform,
-                }
-            }
-        }
-        with SimNOS(inventory=inventory) as net:  # noqa: F841
-            with ConnectHandler(**credentials) as conn:
-                output = conn.send_command("simnos pin unknown command")
-                assert expected in output
+        net = simnos_factory(platform)
+        host = next(iter(net.hosts.values()))
+        with ConnectHandler(**netmiko_device(platform, creds_from_host(host))) as conn:
+            output = conn.send_command("simnos pin unknown command")
+            assert expected in output
 
     @pytest.mark.timeout(600)
     @pytest.mark.parametrize("platform", get_py_platforms())
-    def test_platforms_py_all_commands_are_running(self, platform: str):
+    def test_platforms_py_all_commands_are_running(self, platform: str, simnos_factory):
         """
         Test that all the platforms commands can
         run without any error.
         """
-        if platform == "huawei_smartax":
-            pytest.xfail(
-                "huawei_smartax has callable commands (return/disable) that "
-                "dynamically change the prompt, causing netmiko ReadTimeout"
-            )
-        free_port: int = get_free_port()
-        credentials: dict = {
-            "host": "localhost",
-            "username": "test_user",
-            "password": "test_password",
-            "port": free_port,
-            "device_type": platform,
-        }
-        inventory: dict = {
-            "hosts": {
-                "test_device": {
-                    "username": credentials["username"],
-                    "password": credentials["password"],
-                    "port": credentials["port"],
-                    "platform": platform,
-                }
-            }
-        }
-        with SimNOS(inventory=inventory) as net:
-            host = next(iter(net.hosts.values()))
-            initial_commands, enable_commands, config_commands = get_host_commands(host)
-            with ConnectHandler(**credentials) as conn:
-                for command in initial_commands:
+        if platform in XFAIL_PY_ALL_COMMANDS:
+            pytest.xfail(XFAIL_PY_ALL_COMMANDS[platform].reason)
+        net = simnos_factory(platform)
+        host = next(iter(net.hosts.values()))
+        initial_commands, enable_commands, config_commands = get_host_commands(host)
+        with ConnectHandler(**netmiko_device(platform, creds_from_host(host))) as conn:
+            for command in initial_commands:
+                output = conn.send_command(command)
+                assert isinstance(output, str)
+            if enable_commands:
+                conn.enable()
+                for command in enable_commands:
                     output = conn.send_command(command)
                     assert isinstance(output, str)
-                if enable_commands:
-                    conn.enable()
-                    for command in enable_commands:
-                        output = conn.send_command(command)
-                        assert isinstance(output, str)
-                if config_commands:
-                    conn.config_mode()
-                    for command in config_commands:
-                        output = conn.send_command(command)
-                        assert isinstance(output, str)
+            if config_commands:
+                conn.config_mode()
+                for command in config_commands:
+                    output = conn.send_command(command)
+                    assert isinstance(output, str)

--- a/tests/test_platform_quirks.py
+++ b/tests/test_platform_quirks.py
@@ -1,0 +1,53 @@
+"""Validation pins for the platform quirk registry metadata.
+
+These guard against metadata rot in ``tests/_platform_quirks.py``: every
+``Quirk`` must carry a non-empty reason, a well-formed (or absent) issue
+reference, and an ISO ``YYYY-MM-DD`` review date.
+"""
+
+import re
+
+import pytest
+
+from tests._platform_quirks import (
+    INIT_UNKNOWN_CMD_ALLOWED,
+    SKIP_ENABLE,
+    XFAIL_PY_ALL_COMMANDS,
+    Quirk,
+)
+
+_ALL_QUIRKS: dict[str, dict[str, Quirk]] = {
+    "INIT_UNKNOWN_CMD_ALLOWED": INIT_UNKNOWN_CMD_ALLOWED,
+    "SKIP_ENABLE": SKIP_ENABLE,
+    "XFAIL_PY_ALL_COMMANDS": XFAIL_PY_ALL_COMMANDS,
+}
+
+_ISSUE_RE = re.compile(r"^(#\d+|https?://\S+)$")
+_DATE_RE = re.compile(r"^\d{4}-\d{2}-\d{2}$")
+
+
+def _all_entries() -> list[tuple[str, str, Quirk]]:
+    """Flatten every registry into (registry_name, platform, quirk) tuples."""
+    return [(name, platform, quirk) for name, registry in _ALL_QUIRKS.items() for platform, quirk in registry.items()]
+
+
+@pytest.mark.parametrize("registry_name, platform, quirk", _all_entries())
+def test_quirk_reason_is_non_empty(registry_name: str, platform: str, quirk: Quirk):
+    """Every quirk explains itself with a non-empty reason."""
+    assert quirk.reason.strip(), f"{registry_name}[{platform!r}] has an empty reason"
+
+
+@pytest.mark.parametrize("registry_name, platform, quirk", _all_entries())
+def test_quirk_issue_is_well_formed_or_none(registry_name: str, platform: str, quirk: Quirk):
+    """`issue` is None (untracked) or a '#NNN' / URL reference -- never empty string."""
+    if quirk.issue is None:
+        return
+    assert _ISSUE_RE.match(quirk.issue), f"{registry_name}[{platform!r}] has a malformed issue: {quirk.issue!r}"
+
+
+@pytest.mark.parametrize("registry_name, platform, quirk", _all_entries())
+def test_quirk_last_reviewed_is_iso_date(registry_name: str, platform: str, quirk: Quirk):
+    """`last_reviewed` is an ISO YYYY-MM-DD date."""
+    assert _DATE_RE.match(quirk.last_reviewed), (
+        f"{registry_name}[{platform!r}] has a non-ISO last_reviewed: {quirk.last_reviewed!r}"
+    )

--- a/tests/test_platform_quirks.py
+++ b/tests/test_platform_quirks.py
@@ -5,10 +5,12 @@ These guard against metadata rot in ``tests/_platform_quirks.py``: every
 reference, and an ISO ``YYYY-MM-DD`` review date.
 """
 
+import datetime
 import re
 
 import pytest
 
+from simnos.core.nos import available_platforms
 from tests._platform_quirks import (
     INIT_UNKNOWN_CMD_ALLOWED,
     SKIP_ENABLE,
@@ -23,7 +25,6 @@ _ALL_QUIRKS: dict[str, dict[str, Quirk]] = {
 }
 
 _ISSUE_RE = re.compile(r"^(#\d+|https?://\S+)$")
-_DATE_RE = re.compile(r"^\d{4}-\d{2}-\d{2}$")
 
 
 def _all_entries() -> list[tuple[str, str, Quirk]]:
@@ -46,8 +47,15 @@ def test_quirk_issue_is_well_formed_or_none(registry_name: str, platform: str, q
 
 
 @pytest.mark.parametrize("registry_name, platform, quirk", _all_entries())
-def test_quirk_last_reviewed_is_iso_date(registry_name: str, platform: str, quirk: Quirk):
-    """`last_reviewed` is an ISO YYYY-MM-DD date."""
-    assert _DATE_RE.match(quirk.last_reviewed), (
-        f"{registry_name}[{platform!r}] has a non-ISO last_reviewed: {quirk.last_reviewed!r}"
-    )
+def test_quirk_last_reviewed_is_real_iso_date(registry_name: str, platform: str, quirk: Quirk):
+    """`last_reviewed` is a real ISO YYYY-MM-DD date (rejects e.g. 2026-99-99)."""
+    try:
+        datetime.date.fromisoformat(quirk.last_reviewed)
+    except ValueError:
+        pytest.fail(f"{registry_name}[{platform!r}] has an invalid last_reviewed: {quirk.last_reviewed!r}")
+
+
+@pytest.mark.parametrize("registry_name, platform, quirk", _all_entries())
+def test_quirk_platform_is_a_known_platform(registry_name: str, platform: str, quirk: Quirk):
+    """Quirk keys must be real platforms (guards against typos / stale entries)."""
+    assert platform in available_platforms, f"{registry_name}[{platform!r}] is not a known platform (typo or removed?)"

--- a/tests/test_platform_quirks.py
+++ b/tests/test_platform_quirks.py
@@ -2,7 +2,8 @@
 
 These guard against metadata rot in ``tests/_platform_quirks.py``: every
 ``Quirk`` must carry a non-empty reason, a well-formed (or absent) issue
-reference, and an ISO ``YYYY-MM-DD`` review date.
+reference, and a real ISO ``YYYY-MM-DD`` review date, and every registry key
+must be a known platform (typo / stale-entry guard).
 """
 
 import datetime

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -16,6 +16,49 @@ NETMIKO_DEVICE_TYPE_MAP: dict[str, str] = {
     "watchguard_firebox": "watchguard_fireware",
 }
 
+# Default credentials used to build single-host test inventories.
+TEST_USERNAME = "test_user"
+TEST_PASSWORD = "test_password"
+
+
+def build_inventory(
+    platform: str,
+    *,
+    host_key: str = "device",
+    username: str = TEST_USERNAME,
+    password: str = TEST_PASSWORD,
+    port: int | None = None,
+    **extra,
+) -> dict:
+    """Build a single-host SimNOS inventory dict (test SSoT).
+
+    Single-host only -- multi-host inventories are out of scope here.
+    A free port is allocated when ``port`` is not given.
+    """
+    port = port if port is not None else get_free_port()
+    host = {"username": username, "password": password, "port": port, "platform": platform, **extra}
+    return {"hosts": {host_key: host}}
+
+
+def creds_from_host(host: Host) -> dict:
+    """Return the username/password/port a netmiko client needs to reach ``host``."""
+    return {"username": host.username, "password": host.password, "port": host.port}
+
+
+def netmiko_device(platform: str, creds: dict, **extra) -> dict:
+    """Build netmiko ``ConnectHandler`` kwargs (applies NETMIKO_DEVICE_TYPE_MAP).
+
+    ``**extra`` merges additional kwargs such as ``session_log``.
+    """
+    return {
+        "host": "localhost",
+        "username": creds["username"],
+        "password": creds["password"],
+        "port": creds["port"],
+        "device_type": NETMIKO_DEVICE_TYPE_MAP.get(platform, platform),
+        **extra,
+    }
+
 
 def get_running_hosts(hosts: dict[str, Host]) -> dict[str, bool]:
     """


### PR DESCRIPTION
🐙claude:

## 概要

G6 (test 衛生整備) の **PR1 (基盤)**。`tests/` の SimNOS 起動 boilerplate と platform quirks の散在を一元化する (T-1 + T-15)。**production コードは不変、test のみ**。

Closes なし (issue #247 は PR2 完了時に close)。Refs #247。

設計: `design/20260608_114255_claude_g6-test-conftest-unification.md` (design 2 round + final-refactor、cross-review で codex MUST FIX 2 件解消・gemini LGTM)。

## 変更内容

**T-1 — conftest 一元化:**
- `tests/utils.py`: 純関数 SSoT `build_inventory()` / `netmiko_device(**extra)` / `creds_from_host()` + `TEST_USERNAME`/`TEST_PASSWORD` 定数
- `tests/conftest.py` 新設: `simnos_factory` fixture (auto-start/stop、teardown は start 前 register で mid-start 失敗にも到達)
- `test_netmiko_init_compat.py`: `_make_simnos`→`build_inventory` (HOSTNAME="router" は base_prompt 依存で維持)、device dict 6 箇所→`_device()` helper
- `test_platforms.py`: 3 integration を `simnos_factory`+`creds_from_host`+`netmiko_device` 化
- `compatibility/conftest.py`: `build_inventory` 経由に統一
- creds を `test_user`/`test_password`、host key を `device` に統一 (output 整形依存の netmiko_init_compat は `router` 維持)

**T-15 — platform quirks 集約:**
- `tests/_platform_quirks.py` 新設: frozen `Quirk` dataclass (reason/issue/last_reviewed) + `INIT_UNKNOWN_CMD_ALLOWED` / `SKIP_ENABLE` / `XFAIL_PY_ALL_COMMANDS` を 3 file から集約
- `tests/test_platform_quirks.py` 新設: metadata validation (非空 reason / `#NNN`・URL issue / 実在 ISO 日付 / platform 名が `available_platforms` に存在)
- membership 判定は現状等価、reason は skip/xfail メッセージに surface (軽微改善)

## 等価性

refactor のため挙動・pin 強度は不変。set→dict / dict→dict 変換は `in` membership 等価、creds は server/client 双方が同一定数で整合、base_prompt 依存 assertion は HOSTNAME 維持で保護。cross-review で 3 reviewer が独立検証。

## defer (PR2 / 別 PR)

- PR2: T-2〜T-5 (cmd_shell / ssh_server の `test_init_*` parametrize + unittest→pytest、test_simnos の累積 table 化)
- 別 PR: `test_netmiko.py` の inline device dict / multi-host inventory (`build_inventory` は single-host 専用、multi-host 拡張が必要)

## テスト

- `invoke ruff` (check + format) green / `ty check` 全体 green
- full `pytest -n auto` (docker 除外): **1049 passed / 7 skipped / 1 xfailed** (2:54)

## AI Transparency

AI-assisted (Claude Code)。human maintainer のレビューを経て merge してください。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
