### PR TITLE
refactor: tests の cast idiom を set_attr helper に集約 (#261)

### DIFF
--- a/tests/core/test_simnos.py
+++ b/tests/core/test_simnos.py
@@ -9,7 +9,7 @@ import os
 import platform
 import re
 import threading
-from typing import Any, NamedTuple, cast
+from typing import NamedTuple, cast
 from unittest.mock import MagicMock, Mock, patch
 
 import pytest
@@ -20,7 +20,7 @@ from simnos.core.nos import available_platforms
 from simnos.core.simnos import SimNOS, default_inventory, simnos
 from simnos.core.utils import _is_in_docker
 from simnos.plugins.nos import nos_plugins
-from tests.utils import get_platforms_from_md, get_running_hosts
+from tests.utils import get_platforms_from_md, get_running_hosts, set_attr
 
 
 class _Step(NamedTuple):
@@ -764,7 +764,7 @@ class TestGlobalDeadline:
             call_count[0] += 1
 
         for h in hosts:
-            cast(Any, h).stop = slow_stop
+            set_attr(h, "stop", slow_stop)
 
         # Deadline already in the past → all hosts skipped
         with patch("simnos.core.simnos.time.monotonic", return_value=1000.0):
@@ -783,7 +783,7 @@ class TestGlobalDeadline:
         hosts = list(net.hosts.values())
         for h in hosts:
             h.running = True
-            cast(Any, h).stop = Mock()
+            set_attr(h, "stop", Mock())
 
         mock_ex = MagicMock()
         mock_future = MagicMock()
@@ -816,7 +816,7 @@ class TestGlobalDeadline:
         hosts = list(net.hosts.values())
         for h in hosts:
             h.running = False
-            cast(Any, h).start = Mock()
+            set_attr(h, "start", Mock())
 
         mock_ex = MagicMock()
         mock_future = MagicMock()
@@ -847,7 +847,7 @@ class TestGlobalDeadline:
         hosts = list(net.hosts.values())
         for h in hosts:
             h.running = False
-            cast(Any, h).start = Mock()
+            set_attr(h, "start", Mock())
 
         mock_ex = MagicMock()
         mock_future = MagicMock()

--- a/tests/plugins/test_cmd_shell.py
+++ b/tests/plugins/test_cmd_shell.py
@@ -9,7 +9,6 @@ import sys
 import tempfile
 import threading
 import time
-from typing import Any, cast
 from unittest import TestCase
 from unittest.mock import Mock, patch
 
@@ -20,6 +19,7 @@ import yaml
 from simnos.core.nos import Nos
 from simnos.core.simnos import SimNOS, simnos
 from simnos.plugins.shell.cmd_shell import HANDLER_ERROR_OUTPUT, CMDShell
+from tests.utils import set_attr
 
 
 def make_cmd_shell_args() -> dict:
@@ -150,23 +150,23 @@ class TestCmdShell(TestCase):
         """Test that the start method calls cmdloop."""
         shell = CMDShell(**self.arguments)
         mock_cmdloop = Mock()
-        cast(Any, shell).cmdloop = mock_cmdloop
+        set_attr(shell, "cmdloop", mock_cmdloop)
         shell.start()
         mock_cmdloop.assert_called_once()
 
     def test_stop(self):
         """Test that the stop method writes "exit" to stdin."""
         shell = CMDShell(**self.arguments)
-        cast(Any, shell).stdin = Mock()
+        stdin = set_attr(shell, "stdin", Mock())
         shell.stop()
-        cast(Mock, shell.stdin).write.assert_called_once_with("exit\r\n")
+        stdin.write.assert_called_once_with("exit\r\n")
 
     def test_writeline(self):
         """Test that the writeline method writes a line to stdout with a newline at the end."""
         shell = CMDShell(**self.arguments)
-        cast(Any, shell).stdout = Mock()
+        stdout = set_attr(shell, "stdout", Mock())
         shell.writeline("test")
-        cast(Mock, shell.stdout).write.assert_called_once_with("test\r\n")
+        stdout.write.assert_called_once_with("test\r\n")
 
     def test_emptyline(self):
         """Test that the emptyline method does nothing."""
@@ -207,7 +207,7 @@ class TestCmdShell(TestCase):
     def test_do_help(self):
         """Test that the do_help method writes the help message to stdout."""
         shell = CMDShell(**self.arguments)
-        cast(Any, shell).writeline = Mock()
+        writeline = set_attr(shell, "writeline", Mock())
         shell.do_help("")
         expected_output: list[str] = [
             "exit                Exit commands shell",
@@ -217,7 +217,7 @@ class TestCmdShell(TestCase):
             "terminal width 511  Set terminal width to 511",
             "terminal length 0   Set terminal length to 0",
         ]
-        cast(Mock, shell.writeline).assert_called_once_with("\r\n".join(expected_output))
+        writeline.assert_called_once_with("\r\n".join(expected_output))
 
     def test__check_prompt_is_none(self):
         """Test that the _check_prompt method returns the prompt."""
@@ -259,26 +259,26 @@ class TestCmdShell(TestCase):
         """Test that the default method does nothing."""
         self.arguments["is_running"].set()
         shell = CMDShell(**self.arguments)
-        cast(Any, shell).writeline = Mock()
+        writeline = set_attr(shell, "writeline", Mock())
         shell.default("show clock")
-        cast(Mock, shell.writeline).assert_called_once_with("*21:01:33.000 AET 01 01 01 2022")
+        writeline.assert_called_once_with("*21:01:33.000 AET 01 01 01 2022")
 
     def test_default_command_with_alias(self):
         """Test that the default method does nothing."""
         self.arguments["is_running"].set()
         shell = CMDShell(**self.arguments)
-        cast(Any, shell).writeline = Mock()
+        writeline = set_attr(shell, "writeline", Mock())
         shell.default("sh clock")
-        cast(Mock, shell.writeline).assert_called_once_with("*21:01:33.000 AET 01 01 01 2022")
+        writeline.assert_called_once_with("*21:01:33.000 AET 01 01 01 2022")
 
     def test_default_command_is_function(self):
         """Test that the default method does nothing."""
         self.arguments["is_running"].set()
         self.arguments["nos"] = Nos(filename="tests/assets/module.py")
         shell = CMDShell(**self.arguments)
-        cast(Any, shell).writeline = Mock()
+        writeline = set_attr(shell, "writeline", Mock())
         shell.default("show clock")
-        cast(Mock, shell.writeline).assert_called_once_with(time.ctime())
+        writeline.assert_called_once_with(time.ctime())
 
     def _make_callable_dict_shell(self, output_callable):
         """Build a shell whose 'cmd' command output is `output_callable`.
@@ -311,31 +311,33 @@ class TestCmdShell(TestCase):
             }
         )
         shell = CMDShell(**self.arguments)
-        cast(Any, shell).writeline = Mock()
         return shell
 
     def test_default_callable_dict_new_prompt(self):
         """Callable dict with new_prompt updates the prompt (formatted)."""
         shell = self._make_callable_dict_shell(lambda device, **kwargs: {"output": "", "new_prompt": "{base_prompt}#"})
+        writeline = set_attr(shell, "writeline", Mock())
         stop = shell.default("cmd")
         self.assertFalse(stop)
         self.assertEqual(shell.prompt, "test#")
-        cast(Mock, shell.writeline).assert_called_once_with("")
+        writeline.assert_called_once_with("")
 
     def test_default_callable_dict_exit(self):
         """Callable dict with exit=True signals shell termination."""
         shell = self._make_callable_dict_shell(lambda device, **kwargs: {"exit": True})
+        writeline = set_attr(shell, "writeline", Mock())
         stop = shell.default("cmd")
         self.assertTrue(stop)
-        cast(Mock, shell.writeline).assert_not_called()
+        writeline.assert_not_called()
 
     def test_default_callable_dict_output_only(self):
         """Callable dict with output only writes it, prompt unchanged."""
         shell = self._make_callable_dict_shell(lambda device, **kwargs: {"output": "dynamic body"})
+        writeline = set_attr(shell, "writeline", Mock())
         stop = shell.default("cmd")
         self.assertFalse(stop)
         self.assertEqual(shell.prompt, "test>")
-        cast(Mock, shell.writeline).assert_called_once_with("dynamic body")
+        writeline.assert_called_once_with("dynamic body")
 
     def _make_prompt_form_shell(self, prompt_value):
         """Build a shell whose 'cmd' command uses the given `prompt` authoring form.
@@ -360,22 +362,23 @@ class TestCmdShell(TestCase):
             }
         )
         shell = CMDShell(**self.arguments)
