### PR TITLE
refactor: G6 PR2 — test_init parametrize + unittest→pytest 変換 + start/stop table 化 (T-2〜T-5) (#247)

### DIFF
--- a/tests/core/test_simnos.py
+++ b/tests/core/test_simnos.py
@@ -46,15 +46,16 @@ class TestSimNOS:
         host_key-derived base_prompt are pinned per host.
         """
         expected_hosts = default_inventory["hosts"]
-        expected_user = default_inventory["default"]["username"]
-        expected_password = default_inventory["default"]["password"]
+        default_config = default_inventory["default"]
 
         net = SimNOS()
         assert set(net.hosts) == set(expected_hosts)
         for router_name, host in net.hosts.items():
-            assert host.username == expected_user
-            assert host.password == expected_password
-            assert host.port == expected_hosts[router_name]["port"]
+            # Mirror production's merge: host config overrides the shared default.
+            expected = {**default_config, **expected_hosts[router_name]}
+            assert host.username == expected["username"]
+            assert host.password == expected["password"]
+            assert host.port == expected["port"]
             assert host.server_inventory["plugin"] == "ParamikoSshServer"
             if _is_in_docker() and "WSL2" in platform.release():
                 assert host.server_inventory["configuration"]["address"] == "0.0.0.0"
@@ -427,7 +428,9 @@ class TestSimNOS:
         per row) because each step's expectation depends on the prior steps'
         accumulated state.
         """
-        c, h, a = "router_cisco_ios", "router_huawei_smartax", "router_arista_eos"
+        # Host names come from default_inventory (SSoT); the sequence + expected
+        # per-step states are hand-authored because they encode the cumulative order.
+        c, h, a = default_inventory["hosts"]
         steps = [
             _Step("start", c, {c: True, h: False, a: False}),
             _Step("start", h, {c: True, h: True, a: False}),

--- a/tests/core/test_simnos.py
+++ b/tests/core/test_simnos.py
@@ -9,6 +9,7 @@ import os
 import platform
 import re
 import threading
+from typing import NamedTuple
 from unittest.mock import MagicMock, Mock, patch
 
 import pytest
@@ -16,10 +17,18 @@ import yaml
 
 from simnos.core.host import Host
 from simnos.core.nos import available_platforms
-from simnos.core.simnos import SimNOS, simnos
+from simnos.core.simnos import SimNOS, default_inventory, simnos
 from simnos.core.utils import _is_in_docker
 from simnos.plugins.nos import nos_plugins
 from tests.utils import get_platforms_from_md, get_running_hosts
+
+
+class _Step(NamedTuple):
+    """One start/stop step + the cumulative running state expected afterwards."""
+
+    action: str  # "start" or "stop"
+    target: str  # host name to toggle
+    running: dict[str, bool]  # expected running state of every host after the step
 
 
 # pylint: disable=too-many-public-methods
@@ -29,30 +38,23 @@ class TestSimNOS:
     """
 
     def test_create_simnos_without_arguments(self):
+        """SimNOS() with no args builds exactly the hosts declared in default_inventory.
+
+        Host names / ports / credentials are derived from default_inventory
+        (the SSoT) instead of hardcoded, so this stays correct if the default
+        set changes. server/shell plugins, address (WSL/docker aware) and the
+        host_key-derived base_prompt are pinned per host.
         """
-        Test that SimNOS creates two hosts when no
-        arguments are passed.
-        Those routers should have the following:
-        - names are router0 and router1
-        - port are 6000 and 6001
-        - address is localhost
-        - timeout is 1
-        - username is user
-        - password is user
-        - server plugin is ParamikoSshServer
-        - shell plugin is CMDShell
-        """
+        expected_hosts = default_inventory["hosts"]
+        expected_user = default_inventory["default"]["username"]
+        expected_password = default_inventory["default"]["password"]
+
         net = SimNOS()
-        assert len(net.hosts) == 3
+        assert set(net.hosts) == set(expected_hosts)
         for router_name, host in net.hosts.items():
-            assert router_name in [
-                "router_cisco_ios",
-                "router_huawei_smartax",
-                "router_arista_eos",
-            ]
-            assert host.username in ["user"]
-            assert host.password in ["user"]
-            assert host.port in {6000, 6001, 6002}
+            assert host.username == expected_user
+            assert host.password == expected_password
+            assert host.port == expected_hosts[router_name]["port"]
             assert host.server_inventory["plugin"] == "ParamikoSshServer"
             if _is_in_docker() and "WSL2" in platform.release():
                 assert host.server_inventory["configuration"]["address"] == "0.0.0.0"
@@ -419,42 +421,28 @@ class TestSimNOS:
             assert host.nos.device.configurations == configurations
 
     def test_simnos_start_stop_hosts(self):
+        """start/stop by host name; each step pins the cumulative running state.
+
+        Driven as one sequence over a single SimNOS() instance (not parametrized
+        per row) because each step's expectation depends on the prior steps'
+        accumulated state.
         """
-        Test that the function start and stop hosts by the name.
-        """
+        c, h, a = "router_cisco_ios", "router_huawei_smartax", "router_arista_eos"
+        steps = [
+            _Step("start", c, {c: True, h: False, a: False}),
+            _Step("start", h, {c: True, h: True, a: False}),
+            _Step("start", a, {c: True, h: True, a: True}),
+            _Step("stop", c, {c: False, h: True, a: True}),
+            _Step("stop", h, {c: False, h: False, a: True}),
+            _Step("stop", a, {c: False, h: False, a: False}),
+        ]
         net = SimNOS()
-
-        net.start(hosts="router_cisco_ios")
-        assert net.hosts["router_cisco_ios"].running
-        assert not net.hosts["router_huawei_smartax"].running
-        assert not net.hosts["router_arista_eos"].running
-
-        net.start(hosts="router_huawei_smartax")
-        assert net.hosts["router_cisco_ios"].running
-        assert net.hosts["router_huawei_smartax"].running
-        assert not net.hosts["router_arista_eos"].running
-
-        net.start(hosts="router_arista_eos")
-        assert net.hosts["router_cisco_ios"].running
-        assert net.hosts["router_huawei_smartax"].running
-        assert net.hosts["router_arista_eos"].running
-
-        net.stop(hosts="router_cisco_ios")
-        assert not net.hosts["router_cisco_ios"].running
-        assert net.hosts["router_huawei_smartax"].running
-        assert net.hosts["router_arista_eos"].running
-
-        net.stop(hosts="router_huawei_smartax")
-        assert not net.hosts["router_cisco_ios"].running
-        assert not net.hosts["router_huawei_smartax"].running
-        assert net.hosts["router_arista_eos"].running
-
-        net.stop(hosts="router_arista_eos")
-        assert not net.hosts["router_cisco_ios"].running
-        assert not net.hosts["router_huawei_smartax"].running
-        assert not net.hosts["router_arista_eos"].running
-
-        net.stop()
+        try:
+            for step in steps:
+                getattr(net, step.action)(hosts=step.target)
+                assert get_running_hosts(net.hosts) == step.running
+        finally:
+            net.stop()
 
     def test_simnos_base_inventory(self):
         """

--- a/tests/plugins/test_cmd_shell.py
+++ b/tests/plugins/test_cmd_shell.py
@@ -21,104 +21,77 @@ from simnos.core.simnos import SimNOS, simnos
 from simnos.plugins.shell.cmd_shell import HANDLER_ERROR_OUTPUT, CMDShell
 
 
+def make_cmd_shell_args() -> dict:
+    """Build the CMDShell constructor kwargs shared across cmd_shell tests (SSoT)."""
+    return {
+        "stdin": None,
+        "stdout": None,
+        "nos": Nos(filename="tests/assets/yaml_nos.yaml"),
+        "nos_inventory_config": {},
+        "base_prompt": "test",
+        "is_running": threading.Event(),
+    }
+
+
+@pytest.fixture
+def cmd_shell_args():
+    """CMDShell kwargs as a fixture (thin wrapper over make_cmd_shell_args)."""
+    return make_cmd_shell_args()
+
+
+def test_init_defaults(cmd_shell_args):
+    """With no optional kwargs, every CMDShell attribute takes its default."""
+    shell = CMDShell(**cmd_shell_args)
+    assert shell.intro == "Custom SSH Shell"
+    assert shell.ruler == ""
+    assert shell.completekey == "tab"
+    assert shell.newline == "\r\n"
+    assert shell.prompt == "test>"
+    assert shell.is_running is cmd_shell_args["is_running"]
+    assert shell.commands != {}
+    assert shell.nos is cmd_shell_args["nos"]
+    assert shell.base_prompt == cmd_shell_args["base_prompt"]
+
+
+@pytest.mark.parametrize(
+    "kwargs, attr, expected",
+    [
+        ({"intro": "Test Intro"}, "intro", "Test Intro"),
+        ({"ruler": "Test Ruler"}, "ruler", "Test Ruler"),
+        ({"completekey": "Test Completekey"}, "completekey", "Test Completekey"),
+        ({"newline": "Test Newline"}, "newline", "Test Newline"),
+    ],
+)
+def test_init_optional_kwarg(cmd_shell_args, kwargs, attr, expected):
+    """Each optional kwarg lands on its attribute; base_prompt stays invariant."""
+    shell = CMDShell(**cmd_shell_args, **kwargs)
+    assert getattr(shell, attr) == expected
+    assert shell.base_prompt == "test"  # side-effect guard
+
+
+def test_init_all_optional_kwargs(cmd_shell_args):
+    """All optional kwargs at once each land on their own attribute."""
+    shell = CMDShell(
+        **cmd_shell_args,
+        intro="Test Intro",
+        ruler="Test Ruler",
+        completekey="Test Completekey",
+        newline="Test Newline",
+    )
+    assert shell.intro == "Test Intro"
+    assert shell.ruler == "Test Ruler"
+    assert shell.completekey == "Test Completekey"
+    assert shell.newline == "Test Newline"
+    assert shell.prompt == "test>"
+
+
 # pylint: disable=too-many-public-methods
 class TestCmdShell(TestCase):
     """Test the CmdShell class."""
 
     def setUp(self):
         """Setup the test."""
-        self.arguments = {
-            "stdin": None,
-            "stdout": None,
-            "nos": Nos(filename="tests/assets/yaml_nos.yaml"),
-            "nos_inventory_config": {},
-            "base_prompt": "test",
-            "is_running": threading.Event(),
-        }
-
-    def test_init(self):
-        """Test the init method."""
-        shell = CMDShell(**self.arguments)
-        self.assertEqual(shell.intro, "Custom SSH Shell")
-        self.assertEqual(shell.ruler, "")
-        self.assertEqual(shell.completekey, "tab")
-        self.assertEqual(shell.newline, "\r\n")
-        self.assertEqual(shell.prompt, "test>")
-        self.assertEqual(shell.is_running, self.arguments["is_running"])
-        self.assertNotEqual(shell.commands, {})
-        self.assertEqual(shell.nos, self.arguments["nos"])
-        self.assertEqual(shell.base_prompt, self.arguments["base_prompt"])
-
-    def test_init_with_intro(self):
-        """Test the init method with intro."""
-        shell = CMDShell(**self.arguments, intro="Test Intro")
-        self.assertEqual(shell.intro, "Test Intro")
-        self.assertEqual(shell.ruler, "")
-        self.assertEqual(shell.completekey, "tab")
-        self.assertEqual(shell.newline, "\r\n")
-        self.assertEqual(shell.prompt, "test>")
-        self.assertEqual(shell.is_running, self.arguments["is_running"])
-        self.assertNotEqual(shell.commands, {})
-        self.assertEqual(shell.nos, self.arguments["nos"])
-        self.assertEqual(shell.base_prompt, self.arguments["base_prompt"])
-
-    def test_init_with_ruler(self):
-        """Test the init method with ruler."""
-        shell = CMDShell(**self.arguments, ruler="Test Ruler")
-        self.assertEqual(shell.intro, "Custom SSH Shell")
-        self.assertEqual(shell.ruler, "Test Ruler")
-        self.assertEqual(shell.completekey, "tab")
-        self.assertEqual(shell.newline, "\r\n")
-        self.assertEqual(shell.prompt, "test>")
-        self.assertEqual(shell.is_running, self.arguments["is_running"])
-        self.assertNotEqual(shell.commands, {})
-        self.assertEqual(shell.nos, self.arguments["nos"])
-        self.assertEqual(shell.base_prompt, self.arguments["base_prompt"])
-
-    def test_init_with_completekey(self):
-        """Test the init method with completekey."""
-        shell = CMDShell(**self.arguments, completekey="Test Completekey")
-        self.assertEqual(shell.intro, "Custom SSH Shell")
-        self.assertEqual(shell.ruler, "")
-        self.assertEqual(shell.completekey, "Test Completekey")
-        self.assertEqual(shell.newline, "\r\n")
-        self.assertEqual(shell.prompt, "test>")
-        self.assertEqual(shell.is_running, self.arguments["is_running"])
-        self.assertNotEqual(shell.commands, {})
-        self.assertEqual(shell.nos, self.arguments["nos"])
-        self.assertEqual(shell.base_prompt, self.arguments["base_prompt"])
-
-    def test_init_with_newline(self):
-        """Test the init method with newline."""
-        shell = CMDShell(**self.arguments, newline="Test Newline")
-        self.assertEqual(shell.intro, "Custom SSH Shell")
-        self.assertEqual(shell.ruler, "")
-        self.assertEqual(shell.completekey, "tab")
-        self.assertEqual(shell.newline, "Test Newline")
-        self.assertEqual(shell.prompt, "test>")
-        self.assertEqual(shell.is_running, self.arguments["is_running"])
-        self.assertNotEqual(shell.commands, {})
-        self.assertEqual(shell.nos, self.arguments["nos"])
-        self.assertEqual(shell.base_prompt, self.arguments["base_prompt"])
-
-    def test_init_all_args(self):
-        """Test the init method with all args."""
-        shell = CMDShell(
-            **self.arguments,
-            intro="Test Intro",
-            ruler="Test Ruler",
-            completekey="Test Completekey",
-            newline="Test Newline",
-        )
-        self.assertEqual(shell.intro, "Test Intro")
-        self.assertEqual(shell.ruler, "Test Ruler")
-        self.assertEqual(shell.completekey, "Test Completekey")
-        self.assertEqual(shell.newline, "Test Newline")
-        self.assertEqual(shell.prompt, "test>")
-        self.assertEqual(shell.is_running, self.arguments["is_running"])
-        self.assertNotEqual(shell.commands, {})
-        self.assertEqual(shell.nos, self.arguments["nos"])
-        self.assertEqual(shell.base_prompt, self.arguments["base_prompt"])
+        self.arguments = make_cmd_shell_args()
 
     def test_init_error_if_nos_not_provided(self):
         """Test the init method raises an error if nos is not provided."""
@@ -914,14 +887,7 @@ class HotReloadTest(TestCase):
     """
 
     def setUp(self):
-        self.arguments = {
-            "stdin": None,
-            "stdout": None,
-            "nos": Nos(filename="tests/assets/yaml_nos.yaml"),
-            "nos_inventory_config": {},
-            "base_prompt": "test",
-            "is_running": threading.Event(),
-        }
+        self.arguments = make_cmd_shell_args()
         os.environ["SIMNOS_RELOAD_COMMANDS"] = "ON"
 
     def tearDown(self):

--- a/tests/plugins/test_cmd_shell.py
+++ b/tests/plugins/test_cmd_shell.py
@@ -74,6 +74,7 @@ def _expected_baseline(args: dict) -> dict:
             },
         ),
     ],
+    ids=["baseline", "intro", "ruler", "completekey", "newline", "all"],
 )
 def test_init_kwargs(cmd_shell_args, override_kwargs, expected_override):
     """baseline + each optional kwarg; untouched attrs stay at their defaults."""

--- a/tests/plugins/test_cmd_shell.py
+++ b/tests/plugins/test_cmd_shell.py
@@ -39,50 +39,52 @@ def cmd_shell_args():
     return make_cmd_shell_args()
 
 
-def test_init_defaults(cmd_shell_args):
-    """With no optional kwargs, every CMDShell attribute takes its default."""
-    shell = CMDShell(**cmd_shell_args)
-    assert shell.intro == "Custom SSH Shell"
-    assert shell.ruler == ""
-    assert shell.completekey == "tab"
-    assert shell.newline == "\r\n"
-    assert shell.prompt == "test>"
-    assert shell.is_running is cmd_shell_args["is_running"]
-    assert shell.commands != {}
-    assert shell.nos is cmd_shell_args["nos"]
-    assert shell.base_prompt == cmd_shell_args["base_prompt"]
+def _expected_baseline(args: dict) -> dict:
+    """Attribute values a CMDShell takes with no optional kwargs."""
+    return {
+        "intro": "Custom SSH Shell",
+        "ruler": "",
+        "completekey": "tab",
+        "newline": "\r\n",
+        "prompt": "test>",
+        "base_prompt": args["base_prompt"],
+    }
 
 
 @pytest.mark.parametrize(
-    "kwargs, attr, expected",
+    "override_kwargs, expected_override",
     [
-        ({"intro": "Test Intro"}, "intro", "Test Intro"),
-        ({"ruler": "Test Ruler"}, "ruler", "Test Ruler"),
-        ({"completekey": "Test Completekey"}, "completekey", "Test Completekey"),
-        ({"newline": "Test Newline"}, "newline", "Test Newline"),
+        ({}, {}),  # no optional kwargs (baseline)
+        ({"intro": "Test Intro"}, {"intro": "Test Intro"}),
+        ({"ruler": "Test Ruler"}, {"ruler": "Test Ruler"}),
+        ({"completekey": "Test Completekey"}, {"completekey": "Test Completekey"}),
+        ({"newline": "Test Newline"}, {"newline": "Test Newline"}),
+        (
+            {
+                "intro": "Test Intro",
+                "ruler": "Test Ruler",
+                "completekey": "Test Completekey",
+                "newline": "Test Newline",
+            },
+            {
+                "intro": "Test Intro",
+                "ruler": "Test Ruler",
+                "completekey": "Test Completekey",
+                "newline": "Test Newline",
+            },
+        ),
     ],
 )
-def test_init_optional_kwarg(cmd_shell_args, kwargs, attr, expected):
-    """Each optional kwarg lands on its attribute; base_prompt stays invariant."""
-    shell = CMDShell(**cmd_shell_args, **kwargs)
-    assert getattr(shell, attr) == expected
-    assert shell.base_prompt == "test"  # side-effect guard
-
-
-def test_init_all_optional_kwargs(cmd_shell_args):
-    """All optional kwargs at once each land on their own attribute."""
-    shell = CMDShell(
-        **cmd_shell_args,
-        intro="Test Intro",
-        ruler="Test Ruler",
-        completekey="Test Completekey",
-        newline="Test Newline",
-    )
-    assert shell.intro == "Test Intro"
-    assert shell.ruler == "Test Ruler"
-    assert shell.completekey == "Test Completekey"
-    assert shell.newline == "Test Newline"
-    assert shell.prompt == "test>"
+def test_init_kwargs(cmd_shell_args, override_kwargs, expected_override):
+    """baseline + each optional kwarg; untouched attrs stay at their defaults."""
+    shell = CMDShell(**cmd_shell_args, **override_kwargs)
+    expected = {**_expected_baseline(cmd_shell_args), **expected_override}
+    for attr, value in expected.items():
+        assert getattr(shell, attr) == value
+    # identity-pinned attrs (excluded from the equality table)
+    assert shell.is_running is cmd_shell_args["is_running"]
+    assert shell.nos is cmd_shell_args["nos"]
+    assert shell.commands != {}
 
 
 # pylint: disable=too-many-public-methods

--- a/tests/plugins/test_ssh_server_paramiko.py
+++ b/tests/plugins/test_ssh_server_paramiko.py
@@ -14,6 +14,7 @@ from unittest import mock
 from unittest.mock import MagicMock, Mock
 
 import paramiko
+import pytest
 
 from simnos.core.timeouts import SHUTDOWN_IO_TIMEOUT
 from simnos.plugins.servers.ssh_server_paramiko import (
@@ -791,6 +792,104 @@ class ShellToChannelTapTest(unittest.TestCase):
         self.mock_run_srv.clear.assert_called_once()
 
 
+def make_paramiko_server_args() -> dict:
+    """Build the ParamikoSshServer constructor kwargs (SSoT, no side effects)."""
+    return {
+        "shell": Mock(),
+        "nos": Mock(),
+        "nos_inventory_config": {},
+        "port": 22,
+        "username": "admin",
+        "password": "admin",
+    }
+
+
+@pytest.fixture
+def paramiko_server_args():
+    """ParamikoSshServer kwargs; the class-state reset lives here, not in the builder."""
+    ParamikoSshServer._default_key = None
+    ParamikoSshServer._moduli_loaded = None
+    return make_paramiko_server_args()
+
+
+def _expected_baseline(args: dict) -> dict:
+    """Attribute values a ParamikoSshServer takes with no optional kwargs."""
+    return {
+        "nos": args["nos"],
+        "nos_inventory_config": args["nos_inventory_config"],
+        "shell": args["shell"],
+        "shell_configuration": {},
+        "ssh_banner": "SIMNOS Paramiko SSH Server",
+        "username": args["username"],
+        "password": args["password"],
+        "port": args["port"],
+        "address": "127.0.0.1",
+        "timeout": 1,
+        "watchdog_interval": 1,
+    }
+
+
+@pytest.mark.parametrize(
+    "override_kwargs, expected_override",
+    [
+        ({}, {}),  # minimum arguments (baseline)
+        ({"ssh_banner": "SSH Banner"}, {"ssh_banner": "SSH Banner"}),
+        ({"shell_configuration": {"shell": "configuration"}}, {"shell_configuration": {"shell": "configuration"}}),
+        ({"address": "127.0.0.2"}, {"address": "127.0.0.2"}),
+        ({"timeout": 2}, {"timeout": 2}),
+        ({"watchdog_interval": 2}, {"watchdog_interval": 2}),
+        (
+            {
+                "ssh_banner": "SSH Banner",
+                "shell_configuration": {"shell": "configuration"},
+                "address": "127.0.0.2",
+                "timeout": 2,
+                "watchdog_interval": 2,
+            },
+            {
+                "ssh_banner": "SSH Banner",
+                "shell_configuration": {"shell": "configuration"},
+                "address": "127.0.0.2",
+                "timeout": 2,
+                "watchdog_interval": 2,
+            },
+        ),
+    ],
+)
+def test_init_kwargs(paramiko_server_args, override_kwargs, expected_override):
+    """baseline + each optional kwarg; the default-key identity is pinned per case."""
+    server = ParamikoSshServer(**paramiko_server_args, **override_kwargs)
+    expected = {**_expected_baseline(paramiko_server_args), **expected_override}
+    for attr, value in expected.items():
+        assert getattr(server, attr) == value
+    # No ssh_key_file: a generated RSAKey shared via the class-level cache.
+    assert isinstance(server._ssh_server_key, paramiko.RSAKey)
+    assert server._ssh_server_key is ParamikoSshServer._default_key
+
+
+def test_init_with_ssh_key_file(paramiko_server_args):
+    """ssh_key_file loads the key from disk instead of the default cache."""
+    server = ParamikoSshServer(**paramiko_server_args, ssh_key_file="tests/assets/ssh_host_rsa_key")
+    for attr, value in _expected_baseline(paramiko_server_args).items():
+        assert getattr(server, attr) == value
+    assert server._ssh_server_key == paramiko.RSAKey(filename="tests/assets/ssh_host_rsa_key")
+
+
+def test_init_with_ssh_key_file_and_password(paramiko_server_args):
+    """ssh_key_file + password loads the encrypted key from disk."""
+    server = ParamikoSshServer(
+        **paramiko_server_args,
+        ssh_key_file="tests/assets/ssh_host_rsa_key_with_password",
+        ssh_key_file_password="password",
+    )
+    for attr, value in _expected_baseline(paramiko_server_args).items():
+        assert getattr(server, attr) == value
+    assert server._ssh_server_key == paramiko.RSAKey(
+        filename="tests/assets/ssh_host_rsa_key_with_password",
+        password="password",
+    )
+
+
 class ParamikoSshServerTest(unittest.TestCase):
     """
     Test cases for the ParamikoSshServer class.
@@ -800,230 +899,7 @@ class ParamikoSshServerTest(unittest.TestCase):
         """Set up the ParamikoSshServer tests."""
         ParamikoSshServer._default_key = None
         ParamikoSshServer._moduli_loaded = None
-        self.arguments: dict = {
-            "shell": Mock(),
-            "nos": Mock(),
-            "nos_inventory_config": {},
-            "port": 22,
-            "username": "admin",
-            "password": "admin",
-        }
-
-    def test_init_with_minimum_arguments(self):
-        """
-        Check that the ParamikoSshServer object is initialized correctly with
-        the minimum parameters needed.
-        """
-        paramiko_server: ParamikoSshServer = ParamikoSshServer(**self.arguments)
-        self.assertEqual(paramiko_server.nos, self.arguments["nos"])
-        self.assertEqual(paramiko_server.nos_inventory_config, self.arguments["nos_inventory_config"])
-        self.assertEqual(paramiko_server.shell, self.arguments["shell"])
-        self.assertEqual(paramiko_server.shell_configuration, {})
-        self.assertEqual(paramiko_server.ssh_banner, "SIMNOS Paramiko SSH Server")
-        self.assertEqual(paramiko_server.username, self.arguments["username"])
-        self.assertEqual(paramiko_server.password, self.arguments["password"])
-        self.assertEqual(paramiko_server.port, self.arguments["port"])
-        self.assertEqual(paramiko_server.address, "127.0.0.1")
-        self.assertEqual(paramiko_server.timeout, 1)
-        self.assertEqual(paramiko_server.watchdog_interval, 1)
-        self.assertIsInstance(paramiko_server._ssh_server_key, paramiko.RSAKey)
-        self.assertIs(paramiko_server._ssh_server_key, ParamikoSshServer._default_key)
-
-    def test_init_with_ssh_key_file(self):
-        """
-        Check that the ParamikoSshServer object is initialized correctly with
-        the ssh_key_file parameter.
-        """
-        paramiko_server: ParamikoSshServer = ParamikoSshServer(
-            **self.arguments,
-            ssh_key_file="tests/assets/ssh_host_rsa_key",
-        )
-        self.assertEqual(paramiko_server.nos, self.arguments["nos"])
-        self.assertEqual(paramiko_server.nos_inventory_config, self.arguments["nos_inventory_config"])
-        self.assertEqual(paramiko_server.shell, self.arguments["shell"])
-        self.assertEqual(paramiko_server.shell_configuration, {})
-        self.assertEqual(paramiko_server.ssh_banner, "SIMNOS Paramiko SSH Server")
-        self.assertEqual(paramiko_server.username, self.arguments["username"])
-        self.assertEqual(paramiko_server.password, self.arguments["password"])
-        self.assertEqual(paramiko_server.port, self.arguments["port"])
-        self.assertEqual(paramiko_server.address, "127.0.0.1")
-        self.assertEqual(paramiko_server.timeout, 1)
-        self.assertEqual(paramiko_server.watchdog_interval, 1)
-        self.assertEqual(
-            paramiko_server._ssh_server_key,
-            paramiko.RSAKey(filename="tests/assets/ssh_host_rsa_key"),
-        )
-
-    def test_init_with_ssh_key_file_and_password(self):
-        """
-        Check that the ParamikoSshServer object is initialized correctly with
-        the ssh_key_file and ssh_key_password parameters.
-        """
-        paramiko_server: ParamikoSshServer = ParamikoSshServer(
-            **self.arguments,
-            ssh_key_file="tests/assets/ssh_host_rsa_key_with_password",
-            ssh_key_file_password="password",
-        )
-        self.assertEqual(paramiko_server.nos, self.arguments["nos"])
-        self.assertEqual(paramiko_server.nos_inventory_config, self.arguments["nos_inventory_config"])
-        self.assertEqual(paramiko_server.shell, self.arguments["shell"])
-        self.assertEqual(paramiko_server.shell_configuration, {})
-        self.assertEqual(paramiko_server.ssh_banner, "SIMNOS Paramiko SSH Server")
-        self.assertEqual(paramiko_server.username, self.arguments["username"])
-        self.assertEqual(paramiko_server.password, self.arguments["password"])
-        self.assertEqual(paramiko_server.port, self.arguments["port"])
-        self.assertEqual(paramiko_server.address, "127.0.0.1")
-        self.assertEqual(paramiko_server.timeout, 1)
-        self.assertEqual(paramiko_server.watchdog_interval, 1)
-        self.assertEqual(
-            paramiko_server._ssh_server_key,
-            paramiko.RSAKey(
-                filename="tests/assets/ssh_host_rsa_key_with_password",
-                password="password",
-            ),
-        )
-
-    def test_init_with_ssh_banner(self):
-        """
-        Check that the ParamikoSshServer object is initialized correctly with
-        the ssh_banner parameter.
-        """
-        paramiko_server: ParamikoSshServer = ParamikoSshServer(
-            **self.arguments,
-            ssh_banner="SSH Banner",
-        )
-        self.assertEqual(paramiko_server.nos, self.arguments["nos"])
-        self.assertEqual(paramiko_server.nos_inventory_config, self.arguments["nos_inventory_config"])
-        self.assertEqual(paramiko_server.shell, self.arguments["shell"])
-        self.assertEqual(paramiko_server.shell_configuration, {})
-        self.assertEqual(paramiko_server.ssh_banner, "SSH Banner")
-        self.assertEqual(paramiko_server.username, self.arguments["username"])
-        self.assertEqual(paramiko_server.password, self.arguments["password"])
-        self.assertEqual(paramiko_server.port, self.arguments["port"])
-        self.assertEqual(paramiko_server.address, "127.0.0.1")
-        self.assertEqual(paramiko_server.timeout, 1)
-        self.assertEqual(paramiko_server.watchdog_interval, 1)
-        self.assertIsInstance(paramiko_server._ssh_server_key, paramiko.RSAKey)
-        self.assertIs(paramiko_server._ssh_server_key, ParamikoSshServer._default_key)
-
-    def test_init_with_shell_configuration(self):
-        """
-        Check that the ParamikoSshServer object is initialized correctly with
-        the shell_configuration parameter.
-        """
-        paramiko_server: ParamikoSshServer = ParamikoSshServer(
-            **self.arguments,
-            shell_configuration={"shell": "configuration"},
-        )
-        self.assertEqual(paramiko_server.nos, self.arguments["nos"])
-        self.assertEqual(paramiko_server.nos_inventory_config, self.arguments["nos_inventory_config"])
-        self.assertEqual(paramiko_server.shell, self.arguments["shell"])
-        self.assertEqual(paramiko_server.shell_configuration, {"shell": "configuration"})
-        self.assertEqual(paramiko_server.ssh_banner, "SIMNOS Paramiko SSH Server")
-        self.assertEqual(paramiko_server.username, self.arguments["username"])
-        self.assertEqual(paramiko_server.password, self.arguments["password"])
-        self.assertEqual(paramiko_server.port, self.arguments["port"])
-        self.assertEqual(paramiko_server.address, "127.0.0.1")
-        self.assertEqual(paramiko_server.timeout, 1)
-        self.assertEqual(paramiko_server.watchdog_interval, 1)
-        self.assertIsInstance(paramiko_server._ssh_server_key, paramiko.RSAKey)
-        self.assertIs(paramiko_server._ssh_server_key, ParamikoSshServer._default_key)
-
-    def test_init_with_address(self):
-        """
-        Check that the ParamikoSshServer object is initialized correctly with
-        the address parameter.
-        """
-        paramiko_server: ParamikoSshServer = ParamikoSshServer(
-            **self.arguments,
-            address="127.0.0.2",
-        )
-        self.assertEqual(paramiko_server.nos, self.arguments["nos"])
-        self.assertEqual(paramiko_server.nos_inventory_config, self.arguments["nos_inventory_config"])
-        self.assertEqual(paramiko_server.shell, self.arguments["shell"])
-        self.assertEqual(paramiko_server.shell_configuration, {})
-        self.assertEqual(paramiko_server.ssh_banner, "SIMNOS Paramiko SSH Server")
-        self.assertEqual(paramiko_server.username, self.arguments["username"])
-        self.assertEqual(paramiko_server.password, self.arguments["password"])
-        self.assertEqual(paramiko_server.port, self.arguments["port"])
-        self.assertEqual(paramiko_server.address, "127.0.0.2")
-        self.assertEqual(paramiko_server.timeout, 1)
-        self.assertEqual(paramiko_server.watchdog_interval, 1)
-        self.assertIsInstance(paramiko_server._ssh_server_key, paramiko.RSAKey)
-        self.assertIs(paramiko_server._ssh_server_key, ParamikoSshServer._default_key)
-
-    def test_init_with_timeout(self):
-        """
-        Check that the ParamikoSshServer object is initialized correctly with
-        the timeout parameter.
-        """
-        paramiko_server: ParamikoSshServer = ParamikoSshServer(
-            **self.arguments,
-            timeout=2,
-        )
-        self.assertEqual(paramiko_server.nos, self.arguments["nos"])
-        self.assertEqual(paramiko_server.nos_inventory_config, self.arguments["nos_inventory_config"])
-        self.assertEqual(paramiko_server.shell, self.arguments["shell"])
-        self.assertEqual(paramiko_server.shell_configuration, {})
-        self.assertEqual(paramiko_server.ssh_banner, "SIMNOS Paramiko SSH Server")
-        self.assertEqual(paramiko_server.username, self.arguments["username"])
-        self.assertEqual(paramiko_server.password, self.arguments["password"])
-        self.assertEqual(paramiko_server.port, self.arguments["port"])
-        self.assertEqual(paramiko_server.address, "127.0.0.1")
-        self.assertEqual(paramiko_server.timeout, 2)
-        self.assertEqual(paramiko_server.watchdog_interval, 1)
-        self.assertIsInstance(paramiko_server._ssh_server_key, paramiko.RSAKey)
-        self.assertIs(paramiko_server._ssh_server_key, ParamikoSshServer._default_key)
-
-    def test_init_with_watchdog_interval(self):
-        """
-        Check that the ParamikoSshServer object is initialized correctly with
-        the watchdog_interval parameter.
-        """
-        paramiko_server: ParamikoSshServer = ParamikoSshServer(
-            **self.arguments,
-            watchdog_interval=2,
-        )
-        self.assertEqual(paramiko_server.nos, self.arguments["nos"])
-        self.assertEqual(paramiko_server.nos_inventory_config, self.arguments["nos_inventory_config"])
-        self.assertEqual(paramiko_server.shell, self.arguments["shell"])
-        self.assertEqual(paramiko_server.shell_configuration, {})
-        self.assertEqual(paramiko_server.ssh_banner, "SIMNOS Paramiko SSH Server")
-        self.assertEqual(paramiko_server.username, self.arguments["username"])
-        self.assertEqual(paramiko_server.password, self.arguments["password"])
-        self.assertEqual(paramiko_server.port, self.arguments["port"])
-        self.assertEqual(paramiko_server.address, "127.0.0.1")
-        self.assertEqual(paramiko_server.timeout, 1)
-        self.assertEqual(paramiko_server.watchdog_interval, 2)
-        self.assertIsInstance(paramiko_server._ssh_server_key, paramiko.RSAKey)
-        self.assertIs(paramiko_server._ssh_server_key, ParamikoSshServer._default_key)
-
-    def test_init_with_all_parameters(self):
-        """
-        Check that the ParamikoSshServer object is initialized correctly with
-        all the parameters.
-        """
-        paramiko_server: ParamikoSshServer = ParamikoSshServer(
-            **self.arguments,
-            ssh_banner="SSH Banner",
-            shell_configuration={"shell": "configuration"},
-            address="127.0.0.2",
-            timeout=2,
-            watchdog_interval=2,
-        )
-        self.assertEqual(paramiko_server.nos, self.arguments["nos"])
-        self.assertEqual(paramiko_server.nos_inventory_config, self.arguments["nos_inventory_config"])
-        self.assertEqual(paramiko_server.shell, self.arguments["shell"])
-        self.assertEqual(paramiko_server.shell_configuration, {"shell": "configuration"})
-        self.assertEqual(paramiko_server.ssh_banner, "SSH Banner")
-        self.assertEqual(paramiko_server.username, self.arguments["username"])
-        self.assertEqual(paramiko_server.password, self.arguments["password"])
-        self.assertEqual(paramiko_server.port, self.arguments["port"])
-        self.assertEqual(paramiko_server.address, "127.0.0.2")
-        self.assertEqual(paramiko_server.timeout, 2)
-        self.assertEqual(paramiko_server.watchdog_interval, 2)
-        self.assertIsInstance(paramiko_server._ssh_server_key, paramiko.RSAKey)
-        self.assertIs(paramiko_server._ssh_server_key, ParamikoSshServer._default_key)
+        self.arguments: dict = make_paramiko_server_args()
 
     def test_watchdog_run_srv_loop(self):
         """Check that the watchdog run_srv loop is executed."""

--- a/tests/plugins/test_ssh_server_paramiko.py
+++ b/tests/plugins/test_ssh_server_paramiko.py
@@ -855,6 +855,7 @@ def _expected_baseline(args: dict) -> dict:
             },
         ),
     ],
