### PR TITLE
refactor: M-9 Phase 3 PR2c — 残り tests/ 6 ファイルを ty-clean 化 (#251)

### DIFF
--- a/simnos/core/simnos.py
+++ b/simnos/core/simnos.py
@@ -83,10 +83,10 @@ class SimNOS:
 
     def __init__(
         self,
-        inventory: dict | None = None,
+        inventory: dict | str | None = None,
         plugins: list | None = None,
     ) -> None:
-        self.inventory: dict = inventory or default_inventory
+        self.inventory: dict | str = inventory or default_inventory
         self.plugins: list = plugins or []
 
         self.hosts: dict[str, Host] = {}
@@ -158,6 +158,9 @@ class SimNOS:
         and store them in self.hosts, this
         method called automatically on SimNOS object instantiation.
         """
+        # _load_inventory() が先に走り str パスは dict に解決済 (str/非 dict は raise) なので
+        # ここでは dict 確定。ty 向けに invariant を明示 narrow する。
+        assert isinstance(self.inventory, dict)  # noqa: S101 — caller-side invariant
         for host_name, host_config in self.inventory["hosts"].items():
             params = {
                 **copy.deepcopy(self.inventory["default"]),
@@ -465,7 +468,7 @@ def _get_free_port() -> int:
         return s.getsockname()[1]
 
 
-def simnos(platform: str | None = None, inventory: dict | None = None, return_instance: bool = False):
+def simnos(platform: str | None = None, inventory: dict | str | None = None, return_instance: bool = False):
     """
     Decorator to run a test with SimNOS server.
     """

--- a/simnos/core/simnos.py
+++ b/simnos/core/simnos.py
@@ -158,8 +158,8 @@ class SimNOS:
         and store them in self.hosts, this
         method called automatically on SimNOS object instantiation.
         """
-        # _load_inventory() が先に走り str パスは dict に解決済 (str/非 dict は raise) なので
-        # ここでは dict 確定。ty 向けに invariant を明示 narrow する。
+        # narrow for ty; _load_inventory() ran first and resolved/validated the
+        # inventory to a dict (str paths loaded, non-dict raised), so it is a dict here.
         assert isinstance(self.inventory, dict)  # noqa: S101 — caller-side invariant
         for host_name, host_config in self.inventory["hosts"].items():
             params = {

--- a/tests/compatibility/test_scrapli_cisco_ios.py
+++ b/tests/compatibility/test_scrapli_cisco_ios.py
@@ -3,7 +3,7 @@
 import pytest
 
 pytest.importorskip("scrapli")
-from scrapli.driver.core import IOSXEDriver
+from scrapli.driver.core import IOSXEDriver  # ty: ignore[unresolved-import]
 
 
 def _scrapli_creds(creds: dict) -> dict:

--- a/tests/core/test_netmiko.py
+++ b/tests/core/test_netmiko.py
@@ -152,4 +152,5 @@ class TestNetmiko:
         }
         with SimNOS(inventory=inventory), ConnectHandler(**credentials) as conn:
             output = conn.send_command("show clock")
+            assert isinstance(output, str)
             assert re.match(r"^\w{3} \w{3}\s{1,2}\d{1,2} \d{2}:\d{2}:\d{2} \d{4}$", output)

--- a/tests/core/test_netmiko_init_compat.py
+++ b/tests/core/test_netmiko_init_compat.py
@@ -273,6 +273,7 @@ class TestSendCommandResponse:
             device = _device(device_type, port)
             with ConnectHandler(**device) as conn:
                 output = conn.send_command(cmd, read_timeout=15)
+                assert isinstance(output, str)
                 assert output.strip() == expected.strip(), (
                     f"{device_type}: '{cmd}' returned unexpected output.\n"
                     f"  expected: {expected.strip()!r}\n"
@@ -316,6 +317,7 @@ class TestSendCommandResponse:
                 def check(cmds: list[tuple[str, str]], phase: str) -> None:
                     for cmd, expected in cmds:
                         output = conn.send_command(cmd, read_timeout=15)
+                        assert isinstance(output, str)
                         assert output.strip() == expected.strip(), (
                             f"{device_type}: '{cmd}' ({phase}) returned unexpected output.\n"
                             f"  expected: {expected.strip()!r}\n"

--- a/tests/core/test_nos.py
+++ b/tests/core/test_nos.py
@@ -127,7 +127,7 @@ def test_validate():
     when the NOS attributes are invalid.
     """
     with pytest.raises(ValidationError, match=r"commands"):
-        nos = Nos(commands="invalid_commands")
+        nos = Nos(commands="invalid_commands")  # ty: ignore[invalid-argument-type]
         nos.validate()
 
 
@@ -163,7 +163,7 @@ def test_init_rejects_invalid_field(commands, override, match):
     commands from the shared fixture) so the rejection is attributable to the
     overridden field alone.
     """
-    kwargs = {"name": "MySimNOS", "initial_prompt": "MySimNOS>", "commands": commands}
+    kwargs: dict = {"name": "MySimNOS", "initial_prompt": "MySimNOS>", "commands": commands}
     kwargs.update(override)
     with pytest.raises(ValidationError, match=match):
         Nos(**kwargs)
@@ -610,7 +610,7 @@ def test_register_nos_plugin_from_dict():
     """
     Test that we can register a nos model from a dict.
     """
-    nos_dict = {
+    nos_dict: dict = {
         "name": "MySimNOSPlugin",
         "initial_prompt": "{base_prompt}>",
         "commands": {
@@ -661,7 +661,7 @@ def test_register_nos_plugin_incorrect_name():
     """
     with pytest.raises(ValidationError, match=r"\bname\b"):
         Nos(
-            name=123,
+            name=123,  # ty: ignore[invalid-argument-type]
             initial_prompt="{base_prompt}>",
             commands={
                 "show clock": {"output": ""},
@@ -722,4 +722,5 @@ def test_configuration_file_is_loaded():
         data = file.read()
     nos = Nos(filename="tests/assets/module.py", configuration_file=configuration_file)
     assert nos.configuration_file == configuration_file
+    assert nos.device is not None
     assert nos.device.configurations == yaml.safe_load(data)

--- a/tests/core/test_pydantic_models.py
+++ b/tests/core/test_pydantic_models.py
@@ -62,4 +62,4 @@ class TestCommandHandlerField:
     def test_output_rejects_non_callable_non_str(self):
         """A non-callable, non-str output (int) is rejected."""
         with pytest.raises(ValidationError, match="output"):
-            ModelNosCommand(output=42)
+            ModelNosCommand(output=42)  # ty: ignore[invalid-argument-type]

--- a/tests/core/test_simnos.py
+++ b/tests/core/test_simnos.py
@@ -9,7 +9,7 @@ import os
 import platform
 import re
 import threading
-from typing import NamedTuple
+from typing import Any, NamedTuple, cast
 from unittest.mock import MagicMock, Mock, patch
 
 import pytest
@@ -92,8 +92,8 @@ class TestSimNOS:
         set changes. server/shell plugins, address (WSL/docker aware) and the
         host_key-derived base_prompt are pinned per host.
         """
-        expected_hosts = default_inventory["hosts"]
-        default_config = default_inventory["default"]
+        expected_hosts = cast(dict, default_inventory["hosts"])
+        default_config = cast(dict, default_inventory["default"])
 
         net = SimNOS()
         assert set(net.hosts) == set(expected_hosts)
@@ -270,7 +270,7 @@ class TestSimNOS:
         when the port is already allocated.
         """
         net = SimNOS()
-        net.allocated_ports = [5000]
+        net.allocated_ports = {5000}
         with pytest.raises(ValueError, match=r"already in use"):
             net._allocate_port(5000)
 
@@ -356,6 +356,7 @@ class TestSimNOS:
             }
         }
         net = SimNOS(inventory=inventory)
+        assert isinstance(net.inventory, dict)
         assert net.inventory["hosts"]["R1"]["shell"]["plugin"] == "CMDShell"
 
     def test_inventory_configuration_dict(self):
@@ -557,7 +558,11 @@ class TestPlatformsManifest:
     @simnos(platform="cisco_ios", return_instance=True)
     def test_decorator_with_platform(self, net: SimNOS):
         """Test that the decorator works with a platform."""
-        platforms_used = [host.nos.name for host in net.hosts.values()]
+        platforms_used = []
+        for host in net.hosts.values():
+            nos = host.nos
+            assert nos is not None
+            platforms_used.append(nos.name)
         assert len(net.hosts) == 1
         assert "cisco_ios" in platforms_used
         assert "huawei_smartax" not in platforms_used
@@ -726,7 +731,7 @@ class TestJoinThreadsDeadline:
             return base_time + 16  # past deadline
 
         with patch("simnos.core.servers.time.monotonic", side_effect=mock_monotonic):
-            net._join_threads(mock_threads)
+            net._join_threads(cast(list[threading.Thread], mock_threads))
 
         # First 2 threads should have been joined, rest skipped
         mock_threads[0].join.assert_called_once()
@@ -759,7 +764,7 @@ class TestGlobalDeadline:
             call_count[0] += 1
 
         for h in hosts:
-            h.stop = slow_stop
+            cast(Any, h).stop = slow_stop
 
         # Deadline already in the past → all hosts skipped
         with patch("simnos.core.simnos.time.monotonic", return_value=1000.0):
@@ -778,7 +783,7 @@ class TestGlobalDeadline:
         hosts = list(net.hosts.values())
         for h in hosts:
             h.running = True
-            h.stop = Mock()
+            cast(Any, h).stop = Mock()
 
         mock_ex = MagicMock()
         mock_future = MagicMock()
@@ -811,7 +816,7 @@ class TestGlobalDeadline:
         hosts = list(net.hosts.values())
         for h in hosts:
             h.running = False
-            h.start = Mock()
+            cast(Any, h).start = Mock()
 
         mock_ex = MagicMock()
         mock_future = MagicMock()
@@ -842,7 +847,7 @@ class TestGlobalDeadline:
         hosts = list(net.hosts.values())
         for h in hosts:
             h.running = False
-            h.start = Mock()
+            cast(Any, h).start = Mock()
 
         mock_ex = MagicMock()
         mock_future = MagicMock()

--- a/tests/test_sync_ntc_commands.py
+++ b/tests/test_sync_ntc_commands.py
@@ -22,6 +22,7 @@ import sys
 # it explicitly rather than via a package import.
 _SYNC_PATH = Path(__file__).resolve().parents[1] / "sync_ntc_commands.py"
 _spec = importlib.util.spec_from_file_location("sync_ntc_commands", _SYNC_PATH)
+assert _spec is not None and _spec.loader is not None
 sync_ntc_commands = importlib.util.module_from_spec(_spec)
 sys.modules["sync_ntc_commands"] = sync_ntc_commands
 _spec.loader.exec_module(sync_ntc_commands)

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -130,7 +130,9 @@ def get_host_commands(host: Host) -> tuple[list[str], list[str], list[str]]:
     It gets the initial, enable and config commands.
     """
     initial_commands, enable_commands, config_commands = [], [], []
-    for command, options in host.nos.commands.items():
+    nos = host.nos
+    assert nos is not None
+    for command, options in nos.commands.items():
         if command.startswith("_") and command.endswith("_"):
             continue
         if "prompt" not in options:
@@ -142,10 +144,10 @@ def get_host_commands(host: Host) -> tuple[list[str], list[str], list[str]]:
         if isinstance(prompts, str):
             prompts = [prompts]
         for prompt in prompts:
-            if prompt == host.nos.initial_prompt:
+            if prompt == nos.initial_prompt:
                 initial_commands.append(command)
-            elif host.nos.enable_prompt and prompt == host.nos.enable_prompt:
+            elif nos.enable_prompt and prompt == nos.enable_prompt:
                 enable_commands.append(command)
-            elif host.nos.config_prompt and prompt == host.nos.config_prompt:
+            elif nos.config_prompt and prompt == nos.config_prompt:
                 config_commands.append(command)
     return initial_commands, enable_commands, config_commands


### PR DESCRIPTION
🐙claude:

## 概要
#251 (M-9 Phase 3 — `tests/` の ty exclude 解除) の **PR2c**。PR2 を 3 分割した最終分割で、残り 6 ファイルの ty diagnostics を **47 → 0** にする。これで `tests/` 全体が ty-clean になり、残りは PR3(exclude flip + paramiko 解除)のみ。

PR1 (#256 paramiko) / PR2a (#257 telnet) / PR2b (#258 cmd_shell) は merge 済。

## 変更内容

### production 注釈是正(案P)
`simnos/core/simnos.py`: `SimNOS.__init__` / `simnos()` の `inventory` を `dict | str | None`、`self.inventory` を `dict | str` に widen。runtime は `_is_inventory_in_yaml` / `_load_inventory_yaml` / `_load_inventory` が示す通り **str(YAML パス)入力を元々正式サポート**しているのに、型注釈が `dict | None` / `dict` で str を欠いていた**注釈ギャップの是正**(後方互換 widening)。`_init` は `__init__` 内で `_load_inventory()`(str/非dict を raise して dict 保証)の後に呼ばれる invariant のため、冒頭に `assert isinstance(self.inventory, dict)` を追加して production の ty-clean を維持(既存 `_load_inventory_yaml` と同 narrow idiom)。

これにより test_simnos の `SimNOS(inventory="...yaml")` / `@simnos(inventory=...)` / `net.inventory = "...yaml"` 系 12 件を **test 側の `# ty: ignore` ゼロ**で解消(legitimate usage を masking しない)。

### tests/ 6 ファイル(47 → 0)
| ファイル | 件数 | 手法 |
|---|---|---|
| `tests/core/test_simnos.py` | 20 | 上記注釈で 12件 / `cast(dict)` (inline dict widening) / `{5000}` (set literal、副次的に list→set の実バグ修正) / `assert isinstance(net.inventory, dict)` (既存 idiom) / comprehension→loop + `assert nos is not None` / `cast(list[Thread], ...)` / `cast(Any, h).stop\|start` (PR2b idiom) |
| `tests/core/test_nos.py` | 11 | 意図的 ValidationError 直接 literal 2件 → 局所 `# ty: ignore[invalid-argument-type]` / `**kwargs`・`**nos_dict` → `: dict` 注釈 / `assert nos.device is not None` |
| `tests/utils.py` | 6 | `nos = host.nos; assert nos is not None` で 6 アクセス narrow |
| `tests/core/test_netmiko_init_compat.py` | 4 | `assert isinstance(output, str)` ×2(`send_command` の union 戻り値) |
| `tests/test_sync_ntc_commands.py` | 3 | `assert _spec is not None and _spec.loader is not None` |
| `tests/core/test_pydantic_models.py` | 1 | 意図的 ValidationError → 局所 `# ty: ignore[invalid-argument-type]` |
| `tests/core/test_netmiko.py` | 1 | `assert isinstance(output, str)` |
| `tests/compatibility/test_scrapli_cisco_ios.py` | 1 | optional dep の unresolved-import → 局所 `# ty: ignore[unresolved-import]` |

`# ty: ignore` は意図的 ValidationError 3件 + optional dep import 1件のみに局所限定(design 原則「ignore は意図的型違反のみ」整合)。`typing.cast` は runtime no-op のため全 cast 置換は挙動不変。

## 検証
- `uv run ty check tests/` → **47 → 0**(All checks passed)
- `uv run ty check .`(production 走査)→ All checks passed(widening 後も production clean 維持)
- `uv run invoke ruff` → clean(check + format)
- full suite(`-n auto`、docker 2件除外)→ **1049 passed・7 skipped・1 xfailed・10 subtests passed**(exit 0)

## cross-review
1st round で codex / gemini / claude 全員 **SUGGESTION**(MUST/SHOULD FIX ゼロ、1 round 収束)。SUGGESTION 4件はいずれも defer:
- `self.inventory` を `dict` に絞る(codex): 既存単体テストが属性へ str 直接代入して loader 検証する設計のため `dict | str` が必須 → **テスト設計と非互換、却下**
- `: dict`→`dict[str, Any]`(codex): PR2a で defer 済、#251 内 bare dict 一貫性
- `Nos.device` に具体型注釈(gemini): production typing 改善で scope 外
- 560 を comprehension+cast に戻す(claude): idiom 一貫性で現状維持(reviewer 自身が支持)

codex/gemini の production typing 提案は #251 完了後の future refactor 候補として記録。

---
🤖 AI Transparency: 本 PR は Claude Code (claude-opus-4-8) 支援で作成。全変更は human maintainer のレビュー後に merge されます。

🤖 Generated with [Claude Code](https://claude.com/claude-code)