-        cast(Any, shell).writeline = Mock()
         return shell
 
     def test_default_prompt_str_authoring_dispatches(self):
         """A bare-str `prompt` matches the current prompt and dispatches."""
         shell = self._make_prompt_form_shell("{base_prompt}>")
+        writeline = set_attr(shell, "writeline", Mock())
         stop = shell.default("cmd")
         self.assertFalse(stop)
-        cast(Mock, shell.writeline).assert_called_once_with("form ok")
+        writeline.assert_called_once_with("form ok")
 
     def test_default_prompt_list_authoring_dispatches(self):
         """A list `prompt` matches the current prompt and dispatches."""
         shell = self._make_prompt_form_shell(["{base_prompt}>", "{base_prompt}#"])
+        writeline = set_attr(shell, "writeline", Mock())
         stop = shell.default("cmd")
         self.assertFalse(stop)
-        cast(Mock, shell.writeline).assert_called_once_with("form ok")
+        writeline.assert_called_once_with("form ok")
 
     def test_inventory_commands_prompt_str_is_normalized_and_dispatches(self):
         """Inventory-defined commands get the same str -> [str] normalization.
@@ -397,27 +400,27 @@ class TestCmdShell(TestCase):
             },
         }
         shell = CMDShell(**self.arguments)
-        cast(Any, shell).writeline = Mock()
+        writeline = set_attr(shell, "writeline", Mock())
         self.assertEqual(shell.commands["inv cmd"]["prompt"], ["{base_prompt}>"])
         stop = shell.default("inv cmd")
         self.assertFalse(stop)
-        cast(Mock, shell.writeline).assert_called_once_with("inventory ok")
+        writeline.assert_called_once_with("inventory ok")
 
     def test_default_command_not_matching_prompt(self):
         """Test that the default method does nothing."""
         self.arguments["is_running"].set()
         shell = CMDShell(**self.arguments)
-        cast(Any, shell).writeline = Mock()
+        writeline = set_attr(shell, "writeline", Mock())
         shell.default("show version")
-        cast(Mock, shell.writeline).assert_called_once_with("% Invalid input detected at '^' marker.")
+        writeline.assert_called_once_with("% Invalid input detected at '^' marker.")
 
     def test_default_command_incorrect(self):
         """Test that the default method does nothing."""
         self.arguments["is_running"].set()
         shell = CMDShell(**self.arguments)
-        cast(Any, shell).writeline = Mock()
+        writeline = set_attr(shell, "writeline", Mock())
         shell.default("test")
-        cast(Mock, shell.writeline).assert_called_once_with("% Invalid input detected at '^' marker.")
+        writeline.assert_called_once_with("% Invalid input detected at '^' marker.")
 
     def test_default_alias_target_missing_falls_back_default(self):
         """An alias whose target command is gone degrades to `_default_`.