+    ids=["baseline", "ssh_banner", "shell_configuration", "address", "timeout", "watchdog_interval", "all"],
 )
 def test_init_kwargs(paramiko_server_args, override_kwargs, expected_override):
     """baseline + each optional kwarg; the default-key identity is pinned per case."""


### PR DESCRIPTION
🐙claude:

## 概要

G6 (test 衛生整備) の **PR2 (parametrize + unittest→pytest 変換)**。`test_init_*` の重複を parametrize に集約し、対象メソッドを pytest スタイルへ変換する (T-2〜T-5)。**production コードは不変、test のみ**。

Closes #247 (PR1 #248 で T-1/T-15 完了済、本 PR で T-2〜T-5 完了 → G6 完結)。

設計: `design/20260608_114255_claude_g6-test-conftest-unification.md` (design 2 round + final-refactor)。PR1: #248 (`c55895e`)。

## 変更内容

**T-2 / T-3 (`test_cmd_shell.py`):**
- `self.arguments` を純関数 `make_cmd_shell_args()` に SSoT 化 (TestCmdShell / HotReloadTest 双方が呼ぶ、HotReloadTest は env 副作用を保持)
- init happy-path 6 本 (test_init + with_* 5) を module-level `test_init_kwargs` parametrize に統合 (`_expected_baseline` + override で全 attr 検証、`is_running`/`nos` は identity pin、ids 付き)
- `test_init_error_*` 4 本 + `test_init_broken_initial_prompt` は class 維持 (assertRaises/fallback で parametrize 非対象)

