### PR TITLE
test: G6 follow-up PR1 — replicas 検証 parametrize 集約 + NETMIKO map コメント拡充 (#250)

### DIFF
--- a/tests/core/test_simnos.py
+++ b/tests/core/test_simnos.py
@@ -35,7 +35,7 @@ class _Step(NamedTuple):
 # Every case puts ``replicas`` on the host (not ``default``): ``InventoryDefaultSection``
 # uses ``extra="forbid"``, so keeping ``port`` in ``default`` while moving ``replicas`` to
 # the host lets the merged params reach ``_check_ports_and_replicas`` without pydantic
-# rejecting them first.  The ``replicas_zero`` case is the #220 regression pin: the old
+# rejecting them first. The ``replicas_zero`` case is the #220 regression pin: the old
 # ``if not replicas`` falsy guard short-circuited ``replicas=0`` past the intended
 # "replicas must be greater than 0" branch; #220 switched to ``if replicas is None`` and
 # moved the ``replicas < 1`` check ahead of the port-type checks.

--- a/tests/core/test_simnos.py
+++ b/tests/core/test_simnos.py
@@ -31,6 +31,53 @@ class _Step(NamedTuple):
     running: dict[str, bool]  # expected running state of every host after the step
 
 
+# Invalid port/replicas combinations rejected by ``_check_ports_and_replicas``.
+# Every case puts ``replicas`` on the host (not ``default``): ``InventoryDefaultSection``
+# uses ``extra="forbid"``, so keeping ``port`` in ``default`` while moving ``replicas`` to
+# the host lets the merged params reach ``_check_ports_and_replicas`` without pydantic
+# rejecting them first.  The ``replicas_zero`` case is the #220 regression pin: the old
+# ``if not replicas`` falsy guard short-circuited ``replicas=0`` past the intended
+# "replicas must be greater than 0" branch; #220 switched to ``if replicas is None`` and
+# moved the ``replicas < 1`` check ahead of the port-type checks.
+_REPLICAS_REJECT_CASES = [
+    (
+        "not_set_port_list",
+        {"default": {"port": [5000, 5001]}, "hosts": {"R1": {}}},
+        r"replicas is not set, port must be an integer",
+    ),
+    (
+        "set_port_int",
+        {"default": {"port": 5000}, "hosts": {"R1": {"replicas": 2}}},
+        r"port must be a list of two integers",
+    ),
+    (
+        "port_list_too_few",
+        {"default": {"port": [5000]}, "hosts": {"R1": {"replicas": 2}}},
+        r"port must be a list of two integers",
+    ),
+    (
+        "port_list_too_many",
+        {"default": {"port": [5000, 5001, 5002]}, "hosts": {"R1": {"replicas": 2}}},
+        r"port must be a list of two integers",
+    ),
+    (
+        "port0_ge_port1",
+        {"default": {"port": [5001, 5000]}, "hosts": {"R1": {"replicas": 2}}},
+        r"port\[0\] must be less than port\[1\]",
+    ),
+    (
+        "replicas_zero",
+        {"default": {"port": [5000, 5001]}, "hosts": {"R1": {"replicas": 0}}},
+        r"replicas must be greater than 0",
+    ),
+    (
+        "len_mismatch",
+        {"default": {"port": [5000, 5001]}, "hosts": {"R1": {"replicas": 3}}},
+        r"port range must be equal to the number of replicas",
+    ),
+]
+
+
 # pylint: disable=too-many-public-methods
 class TestSimNOS:
     """
@@ -262,90 +309,19 @@ class TestSimNOS:
         net._allocate_port_single(65535)
         assert {1, 65535}.issubset(net.allocated_ports)
 
-    def test_replicas_not_set_and_port_list(self):
-        """
-        Test that the function _check_ports_and_replicas raises an exception
-        when replicas is not set.
-        """
-        inventory = {"default": {"port": [5000, 5001]}, "hosts": {"R1": {}}}
-        with pytest.raises(ValueError, match=r"replicas is not set, port must be an integer"):
-            SimNOS(inventory=inventory)
+    @pytest.mark.parametrize(
+        "inventory, match",
+        [(inventory, match) for _, inventory, match in _REPLICAS_REJECT_CASES],
+        ids=[case_id for case_id, _, _ in _REPLICAS_REJECT_CASES],
+    )
+    def test_check_ports_and_replicas_rejects(self, inventory, match):
+        """``_check_ports_and_replicas`` rejects invalid port/replicas combinations.
 
-    def test_replicas_set_and_port_int(self):
+        See ``_REPLICAS_REJECT_CASES`` for the per-case rationale (including the
+        ``extra="forbid"`` placement constraint and the #220 ``replicas_zero``
+        regression pin).
         """
-        Test that the function _check_ports_and_replicas raises an exception
-        when replicas is set and port is an int.
-
-        Note: ``replicas`` lives on each host (not in ``default``) because
-        ``InventoryDefaultSection`` uses ``extra="forbid"``. Keeping ``port`` in
-        ``default`` while moving ``replicas`` to the host lets the merged params
-        reach ``_check_ports_and_replicas`` without tripping pydantic first.
-        """
-        inventory = {"default": {"port": 5000}, "hosts": {"R1": {"replicas": 2}}}
-        with pytest.raises(ValueError, match=r"port must be a list of two integers"):
-            SimNOS(inventory=inventory)
-
-    def test_replicas_set_and_port_list_not_enough_ports(self):
-        """
-        Test that the function _check_ports_and_replicas raises an exception
-        when replicas is set and there are not enough ports.
-        """
-        inventory = {"default": {"port": [5000]}, "hosts": {"R1": {"replicas": 2}}}
-        with pytest.raises(ValueError, match=r"port must be a list of two integers"):
-            SimNOS(inventory=inventory)
-
-    def test_replicas_set_and_port_list_too_many_ports(self):
-        """
-        Test that the function _check_ports_and_replicas raises an exception
-        when replicas is set and there are too many ports.
-        """
-        inventory = {
-            "default": {"port": [5000, 5001, 5002]},
-            "hosts": {"R1": {"replicas": 2}},
-        }
-        with pytest.raises(ValueError, match=r"port must be a list of two integers"):
-            SimNOS(inventory=inventory)
-
-    def test_replicas_set_and_port_1_larger_than_port_2(self):
-        """
-        Test that the function _check_ports_and_replicas raises an exception
-        when replicas is set and the first port is larger than the second port.
-        """
-        inventory = {
-            "default": {"port": [5001, 5000]},
-            "hosts": {"R1": {"replicas": 2}},
-        }
-        with pytest.raises(ValueError, match=r"port\[0\] must be less than port\[1\]"):
-            SimNOS(inventory=inventory)
-
-    def test_replicas_set_and_replicas_less_than_1(self):
-        """
-        Test that the function _check_ports_and_replicas raises an exception
-        when replicas is set and the replicas are less than 1.
-
-        Fix in #220 promoted the ``replicas < 1`` check above the ``port`` type
-        checks and switched the entry guard from ``if not replicas`` to
-        ``if replicas is None``, so ``replicas=0`` now reaches the intended
-        "replicas must be greater than 0" branch instead of short-circuiting
-        on the falsy-replicas path.
-        """
-        inventory = {
-            "default": {"port": [5000, 5001]},
-            "hosts": {"R1": {"replicas": 0}},
-        }
-        with pytest.raises(ValueError, match=r"replicas must be greater than 0"):
-            SimNOS(inventory=inventory)
-
-    def test_replicas_set_and_ports_set_not_same_length(self):
-        """
-        Test that the function _check_ports_and_replicas raises an exception
-        when replicas is set and the ports are not the same length.
-        """
-        inventory = {
-            "default": {"port": [5000, 5001]},
-            "hosts": {"R1": {"replicas": 3}},
-        }
-        with pytest.raises(ValueError, match=r"port range must be equal to the number of replicas"):
+        with pytest.raises(ValueError, match=match):
             SimNOS(inventory=inventory)
 
     def test_wrong_plugin_name(self):

--- a/tests/core/test_simnos.py
+++ b/tests/core/test_simnos.py
@@ -40,40 +40,40 @@ class _Step(NamedTuple):
 # "replicas must be greater than 0" branch; #220 switched to ``if replicas is None`` and
 # moved the ``replicas < 1`` check ahead of the port-type checks.
 _REPLICAS_REJECT_CASES = [
-    (
-        "not_set_port_list",
+    pytest.param(
         {"default": {"port": [5000, 5001]}, "hosts": {"R1": {}}},
         r"replicas is not set, port must be an integer",
+        id="not_set_port_list",
     ),
-    (
-        "set_port_int",
+    pytest.param(
         {"default": {"port": 5000}, "hosts": {"R1": {"replicas": 2}}},
         r"port must be a list of two integers",
+        id="set_port_int",
     ),
-    (
-        "port_list_too_few",
+    pytest.param(
         {"default": {"port": [5000]}, "hosts": {"R1": {"replicas": 2}}},
         r"port must be a list of two integers",
+        id="port_list_too_few",
     ),
-    (
-        "port_list_too_many",
+    pytest.param(
         {"default": {"port": [5000, 5001, 5002]}, "hosts": {"R1": {"replicas": 2}}},
         r"port must be a list of two integers",
+        id="port_list_too_many",
     ),
-    (
-        "port0_ge_port1",
+    pytest.param(
         {"default": {"port": [5001, 5000]}, "hosts": {"R1": {"replicas": 2}}},
         r"port\[0\] must be less than port\[1\]",
+        id="port0_ge_port1",
     ),
-    (
-        "replicas_zero",
+    pytest.param(
         {"default": {"port": [5000, 5001]}, "hosts": {"R1": {"replicas": 0}}},
         r"replicas must be greater than 0",
+        id="replicas_zero",
     ),
-    (
-        "len_mismatch",
+    pytest.param(
         {"default": {"port": [5000, 5001]}, "hosts": {"R1": {"replicas": 3}}},
         r"port range must be equal to the number of replicas",
+        id="len_mismatch",
     ),
 ]
 
@@ -309,11 +309,7 @@ class TestSimNOS:
         net._allocate_port_single(65535)
         assert {1, 65535}.issubset(net.allocated_ports)
 
-    @pytest.mark.parametrize(
-        "inventory, match",
-        [(inventory, match) for _, inventory, match in _REPLICAS_REJECT_CASES],
-        ids=[case_id for case_id, _, _ in _REPLICAS_REJECT_CASES],
-    )
+    @pytest.mark.parametrize("inventory, match", _REPLICAS_REJECT_CASES)
     def test_check_ports_and_replicas_rejects(self, inventory, match):
         """``_check_ports_and_replicas`` rejects invalid port/replicas combinations.
 

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -14,9 +14,9 @@ from simnos.plugins.nos import nos_plugins
 # before building ConnectHandler kwargs (see netmiko_device()).
 # netmiko canonical names: https://github.com/ktbyers/netmiko/blob/master/PLATFORMS.md
 NETMIKO_DEVICE_TYPE_MAP: dict[str, str] = {
-    "edgecore": "edgecore_sonic",  # netmiko canonical: edgecore_sonic
-    "extreme_slxos": "extreme_slx",  # netmiko canonical: extreme_slx
-    "watchguard_firebox": "watchguard_fireware",  # netmiko canonical: watchguard_fireware
+    "edgecore": "edgecore_sonic",
+    "extreme_slxos": "extreme_slx",
+    "watchguard_firebox": "watchguard_fireware",
 }
 
 # Default credentials used to build single-host test inventories.

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -9,11 +9,14 @@ import string
 from simnos.core.host import Host
 from simnos.plugins.nos import nos_plugins
 
-# Mapping for platforms where simnos name differs from netmiko device_type
+# Platforms where the simnos platform name differs from netmiko's device_type.
+# netmiko expects its own canonical device_type string, so these must be mapped
+# before building ConnectHandler kwargs (see netmiko_device()).
+# netmiko canonical names: https://github.com/ktbyers/netmiko/blob/master/PLATFORMS.md
 NETMIKO_DEVICE_TYPE_MAP: dict[str, str] = {
-    "edgecore": "edgecore_sonic",
-    "extreme_slxos": "extreme_slx",
-    "watchguard_firebox": "watchguard_fireware",
+    "edgecore": "edgecore_sonic",  # netmiko canonical: edgecore_sonic
+    "extreme_slxos": "extreme_slx",  # netmiko canonical: extreme_slx
+    "watchguard_firebox": "watchguard_fireware",  # netmiko canonical: watchguard_fireware
 }
 
 # Default credentials used to build single-host test inventories.


### PR DESCRIPTION
🐙claude:

## 概要
issue #250 (G6 follow-up — test 衛生) の **PR1**。低リスク・高 win の T-7 + T-16 を先行。production コード不変 (test のみ)。

## 変更内容
### T-7: replicas 検証の parametrize 集約
- `tests/core/test_simnos.py` の `test_replicas_*` **7 メソッド → `_REPLICAS_REJECT_CASES` (pytest.param 7 件) + 1 parametrized test** (`test_check_ports_and_replicas_rejects`) に集約。
- inventory dict / `match=` 文字列は **byte 一致**で移行 (7 ケース全展開、件数不変、regression 検出力維持)。
- `extra="forbid"` placement rationale と #220 `replicas_zero` regression pin はテーブル直上コメントに保存 (情報損失ゼロ)。

### T-16: NETMIKO_DEVICE_TYPE_MAP コメント拡充
- `tests/utils.py` の map コメントを拡充 — 「simnos platform name ≠ netmiko device_type」の乖離理由 + Netmiko PLATFORMS.md リンク (canonical 名は値そのものなので行末注は付けない)。

正味 -25 行 (重複削減)。

## 品質パイプライン
- design (pre-review + cross-review 1st SHOULD FIX 全取り込み + final-refactor) → 設計確定
- 実装 → pre-review-refactor → **cross-review 1st (codex/claude/gemini 全員 SUGGESTION)** → 反映 (pytest.param 化 + 行末注削除) → final-refactor
- cross-review で 3 者が等価性 (inventory/match/件数 byte 単位) + rationale (production `simnos.py` / `pydantic_models.py`) + T-16 canonical 名 (installed netmiko CLASS_MAPPER) を全数検証

## 検証
- `invoke ruff` (check + format) / `ty check` (gating) green
- full suite **1049 passed / 7 skipped / 1 xfailed** (`-n auto`、docker 2件はローカル環境依存で除外、exit 0)

## scope 補足
PR1 は T-7 + T-16 のみ。PR2 (test_nos.py の unittest→pytest 移行) / PR3 (multi-host helper、条件付き) は後続。T-6 docker dedup + 重量 unittest file は defer (設計書 Notes に正当理由 + #250 close 時に単独 issue 起票予定)。

---
🤖 Generated with [Claude Code](https://claude.com/claude-code) — AI-assisted、human maintainer のレビュー後に merge してください。