@@ -430,10 +433,10 @@ class TestCmdShell(TestCase):
         """
         self.arguments["is_running"].set()
         shell = CMDShell(**self.arguments)
-        cast(Any, shell).writeline = Mock()
+        writeline = set_attr(shell, "writeline", Mock())
         shell.commands["broken alias"] = {"alias": "no such target"}
         shell.default("broken alias")
-        cast(Mock, shell.writeline).assert_called_once_with("% Invalid input detected at '^' marker.")
+        writeline.assert_called_once_with("% Invalid input detected at '^' marker.")
 
     def test_resolve_command_unknown_returns_none(self):
         """`_resolve_command` degrades an unknown command to None.
@@ -527,15 +530,15 @@ class TestCmdShell(TestCase):
             }
         )
         shell = CMDShell(**self.arguments)
-        cast(Any, shell).writeline = Mock()
         return shell
 
     def test_default_callable_default_invoked_on_unknown_command(self):
         """An unknown command invokes a callable `_default_` (#241)."""
         shell = self._make_callable_default_shell()
+        writeline = set_attr(shell, "writeline", Mock())
         stop = shell.default("nope")
         self.assertFalse(stop)
-        cast(Mock, shell.writeline).assert_called_once_with("dynamic unknown: nope")
+        writeline.assert_called_once_with("dynamic unknown: nope")
 
     def test_default_callable_default_invoked_on_prompt_mismatch(self):
         """A prompt mismatch invokes a callable `_default_` (#241).
@@ -545,9 +548,10 @@ class TestCmdShell(TestCase):
         wire. The unification fixes that display bug.
         """
         shell = self._make_callable_default_shell()
+        writeline = set_attr(shell, "writeline", Mock())
         stop = shell.default("known")  # requires "test#", current prompt is "test>"
         self.assertFalse(stop)
-        cast(Mock, shell.writeline).assert_called_once_with("dynamic unknown: known")
+        writeline.assert_called_once_with("dynamic unknown: known")
 
     def test_default_callable_default_dict_return_gets_full_dispatch(self):
         """A dict-returning callable `_default_` gets the same dispatch (#241).
@@ -571,11 +575,11 @@ class TestCmdShell(TestCase):
             }
         )
         shell = CMDShell(**self.arguments)
-        cast(Any, shell).writeline = Mock()
+        writeline = set_attr(shell, "writeline", Mock())
         stop = shell.default("nope")
         self.assertFalse(stop)
         self.assertEqual(shell.prompt, "test#")
-        cast(Mock, shell.writeline).assert_called_once_with("locked out")
+        writeline.assert_called_once_with("locked out")
 
     def test_default_handler_crash_writes_fixed_error_line(self):
         """A crashing handler answers with HANDLER_ERROR_OUTPUT only.
