### PR TITLE
refactor: M-9 Phase 3 PR3 — tests/ + paramiko の ty exclude 解除 (#251 close-out)

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -38,8 +38,9 @@ jobs:
       - name: "Security: bandit"
         run: "uv run invoke bandit"
       # Typecheck: ty is blocking since Phase 2 (#218).
-      # Production code (simnos/) is ty-clean; tests/ excluded via
-      # pyproject.toml [tool.ty.src]. New type errors in production fail CI.
+      # Phase 3 (#251) removed the tests/ and ssh_server_paramiko exclusions
+      # from pyproject.toml [tool.ty.src]; the whole tree is now ty-clean and
+      # scanned, so new type errors anywhere (production or tests) fail CI.
       # GitHub Actions annotation format surfaces error locations directly in
       # PR review's "Files changed" tab.
       - name: "Typecheck: ty"

--- a/CONTRIBUTING.ja.md
+++ b/CONTRIBUTING.ja.md
@@ -86,10 +86,11 @@ uv run pre-commit install
 ### テストの実行
 
 ```bash
-# すべてのチェック（lint + security + tests）
+# すべてのチェック（lint + security + type-check + tests）
 uv run invoke ruff       # リンティングとフォーマット
 uv run invoke yamllint   # YAML リンティング
 uv run invoke bandit     # セキュリティチェック
+uv run invoke ty         # 型チェック（blocking、#251 以降は全ツリー）
 uv run pytest -n auto    # ユニットテスト
 ```
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -86,10 +86,11 @@ uv run pre-commit install
 ### Running Tests
 
 ```bash
-# Run all checks (lint + security + tests)
+# Run all checks (lint + security + type-check + tests)
 uv run invoke ruff       # Linting and formatting
 uv run invoke yamllint   # YAML linting
 uv run invoke bandit     # Security checks
+uv run invoke ty         # Type checking (blocking, whole tree since #251)
 uv run pytest -n auto    # Unit tests
 ```
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -103,19 +103,18 @@ skips = ["B101", "B601"]
 
 
 [tool.ty.src]
-# Phase 2 (#218): production code (simnos/) is ty-clean (0 diagnostics).
-# tests/ is excluded because the test layer relies heavily on MagicMock dynamic
-# attributes and function-state fixture patterns that defeat static type
-# analysis. Phase 3 (TBD) will revisit tests with a type-aware testing approach
-# (e.g. create_autospec) if/when MagicMock alternatives mature.
-#
-# Phase 1 (#216) excluded ssh_server_paramiko separately because paramiko is
-# untyped and types-paramiko v4 was incompatible with paramiko 5.0. Keep that
-# entry until Phase 3 reassesses types-paramiko v5.x adoption.
-exclude = [
-    "simnos/plugins/servers/ssh_server_paramiko.py",
-    "tests/",
-]
+# Phase 3 (#251) complete: the whole tree is ty-clean and scanned with no
+# exclusions. The former exclusions were lifted in this order:
+#   - Phase 1 (#216) had excluded ssh_server_paramiko (paramiko is untyped and
+#     types-paramiko v4 was incompatible with paramiko 5.0); the production file
+#     is now ty-clean without stubs, so the entry was dropped.
+#   - Phase 2 (#218) had excluded tests/ (MagicMock dynamic attributes and
+#     function-state fixtures defeated static analysis); tests/ was brought to
+#     0 diagnostics (cast/assert narrowing + localized `# ty: ignore` for
+#     intentional type-violation cases) and the entry was dropped.
+# Keep exclude empty so any new file is gated by default. ty's own defaults
+# still skip .venv and build artifacts.
+exclude = []
 
 
 [tool.coverage.run]

--- a/tasks.py
+++ b/tasks.py
@@ -163,10 +163,11 @@ def lint_platform_yaml(context):
 def ty(context, exit_zero=False):
     """Run ty type-checker (blocking since Phase 2, see #218).
 
-    Phase 2 brought production code to 0 diagnostics; tests/ is excluded
-    via pyproject.toml ``[tool.ty.src]``. CI now treats ty as blocking
-    (exit_zero=False default + no continue-on-error). New type errors in
-    production code break the build.
+    Phase 2 brought production code to 0 diagnostics; Phase 3 (#251) then
+    removed the tests/ and ssh_server_paramiko exclusions from pyproject.toml
+    ``[tool.ty.src]``, so the whole tree is now scanned with 0 diagnostics.
+    CI treats ty as blocking (exit_zero=False default + no continue-on-error),
+    so new type errors anywhere (production or tests) break the build.
 
     Args:
         exit_zero: When True, pass ``--exit-zero`` so ty never exits


### PR DESCRIPTION
🐙claude:

## 概要
#251 (M-9 Phase 3 — `tests/` の ty exclude 解除) の **最終 PR / close-out**。`pyproject.toml [tool.ty.src] exclude` から `tests/` と `simnos/plugins/servers/ssh_server_paramiko.py` を除去し、**全ツリー (73 files) を ty 走査対象**にする gating flip。

PR1 #256 (paramiko 本体) / PR2a #257 (telnet) / PR2b #258 (cmd_shell) / PR2c #259 (残り6ファイル + production 注釈) で tests/ + paramiko 本体を ty-clean 化済のため、本 PR は **config + docs のみ**(production/test コード変更なし)。

## 変更内容
- **`pyproject.toml [tool.ty.src]`**: `exclude = ["ssh_server_paramiko.py", "tests/"]` → **`exclude = []`**。Phase 1/2 で除外 → Phase 3 で両方解除した経緯をコメントに記録(section は維持し将来の新規ファイルを default で gating)
- **`tasks.py`** / **`.github/workflows/main.yml`**: ty が tests/ を除外する旨 → 全ツリー走査(production + tests、新規型エラーはどこでも CI fail)の記述に更新
- **`CONTRIBUTING.md` / `CONTRIBUTING.ja.md`**: contributor 向け「Run all checks」一覧に blocking step である `uv run invoke ty` を追加(en/ja 両方)

## 検証(明示 clean ≠ 走査 clean リスクの最終確認)
- flip 前: `ty check ssh_server_paramiko.py`(explicit)→ 0(本体は PR1 時点で ty-clean)
- **flip 後: `ty check .` / `invoke ty`(73 files 全走査)→ All checks passed!** ✅(paramiko は types-paramiko stub 無しで clean、`paramiko>=4.0,<6.0` のみ)
- ruff(check+format)/ yamllint clean
- full suite(`-n auto`、docker 2件除外)→ **1049 passed・7 skipped・1 xfailed**
- stale 参照 grep(`tests/ excluded` / `create_autospec` / `Phase 3 TBD`)残存なし

## cross-review
1st round: claude **LGTM** / codex SUGGESTION / gemini SUGGESTION(MUST/SHOULD FIX ゼロ、1 round 収束)。claude reviewer が `ty check .` 73 files = All checks passed・paramiko 単独 0・types-paramiko 依存なしを自分で再現確認し主張を裏取り。
- **取り込み**: CONTRIBUTING の all checks に ty 追加(codex #3、close-out 直結の trivial 改善)
- **defer**: bandit `exclude_dirs` の tests/ を doc 化(claude、別ツール設定)/ pyproject 経緯コメントを安定期に docs へ archival(gemini、将来)/ types-paramiko 安定後の stub 再導入(gemini、既知の future 方向性)

## #251 完了
本 PR merge で #251 のコア(`tests/` ty exclude 解除)完了。以降、production・tests 問わず新規型エラーは CI gating で弾かれる。

future 候補(#251 完了後): cast idiom helper 抽出 / `patch.object` 化(tests 全体が ty 対象になった今が検討時)、production typing 改善(`self.inventory` post-init dict invariant の型埋め込み / `Nos.device` 具体型注釈)、types-paramiko v5.x 安定後の stub 再導入。

---
🤖 AI Transparency: 本 PR は Claude Code (claude-opus-4-8) 支援で作成。全変更は human maintainer のレビュー後に merge されます。

🤖 Generated with [Claude Code](https://claude.com/claude-code)