### PR TITLE
refactor: M-9 Phase 3 PR1 — test_ssh_server_paramiko を ty-clean 化 (#251)

### DIFF
--- a/tests/plugins/test_ssh_server_paramiko.py
+++ b/tests/plugins/test_ssh_server_paramiko.py
@@ -1026,6 +1026,9 @@ class ParamikoSshServerTest(unittest.TestCase):
 
         def create_server(port):
             barrier.wait()
+            # port は仮引数 (literal でない) なので spread しても ty の union widening を誘発しない。
+            # helper 化すると make_paramiko_server_args() が thread ごとに走り共有 mock 前提が変わるため、
+            # この concurrency test では inline spread を維持する。
             return ParamikoSshServer(**{**self.arguments, "port": port})
 
         with concurrent.futures.ThreadPoolExecutor(max_workers=num_threads) as ex:
@@ -1118,6 +1121,9 @@ class ParamikoSshServerTest(unittest.TestCase):
 
             def create_server(port):
                 barrier.wait()
+                # port は仮引数 (literal でない) なので spread しても ty の union widening を誘発しない。
+                # helper 化すると make_paramiko_server_args() が thread ごとに走り共有 mock 前提が変わるため、
+                # この concurrency test では inline spread を維持する。
                 return ParamikoSshServer(**{**self.arguments, "port": port})
 
             with concurrent.futures.ThreadPoolExecutor(max_workers=num_threads) as ex:

--- a/tests/plugins/test_ssh_server_paramiko.py
+++ b/tests/plugins/test_ssh_server_paramiko.py
@@ -1328,7 +1328,7 @@ class ParamikoSshServerChannelLoginTest(unittest.TestCase):
     """Test cases for _channel_login in ParamikoSshServer."""
 
     def setUp(self):
-        self.arguments = make_paramiko_server_args()
+        self.arguments: dict = make_paramiko_server_args()
 
     def _make_channel(self, input_bytes: bytes):
         """Create a mock channel that returns input_bytes one byte at a time."""
@@ -1647,7 +1647,7 @@ class TeardownFixTests(unittest.TestCase):
     def setUp(self):
         """Set up common fixtures."""
         ParamikoSshServer._default_key = None
-        self.arguments = make_paramiko_server_args()
+        self.arguments: dict = make_paramiko_server_args()
 
     # -- Watchdog tests --------------------------------------------------------
 

--- a/tests/plugins/test_ssh_server_paramiko.py
+++ b/tests/plugins/test_ssh_server_paramiko.py
@@ -517,7 +517,7 @@ class ChannelToShellTapTest(unittest.TestCase):
         )
         # NUL byte must NOT be echoed to channel
         for call_args in self.mock_channel.sendall.call_args_list:
-            self.assertNotEqual(call_args, unittest.mock.call(b"\x00"))
+            self.assertNotEqual(call_args, mock.call(b"\x00"))
         # "a" echoed + "\r\n" for newline = 2 writes
         self.assertEqual(self.mock_channel.sendall.call_count, 2)
         self.mock_shell_stdin.write.assert_called_with("a\n")
@@ -1003,7 +1003,8 @@ class ParamikoSshServerTest(unittest.TestCase):
         self.addCleanup(setattr, ParamikoSshServer, "_default_key", None)
 
         server1 = ParamikoSshServer(**self.arguments)
-        server2_args = {**self.arguments, "port": 23}
+        server2_args = make_paramiko_server_args()
+        server2_args["port"] = 23
         server2 = ParamikoSshServer(**server2_args)
 
         mock_generate.assert_called_once_with(2048)
@@ -1327,14 +1328,7 @@ class ParamikoSshServerChannelLoginTest(unittest.TestCase):
     """Test cases for _channel_login in ParamikoSshServer."""
 
     def setUp(self):
-        self.arguments = {
-            "shell": Mock(),
-            "nos": Mock(),
-            "nos_inventory_config": {},
-            "port": 22,
-            "username": "admin",
-            "password": "admin",
-        }
+        self.arguments = make_paramiko_server_args()
 
     def _make_channel(self, input_bytes: bytes):
         """Create a mock channel that returns input_bytes one byte at a time."""
@@ -1653,14 +1647,7 @@ class TeardownFixTests(unittest.TestCase):
     def setUp(self):
         """Set up common fixtures."""
         ParamikoSshServer._default_key = None
-        self.arguments = {
-            "shell": Mock(),
-            "nos": Mock(),
-            "nos_inventory_config": {},
-            "port": 22,
-            "username": "admin",
-            "password": "admin",
-        }
+        self.arguments = make_paramiko_server_args()
 
     # -- Watchdog tests --------------------------------------------------------
 


### PR DESCRIPTION
🐙claude:

## 概要
Issue #251 (M-9 Phase 3 — tests/ の ty exclude 解除) の **PR1**。tests/ を ty 型チェック対象に入れる準備として、`test_ssh_server_paramiko.py` の ty diagnostics **248 → 0** にする。tests/ exclude の解除自体は PR3。

設計 doc に基づく 3 PR 分割: **PR1(本 PR)= paramiko test file** / PR2 = telnet・cmd_shell・残り / PR3 = exclude flip + production paramiko 解除。

## root cause
inline literal dict の `**` unpack で ty が値型を `Mock | dict | int | str` の union に推論 → 全 param にその union が渡り、`shell: type` / `nos: Nos` / `port: int` すべてが「union の一部が非適合」で誤検知(構築 1 回あたり ~14 件)。`create_autospec` 化は**不要**(機序は dict の widening であり Mock 型ではない、plain Mock は ty 上そのまま代入可)。

真のレバーは **inline literal dict unpack を避け、G6 で新設済の `make_paramiko_server_args() -> dict`(Unknown erase)経由に統一**すること。

## 変更
- setUp の inline literal dict 2 箇所(`ParamikoSshServerChannelLoginTest` / `TeardownFixTests`)→ `make_paramiko_server_args()` 呼びに置換 → **下流 call site が cascade で一括解消**
- named-local spread(`server2_args = {**self.arguments, "port": 23}`)→ `make_paramiko_server_args()` + 後置 mutate(inline 合成はリテラルで再 widening するため不可)
- `unittest.mock.call` → `mock.call`(既存 `from unittest import mock` を利用、`possibly-missing-submodule` 解消)
- 3 setUp の `self.arguments: dict = ...` annotation を統一(pre-review)
- **thread-safe test の `{**self.arguments, "port": port}`(L1028/L1120)は不変** — `port` が仮引数で union widening を誘発せず 0 件。helper 化すると per-thread で Mock 生成が走り共有 mock 前提が変わるため inline spread を維持(rationale コメント追加)

production コードは不変、test layer のみ。挙動不変(型表現の調整のみ)。

## 検証
- `uv run ty check tests/plugins/test_ssh_server_paramiko.py` → **248 → 0**(All checks passed)
- `invoke ty`(走査経路)→ production-clean 維持
- `invoke ruff` → clean
- full suite `-n auto`(docker 2 件除外)→ **1049 passed / 7 skipped / 1 xfailed**

## レビュー
design 1 round + code cross-review 1 round(codex/gemini SUGGESTION・claude LGTM、MUST/SHOULD FIX ゼロ)。reviewer 間で割れた L1028/L1120 の扱いは ty 実測で裁定し rationale コメント化。

---
🤖 AI (Claude Code) 支援。human maintainer レビュー後に merge。

🤖 Generated with [Claude Code](https://claude.com/claude-code)