@@ -590,10 +594,11 @@ class TestCmdShell(TestCase):
             raise RuntimeError("boom")
 
         shell = self._make_callable_dict_shell(crash)
+        writeline = set_attr(shell, "writeline", Mock())
         with self.assertLogs("simnos.plugins.shell.cmd_shell", level="ERROR"):
             stop = shell.default("cmd")
         self.assertFalse(stop)
-        cast(Mock, shell.writeline).assert_called_once_with(HANDLER_ERROR_OUTPUT)
+        writeline.assert_called_once_with(HANDLER_ERROR_OUTPUT)
 
     def test_default_handler_crash_logs_full_traceback(self):
         """A crashing handler's traceback goes to the server log.
@@ -608,6 +613,7 @@ class TestCmdShell(TestCase):
             raise RuntimeError("boom-for-log")
 
         shell = self._make_callable_dict_shell(crash)
+        set_attr(shell, "writeline", Mock())
         with self.assertLogs("simnos.plugins.shell.cmd_shell", level="ERROR") as captured:
             shell.default("cmd")
         self.assertEqual(len(captured.output), 1)
@@ -628,7 +634,7 @@ class TestCmdShell(TestCase):
         """
         self.arguments["is_running"].set()
         shell = CMDShell(**self.arguments)
-        cast(Any, shell).writeline = Mock()
+        writeline = set_attr(shell, "writeline", Mock())
         shell.commands["broken_key_cmd"] = {
             "output": "value is {unknown_key}",
             "prompt": ["{base_prompt}>"],
@@ -637,7 +643,7 @@ class TestCmdShell(TestCase):
             shell.default("broken_key_cmd")
         self.assertEqual(len(captured.output), 1)
         self.assertTrue(any("error formatting output" in msg and "broken_key_cmd" in msg for msg in captured.output))
-        cast(Mock, shell.writeline).assert_called_once_with("value is {unknown_key}")
+        writeline.assert_called_once_with("value is {unknown_key}")
 
     def test_default_silent_fallback_on_valueerror(self):
         """`ValueError` failure mode of `.format()` is silently logged.
@@ -649,7 +655,7 @@ class TestCmdShell(TestCase):
         """
         self.arguments["is_running"].set()
         shell = CMDShell(**self.arguments)
-        cast(Any, shell).writeline = Mock()
+        writeline = set_attr(shell, "writeline", Mock())
         shell.commands["broken_brace_cmd"] = {
             "output": "value is {broken",
             "prompt": ["{base_prompt}>"],
@@ -658,7 +664,7 @@ class TestCmdShell(TestCase):
             shell.default("broken_brace_cmd")
         self.assertEqual(len(captured.output), 1)
         self.assertTrue(any("error formatting output" in msg and "broken_brace_cmd" in msg for msg in captured.output))
-        cast(Mock, shell.writeline).assert_called_once_with("value is {broken")
+        writeline.assert_called_once_with("value is {broken")
 
     def test_default_silent_fallback_on_indexerror(self):
         """`IndexError` failure mode of `.format()` is silently logged.
@@ -671,7 +677,7 @@ class TestCmdShell(TestCase):
         """
         self.arguments["is_running"].set()
         shell = CMDShell(**self.arguments)
-        cast(Any, shell).writeline = Mock()
+        writeline = set_attr(shell, "writeline", Mock())
         shell.commands["broken_pos_cmd"] = {
             "output": "value is {}",
             "prompt": ["{base_prompt}>"],
@@ -680,7 +686,7 @@ class TestCmdShell(TestCase):
             shell.default("broken_pos_cmd")
         self.assertEqual(len(captured.output), 1)
         self.assertTrue(any("error formatting output" in msg and "broken_pos_cmd" in msg for msg in captured.output))
-        cast(Mock, shell.writeline).assert_called_once_with("value is {}")
+        writeline.assert_called_once_with("value is {}")
 
     def test_default_silent_fallback_on_attributeerror(self):
         """`AttributeError` failure mode of `.format()` is silently logged.
@@ -693,7 +699,7 @@ class TestCmdShell(TestCase):
         """
         self.arguments["is_running"].set()
         shell = CMDShell(**self.arguments)
-        cast(Any, shell).writeline = Mock()
+        writeline = set_attr(shell, "writeline", Mock())
         shell.commands["broken_attr_cmd"] = {
             "output": "value is {base_prompt.foo}",
             "prompt": ["{base_prompt}>"],
@@ -702,7 +708,7 @@ class TestCmdShell(TestCase):
             shell.default("broken_attr_cmd")
         self.assertEqual(len(captured.output), 1)
         self.assertTrue(any("error formatting output" in msg and "broken_attr_cmd" in msg for msg in captured.output))
-        cast(Mock, shell.writeline).assert_called_once_with("value is {base_prompt.foo}")
+        writeline.assert_called_once_with("value is {base_prompt.foo}")
 
     def test_default_silent_fallback_on_typeerror(self):
         """`TypeError` failure mode of `.format()` is silently logged.
@@ -715,7 +721,7 @@ class TestCmdShell(TestCase):
         """
         self.arguments["is_running"].set()
         shell = CMDShell(**self.arguments)
-        cast(Any, shell).writeline = Mock()
+        writeline = set_attr(shell, "writeline", Mock())
         shell.commands["broken_item_cmd"] = {
             "output": "value is {base_prompt[bad]}",
             "prompt": ["{base_prompt}>"],
@@ -724,7 +730,7 @@ class TestCmdShell(TestCase):
             shell.default("broken_item_cmd")
         self.assertEqual(len(captured.output), 1)
         self.assertTrue(any("error formatting output" in msg and "broken_item_cmd" in msg for msg in captured.output))
-        cast(Mock, shell.writeline).assert_called_once_with("value is {base_prompt[bad]}")
+        writeline.assert_called_once_with("value is {base_prompt[bad]}")
 
     def test_default_new_prompt_format_failure_keeps_prompt(self):
         """A broken cmd_data new_prompt does not transition the prompt.
@@ -736,7 +742,7 @@ class TestCmdShell(TestCase):
         """
         self.arguments["is_running"].set()
         shell = CMDShell(**self.arguments)
-        cast(Any, shell).writeline = Mock()
+        writeline = set_attr(shell, "writeline", Mock())
         shell.commands["broken_np_cmd"] = {
             "output": "mode change attempted",
             "prompt": ["{base_prompt}>"],
@@ -748,7 +754,7 @@ class TestCmdShell(TestCase):
         self.assertEqual(shell.prompt, "test>")
         self.assertEqual(len(captured.output), 1)
         self.assertTrue(any("error formatting new_prompt" in msg and "broken_np_cmd" in msg for msg in captured.output))
-        cast(Mock, shell.writeline).assert_called_once_with("mode change attempted")
+        writeline.assert_called_once_with("mode change attempted")
 
     def test_default_callable_dict_new_prompt_format_failure(self):
         """A broken callable-dict new_prompt does not transition the prompt.
@@ -762,13 +768,14 @@ class TestCmdShell(TestCase):
         shell = self._make_callable_dict_shell(
             lambda device, **kwargs: {"output": "body", "new_prompt": "{base_prompt.foo}#"}
         )
+        writeline = set_attr(shell, "writeline", Mock())
         with self.assertLogs("simnos.plugins.shell.cmd_shell", level="ERROR") as captured:
             stop = shell.default("cmd")
         self.assertFalse(stop)
         self.assertEqual(shell.prompt, "test>")
         self.assertEqual(len(captured.output), 1)
         self.assertTrue(any("error formatting new_prompt" in msg and "'cmd'" in msg for msg in captured.output))
-        cast(Mock, shell.writeline).assert_called_once_with("body")
+        writeline.assert_called_once_with("body")
 
     def test_default_callable_dict_output_passed_through_unformatted(self):
         """Callable-dict output skips `_safe_format` entirely (#241 / D-b).
@@ -782,10 +789,11 @@ class TestCmdShell(TestCase):
         shape.
         """
         shell = self._make_callable_dict_shell(lambda device, **kwargs: {"output": "value is {base_prompt.foo}"})
+        writeline = set_attr(shell, "writeline", Mock())
         with self.assertNoLogs("simnos.plugins.shell.cmd_shell", level="ERROR"):
             stop = shell.default("cmd")
         self.assertFalse(stop)
-        cast(Mock, shell.writeline).assert_called_once_with("value is {base_prompt.foo}")
+        writeline.assert_called_once_with("value is {base_prompt.foo}")
 
     def test_default_callable_str_output_passed_through_unformatted(self):
         """Callable str output skips `_safe_format` too (#241 / D-b).
@@ -796,10 +804,11 @@ class TestCmdShell(TestCase):
         raw fallback.
         """
         shell = self._make_callable_dict_shell(lambda device, **kwargs: "literal {brace} stays")
+        writeline = set_attr(shell, "writeline", Mock())
         with self.assertNoLogs("simnos.plugins.shell.cmd_shell", level="ERROR"):
             stop = shell.default("cmd")
         self.assertFalse(stop)
-        cast(Mock, shell.writeline).assert_called_once_with("literal {brace} stays")
+        writeline.assert_called_once_with("literal {brace} stays")
 
     def test_default_broken_prompt_treated_as_non_match(self):
         """A command with a broken prompt template is just unreachable.
@@ -811,7 +820,7 @@ class TestCmdShell(TestCase):
         """
         self.arguments["is_running"].set()
         shell = CMDShell(**self.arguments)
-        cast(Any, shell).writeline = Mock()
+        writeline = set_attr(shell, "writeline", Mock())
         # Injected directly into shell.commands (bypassing the load
         # paths), so the list form is used per the #244 / D3 contract.
         shell.commands["broken_prompt_cmd"] = {
@@ -822,7 +831,7 @@ class TestCmdShell(TestCase):
             shell.default("broken_prompt_cmd")
         self.assertEqual(len(captured.output), 1)
         self.assertTrue(any("error formatting prompt" in msg and "broken_prompt_cmd" in msg for msg in captured.output))
-        cast(Mock, shell.writeline).assert_called_once_with("% Invalid input detected at '^' marker.")
+        writeline.assert_called_once_with("% Invalid input detected at '^' marker.")
 
     def test_do_help_broken_prompt_command_hidden(self):
         """`do_help` survives a broken prompt template (command hidden).
@@ -833,7 +842,7 @@ class TestCmdShell(TestCase):
         """
         self.arguments["is_running"].set()
         shell = CMDShell(**self.arguments)
-        cast(Any, shell).writeline = Mock()
+        writeline = set_attr(shell, "writeline", Mock())
         # Direct injection -> list form per the #244 / D3 contract.
         shell.commands["broken_prompt_cmd"] = {
             "output": "x",
@@ -843,7 +852,7 @@ class TestCmdShell(TestCase):
         with self.assertLogs("simnos.plugins.shell.cmd_shell", level="ERROR") as captured:
             shell.do_help("")
         self.assertEqual(len(captured.output), 1)
-        help_text = cast(Mock, shell.writeline).call_args[0][0]
+        help_text = writeline.call_args[0][0]
         self.assertNotIn("broken_prompt_cmd", help_text)
         self.assertIn("show clock", help_text)  # healthy commands still listed
 
@@ -857,7 +866,7 @@ class TestCmdShell(TestCase):
         """
         self.arguments["is_running"].set()
         shell = CMDShell(**self.arguments)
-        cast(Any, shell).writeline = Mock()
+        writeline = set_attr(shell, "writeline", Mock())
         shell.commands["partial_prompt_cmd"] = {
             "output": "reached",
             "prompt": ["{base_prompt.foo}>", "{base_prompt}>"],
@@ -865,13 +874,13 @@ class TestCmdShell(TestCase):
         with self.assertLogs("simnos.plugins.shell.cmd_shell", level="ERROR") as captured:
             shell.default("partial_prompt_cmd")
         self.assertEqual(len(captured.output), 1)  # the broken candidate, once
-        cast(Mock, shell.writeline).assert_called_once_with("reached")
+        writeline.assert_called_once_with("reached")
 
     def test_default_command_new_prompt(self):
         """Test that the default method does nothing."""
         self.arguments["is_running"].set()
         shell = CMDShell(**self.arguments)
-        cast(Any, shell).writeline = Mock()
+        set_attr(shell, "writeline", Mock())
         shell.default("enable")
         shell.prompt = "test#"
 
@@ -906,7 +915,7 @@ class HotReloadTest(TestCase):
         os.environ.pop("SIMNOS_RELOAD_COMMANDS")
         mock_get_files_changed = Mock()
         shell = CMDShell(**self.arguments)
-        cast(Any, shell).get_files_changed = mock_get_files_changed
+        set_attr(shell, "get_files_changed", mock_get_files_changed)
         shell.precmd("show clock")
         mock_get_files_changed.assert_not_called()
 
@@ -944,8 +953,8 @@ class HotReloadTest(TestCase):
         broken file is logged and skipped while remaining files reload.
         """
         shell = CMDShell(**self.arguments)
-        cast(Any, shell.nos).from_file = Mock(side_effect=[ValueError("boom"), None])
-        cast(Any, shell.nos).commands = {"healthy": {"output": "ok"}}
+        set_attr(shell.nos, "from_file", Mock(side_effect=[ValueError("boom"), None]))
+        set_attr(shell.nos, "commands", {"healthy": {"output": "ok"}})
         with self.assertLogs("simnos.plugins.shell.cmd_shell", level="ERROR") as captured:
             shell.reload_commands(["broken.yaml", "healthy.yaml"])
         self.assertEqual(len(captured.output), 1)
@@ -960,8 +969,8 @@ class HotReloadTest(TestCase):
         broken file raises, and the error is still logged.
         """
         shell = CMDShell(**self.arguments)
-        cast(Any, shell.nos).from_file = Mock(side_effect=[None, ValueError("boom")])
-        cast(Any, shell.nos).commands = {"healthy": {"output": "ok"}}
+        set_attr(shell.nos, "from_file", Mock(side_effect=[None, ValueError("boom")]))
+        set_attr(shell.nos, "commands", {"healthy": {"output": "ok"}})
         with self.assertLogs("simnos.plugins.shell.cmd_shell", level="ERROR") as captured:
             shell.reload_commands(["healthy.yaml", "broken.yaml"])
         self.assertEqual(len(captured.output), 1)

--- a/tests/plugins/test_cmd_shell.py
+++ b/tests/plugins/test_cmd_shell.py
@@ -149,8 +149,7 @@ class TestCmdShell(TestCase):
     def test_start(self):
         """Test that the start method calls cmdloop."""
         shell = CMDShell(**self.arguments)
-        mock_cmdloop = Mock()
-        set_attr(shell, "cmdloop", mock_cmdloop)
+        mock_cmdloop = set_attr(shell, "cmdloop", Mock())
         shell.start()
         mock_cmdloop.assert_called_once()
 
@@ -913,9 +912,8 @@ class HotReloadTest(TestCase):
     def test_hot_reload_not_activated_doesnt_enter(self):
         """Test that the if is not set  hot_reload method does nothing."""
         os.environ.pop("SIMNOS_RELOAD_COMMANDS")
-        mock_get_files_changed = Mock()
         shell = CMDShell(**self.arguments)
-        set_attr(shell, "get_files_changed", mock_get_files_changed)
+        mock_get_files_changed = set_attr(shell, "get_files_changed", Mock())
         shell.precmd("show clock")
         mock_get_files_changed.assert_not_called()
 

--- a/tests/plugins/test_cmd_shell.py
+++ b/tests/plugins/test_cmd_shell.py
@@ -612,6 +612,9 @@ class TestCmdShell(TestCase):
             raise RuntimeError("boom-for-log")
 
         shell = self._make_callable_dict_shell(crash)
+        # crash-path guard: default() writes HANDLER_ERROR_OUTPUT via writeline,
+        # and stdout is None, so writeline must be mocked even though this test
+        # only asserts on the log (return unused → bare set_attr).
         set_attr(shell, "writeline", Mock())
         with self.assertLogs("simnos.plugins.shell.cmd_shell", level="ERROR") as captured:
             shell.default("cmd")
@@ -879,6 +882,8 @@ class TestCmdShell(TestCase):
         """Test that the default method does nothing."""
         self.arguments["is_running"].set()
         shell = CMDShell(**self.arguments)
+        # writeline guard only (stdout is None); this test asserts on prompt,
+        # not on the mock (return unused → bare set_attr).
         set_attr(shell, "writeline", Mock())
         shell.default("enable")
         shell.prompt = "test#"

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -151,3 +151,20 @@ def get_host_commands(host: Host) -> tuple[list[str], list[str], list[str]]:
             elif nos.config_prompt and prompt == nos.config_prompt:
                 config_commands.append(command)
     return initial_commands, enable_commands, config_commands
+
+
+def set_attr[T](obj: object, name: str, value: T) -> T:
+    """Assign ``value`` to ``obj.name`` (ty-clean, no cast/B010) and return it.
+
+    Tests mock attributes that are typed as methods (e.g. ``shell.writeline``),
+    which ty rejects on plain assignment and ruff B010 rejects via
+    ``setattr(obj, "literal", ...)``. Routing the assignment through this helper
+    (variable ``name`` → not B010; ``obj: object`` → ty accepts) sidesteps both.
+
+    ``value`` is generic so a single helper covers every test assignment:
+    ``Mock()``, ``Mock(side_effect=...)``, a plain function, or a dict literal.
+    Returning ``value`` (typed ``T``) lets call sites bind the result and drop
+    the access-side ``cast(Mock, ...)`` when asserting on the mock.
+    """
+    setattr(obj, name, value)
+    return value

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -154,17 +154,23 @@ def get_host_commands(host: Host) -> tuple[list[str], list[str], list[str]]:
 
 
 def set_attr[T](obj: object, name: str, value: T) -> T:
-    """Assign ``value`` to ``obj.name`` (ty-clean, no cast/B010) and return it.
+    """Test helper: assign ``value`` to ``obj.name`` (ty-clean, no cast/B010) and return it.
 
-    Tests mock attributes that are typed as methods (e.g. ``shell.writeline``),
-    which ty rejects on plain assignment and ruff B010 rejects via
-    ``setattr(obj, "literal", ...)``. Routing the assignment through this helper
-    (variable ``name`` → not B010; ``obj: object`` → ty accepts) sidesteps both.
+    For tests only — it deliberately bypasses static type checks, so do not use
+    it in production code. Tests mock attributes that are typed as methods
+    (e.g. ``shell.writeline``), which ty rejects on plain assignment and ruff
+    B010 rejects via ``setattr(obj, "literal", ...)``. Routing the assignment
+    through this helper (variable ``name`` → not B010; ``obj: object`` → ty
+    accepts) sidesteps both.
 
     ``value`` is generic so a single helper covers every test assignment:
     ``Mock()``, ``Mock(side_effect=...)``, a plain function, or a dict literal.
-    Returning ``value`` (typed ``T``) lets call sites bind the result and drop
-    the access-side ``cast(Mock, ...)`` when asserting on the mock.
+
+    Two call styles are both intended:
+    - bound: ``wl = set_attr(shell, "writeline", Mock())`` then ``wl.assert_*``
+      — the ``-> T`` return drops the access-side ``cast(Mock, ...)``.
+    - bare: ``set_attr(shell, "writeline", Mock())`` — return ignored, used when
+      the mock only guards a side effect (e.g. stdout=None) and is not asserted.
     """
     setattr(obj, name, value)
     return value


### PR DESCRIPTION
🐙claude:

Closes #261

## 概要
#251(M-9 Phase 3、tests/ ty exclude 解除)で大量発生した cast idiom を単一汎用 helper に集約する refactor。**挙動完全不変**(`typing.cast` は runtime no-op、helper も同等の代入)。

```python
# before
cast(Any, shell).writeline = Mock()
cast(Mock, shell.writeline).assert_called_once_with("foo")
# after
writeline = set_attr(shell, "writeline", Mock())
writeline.assert_called_once_with("foo")
```

## 変更内容
- **`tests/utils.py`**: 汎用 helper `set_attr[T](obj, name, value: T) -> T` 追加(PEP 695 generic)。helper 内 `setattr`(変数 name)で ruff B010 非該当、`obj: object`/`-> T` で ty-clean、返り値束縛で access 側 `cast(Mock, ...)` も全廃。docstring に test 専用・bound/bare 両用途を明記。
- **`tests/plugins/test_cmd_shell.py`(61 箇所)**: cast(Any)/cast(Mock) → set_attr。事前生成 Mock 変数(cmdloop/get_files_changed)は `m = set_attr(...)` に collapse。`Mock(side_effect=)` / dict 代入も汎用 value で吸収。`from typing import Any, cast` 行削除。
  - **factory Strategy 2**: `_make_callable_dict_shell` / `_make_prompt_form_shell` / `_make_callable_default_shell` を純 builder 化(内部 writeline mock 削除)、mock を全 factory-fed テストの test-local に統一。`default()` の crash 経路が `HANDLER_ERROR_OUTPUT` を writeline 経由で出力するため、log 専用テストにも mock 保護(stdout=None crash guard、コメント明記)を維持。
- **`tests/core/test_simnos.py`(4 箇所)**: `cast(Any, h).{stop,start}` → set_attr(slow_stop は関数のまま保持)。import から `Any` のみ除去(`cast` は `cast(dict/list[Thread])` 用途で維持)。

スコープは cmd_shell + simnos の 2 ファイルのみ(telnet/paramiko は元から patch.object 使用で対象外)。production・CI 設定の変更なし。

## 検証
- `uv run ty check .`(全ツリー gating)→ All checks passed
- `uv run invoke ruff`(B010 含む)→ clean(format も)
- full suite(`-n auto`、docker 2 件除外)→ **1049 passed・7 skipped・1 xfailed**(挙動不変)
- tests 全体の `cast(Any`/`cast(Mock` 残骸ゼロ

## レビュー経緯
- 設計(design 3 round cross-review + final-refactor): 2 つの design-hole を事前に解消 ―― ① 固定 Mock helper では非 plain-Mock 代入(関数/dict/side_effect)を取りこぼす → 単一汎用 `set_attr[T]` に ② factory が内部で mock し shell だけ返すと access cast を消せない → factory Strategy 2(純 builder + test-local mock)
- コード cross-review 1 round: 3 者(codex/gemini/claude)で MUST/SHOULD FIX ゼロ、SUGGESTION 3 件(bare mock コメント / docstring 強化)は全て inline 取り込み

## 関連 / future
#251 defer の残り(production typing 改善 / tests bare `dict` → `dict[str, Any]` / types-paramiko 再導入)は本 PR scope 外。

---
🤖 AI Transparency: 本 PR は Claude Code (claude-opus-4-8) 支援で作成。全変更は human maintainer のレビュー後に merge されます。

🤖 Generated with [Claude Code](https://claude.com/claude-code)