**T-4 (`test_ssh_server_paramiko.py`):**
- `make_paramiko_server_args()` (dict 専用) + `paramiko_server_args` fixture (class-state reset を担当)
- init 9 本を `test_init_kwargs` parametrize 7 行に変換 (baseline+override 全 attr + `is _default_key` identity を各ケース pin、ids 付き)
- `ssh_key_file` plain / password 2 本は key load equality 検証で別関数維持

**T-5 (`test_simnos.py`):**
- `test_create_simnos_without_arguments` を `default_inventory` (SSoT) 導出 + production の `{**default, **host}` merge semantics
- `test_simnos_start_stop_hosts` を `_Step` NamedTuple 累積 table (単一 `SimNOS()` 順回し = 逐次状態遷移を保持、host 名は `default_inventory` 由来)

## 等価性 / pin 強度

refactor のため挙動・pin 強度は不変または強化。identity は `is`、累積状態は 1-instance 順回し、全 attr 検証で「1 kwarg 変更で他 attr は default」の独立性 pin を維持。unittest→pytest は対象メソッドのみ (file 全体の移行 = T-8 は非目標)。cross-review で 3 reviewer が等価性を独立検証 (claude LGTM)。

## scope 境界

- unittest 全 file の pytest 移行 (T-8) は非目標。本 PR は parametrize 対象メソッドのみ変換、他 unittest class は据え置き (1 file 内で module-level pytest 関数 + unittest class が混在、collection 問題なし)

## テスト

- `invoke ruff` (check + format) green / `ty check` (gating、tests/ は M-9 で exclude) green
- full `pytest -n auto` (docker 除外): **1049 passed / 7 skipped / 1 xfailed** (2:47)

## AI Transparency

AI-assisted (Claude Code)。human maintainer のレビューを経て merge してください。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
