### PR TITLE
fix: telnet 認証失敗時に pending 入力を drain して RST でなく FIN で close する (#268)

### DIFF
--- a/simnos/plugins/servers/telnet_server.py
+++ b/simnos/plugins/servers/telnet_server.py
@@ -151,6 +151,29 @@ class TelnetServer(TCPServerBase):
                 continue
             continue  # Other IAC commands (NOP, GA) → skip
 
+    def _drain_pending_input(self, sock: socket.socket) -> None:
+        """Drain bytes the client already sent, answering IAC sequences.
+
+        Closing a socket whose receive buffer still holds unread data makes
+        TCP send RST instead of FIN (RFC 2525 2.17); on Windows an RST also
+        discards data the client has not read yet, so anything we just sent
+        (e.g. ``Authentication failed.``) silently disappears (#268). Callers
+        run this right before giving up on a connection so the close
+        degrades to a graceful FIN. A short blocking timeout is used instead
+        of non-blocking mode so that multi-byte IAC sequences split across
+        TCP segments are received completely rather than raising
+        mid-sequence.
+        """
+        sock.settimeout(_IAC_DRAIN_TIMEOUT)
+        try:
+            while True:
+                if self._recv_byte(sock) is None:
+                    break  # EOF — client disconnected
+        except TimeoutError:
+            pass  # No more data available — expected
+        finally:
+            sock.settimeout(self.timeout)
+
     def _handle_negotiation(self, sock: socket.socket, cmd: int, opt: int) -> None:
         """Respond to a Telnet negotiation command."""
         if cmd == DO:
@@ -248,19 +271,8 @@ class TelnetServer(TCPServerBase):
             # then drain them using _recv_byte so that negotiation commands
             # (e.g. DO SGA, DO ECHO, WILL NAWS) are properly answered via
             # _handle_negotiation instead of being silently discarded.
-            # A short blocking timeout is used instead of non-blocking mode
-            # so that multi-byte IAC sequences split across TCP segments
-            # are received completely rather than raising mid-sequence.
             time.sleep(0.1)
-            client.settimeout(_IAC_DRAIN_TIMEOUT)
-            try:
-                while True:
-                    if self._recv_byte(client) is None:
-                        break  # EOF — client disconnected
-            except TimeoutError:
-                pass  # No more data available — expected
-            finally:
-                client.settimeout(self.timeout)
+            self._drain_pending_input(client)
 
             # Send banner
             if self.banner:
@@ -276,6 +288,13 @@ class TelnetServer(TCPServerBase):
                 log.warning("Telnet authentication failed, closing connection")
                 with contextlib.suppress(OSError):
                     client.sendall(b"Authentication failed.\r\n")
+                # Consume the input left pending on the failure path (the
+                # LF/NUL that read_line's skip_lf defers from the password
+                # line's CR is forwarded to client_to_shell_tap only on
+                # success) — otherwise close() RSTs and the failure message
+                # never reaches Windows clients (#268).
+                with contextlib.suppress(OSError):
+                    self._drain_pending_input(client)
                 return
 
             # Create stdio for the shell

--- a/simnos/plugins/servers/telnet_server.py
+++ b/simnos/plugins/servers/telnet_server.py
@@ -45,6 +45,12 @@ NAWS = 0x1F  # Negotiate About Window Size
 # is sub-millisecond, so 50 ms gives ample margin.
 _IAC_DRAIN_TIMEOUT = 0.05
 
+# Total wall-clock budget (seconds) for one _drain_pending_input() call.
+# The per-recv idle timeout above ends a drain once the client goes quiet;
+# this deadline additionally bounds the case where a client keeps sending,
+# so an unauthenticated peer cannot pin the connection thread (#268 review).
+_DRAIN_TOTAL_BUDGET = 1.0
+
 
 def _is_loopback(address: str) -> bool:
     """Check whether *address* resolves to a loopback IP."""
@@ -155,25 +161,29 @@ class TelnetServer(TCPServerBase):
         """Drain bytes the client already sent, answering IAC sequences.
 
         Used after the initial negotiation window (answering queued IAC
-        responses) and right before abandoning a connection on the
-        authentication-failure path. The failure-path call matters because
-        closing a socket whose receive buffer still holds unread data makes
-        TCP send RST instead of FIN (RFC 2525 2.17); on Windows an RST also
-        discards data the client has not read yet, so anything we just sent
-        (e.g. ``Authentication failed.``) silently disappears (#268). A
-        short blocking timeout is used instead of non-blocking mode so that
-        multi-byte IAC sequences split across TCP segments are received
-        completely rather than raising mid-sequence.
+        responses) and right before abandoning a connection (authentication
+        failure / disconnect during authentication). The abandonment calls
+        matter because closing a socket whose receive buffer still holds
+        unread data makes TCP send RST instead of FIN (RFC 2525 2.17); on
+        Windows an RST also discards data the client has not read yet, so
+        anything we just sent (e.g. ``Authentication failed.``) silently
+        disappears (#268). A short blocking timeout is used instead of
+        non-blocking mode so that multi-byte IAC sequences split across TCP
+        segments are received completely rather than raising mid-sequence;
+        ``_DRAIN_TOTAL_BUDGET`` additionally bounds a client that never
+        goes quiet. The socket's original timeout is restored on exit.
         """
+        original_timeout = sock.gettimeout()
+        deadline = time.monotonic() + _DRAIN_TOTAL_BUDGET
         sock.settimeout(_IAC_DRAIN_TIMEOUT)
         try:
-            while True:
+            while time.monotonic() < deadline:
                 if self._recv_byte(sock) is None:
                     break  # EOF — client disconnected
         except TimeoutError:
             pass  # No more data available — expected
         finally:
-            sock.settimeout(self.timeout)
+            sock.settimeout(original_timeout)
 
     def _handle_negotiation(self, sock: socket.socket, cmd: int, opt: int) -> None:
         """Respond to a Telnet negotiation command."""
@@ -284,6 +294,11 @@ class TelnetServer(TCPServerBase):
                 auth_ok, skip_lf = self._authenticate(client)
             except (TimeoutError, OSError):
                 log.debug("Client disconnected during authentication")
+                # Same FIN-not-RST treatment as the auth-failure branch
+                # below: a server-side timeout can leave client bytes
+                # pending, and closing over them would RST (#268 review).
+                with contextlib.suppress(OSError):
+                    self._drain_pending_input(client)
                 return
             if not auth_ok:
                 log.warning("Telnet authentication failed, closing connection")

--- a/simnos/plugins/servers/telnet_server.py
+++ b/simnos/plugins/servers/telnet_server.py
@@ -51,8 +51,7 @@ _IAC_DRAIN_TIMEOUT = 0.05
 # (#268 review). Scope note: the deadline is only checked between
 # _recv_byte() calls, so a continuous pure-IAC stream is still consumed
 # inside _recv_byte() without deadline checks — bounding that (and the
-# pre-existing unauthenticated read_line path) is deliberately out of
-# scope here.
+# pre-existing unauthenticated read_line path) is tracked in #269.
 _DRAIN_TOTAL_BUDGET = 1.0
 
 

--- a/simnos/plugins/servers/telnet_server.py
+++ b/simnos/plugins/servers/telnet_server.py
@@ -47,8 +47,12 @@ _IAC_DRAIN_TIMEOUT = 0.05
 
 # Total wall-clock budget (seconds) for one _drain_pending_input() call.
 # The per-recv idle timeout above ends a drain once the client goes quiet;
-# this deadline additionally bounds the case where a client keeps sending,
-# so an unauthenticated peer cannot pin the connection thread (#268 review).
+# this deadline additionally bounds a client that keeps sending data bytes
+# (#268 review). Scope note: the deadline is only checked between
+# _recv_byte() calls, so a continuous pure-IAC stream is still consumed
+# inside _recv_byte() without deadline checks — bounding that (and the
+# pre-existing unauthenticated read_line path) is deliberately out of
+# scope here.
 _DRAIN_TOTAL_BUDGET = 1.0
 
 
@@ -170,8 +174,9 @@ class TelnetServer(TCPServerBase):
         disappears (#268). A short blocking timeout is used instead of
         non-blocking mode so that multi-byte IAC sequences split across TCP
         segments are received completely rather than raising mid-sequence;
-        ``_DRAIN_TOTAL_BUDGET`` additionally bounds a client that never
-        goes quiet. The socket's original timeout is restored on exit.
+        ``_DRAIN_TOTAL_BUDGET`` additionally bounds a client that keeps
+        sending data bytes (see the constant's scope note for what it does
+        NOT bound). The socket's original timeout is restored on exit.
         """
         original_timeout = sock.gettimeout()
         deadline = time.monotonic() + _DRAIN_TOTAL_BUDGET

--- a/simnos/plugins/servers/telnet_server.py
+++ b/simnos/plugins/servers/telnet_server.py
@@ -154,15 +154,16 @@ class TelnetServer(TCPServerBase):
     def _drain_pending_input(self, sock: socket.socket) -> None:
         """Drain bytes the client already sent, answering IAC sequences.
 
-        Closing a socket whose receive buffer still holds unread data makes
+        Used after the initial negotiation window (answering queued IAC
+        responses) and right before abandoning a connection on the
+        authentication-failure path. The failure-path call matters because
+        closing a socket whose receive buffer still holds unread data makes
         TCP send RST instead of FIN (RFC 2525 2.17); on Windows an RST also
         discards data the client has not read yet, so anything we just sent
-        (e.g. ``Authentication failed.``) silently disappears (#268). Callers
-        run this right before giving up on a connection so the close
-        degrades to a graceful FIN. A short blocking timeout is used instead
-        of non-blocking mode so that multi-byte IAC sequences split across
-        TCP segments are received completely rather than raising
-        mid-sequence.
+        (e.g. ``Authentication failed.``) silently disappears (#268). A
+        short blocking timeout is used instead of non-blocking mode so that
+        multi-byte IAC sequences split across TCP segments are received
+        completely rather than raising mid-sequence.
         """
         sock.settimeout(_IAC_DRAIN_TIMEOUT)
         try:

--- a/tests/plugins/test_telnet_server.py
+++ b/tests/plugins/test_telnet_server.py
@@ -496,10 +496,10 @@ class TelnetIntegrationTest(unittest.TestCase):
         closing with unread receive data makes TCP RST the connection —
         Windows clients then never see ``Authentication failed.``. Pins:
         (1) the failure message reaches the client, (2) the close is a
-        graceful FIN — the RST is sent on Linux too, so pre-fix the second
-        recv raised ConnectionResetError even here — and (3) the structural
-        shape: _drain_pending_input runs twice (negotiation window +
-        auth-failure path).
+        graceful FIN — the RST is sent on Linux too, so pre-fix the
+        collecting recv raised ConnectionResetError even here — and (3) the
+        structural shape: _drain_pending_input runs twice (negotiation
+        window + auth-failure path).
         """
         server, port, shell_cls = self._create_server_on_free_port()
         with mock.patch.object(server, "_drain_pending_input", wraps=server._drain_pending_input) as drain:

--- a/tests/plugins/test_telnet_server.py
+++ b/tests/plugins/test_telnet_server.py
@@ -15,6 +15,7 @@ from simnos.core.timeouts import SHUTDOWN_IO_TIMEOUT
 from simnos.plugins.servers import servers_plugins
 from simnos.plugins.servers.tap_bridge import client_to_shell_tap, read_line, shell_to_client_tap
 from simnos.plugins.servers.telnet_server import (
+    _IAC_DRAIN_TIMEOUT,
     DO,
     DONT,
     ECHO,
@@ -156,21 +157,36 @@ class DrainPendingInputTest(unittest.TestCase):
     def setUp(self):
         self.server = _make_server()
         self.sock = MagicMock(spec=socket.socket)
+        self.sock.gettimeout.return_value = 7  # Distinct sentinel for restore
 
     def test_drains_until_quiet_and_restores_timeout(self):
         """Pending bytes are consumed until the socket goes quiet; the
-        configured timeout is restored afterwards."""
+        drain timeout is applied and the original timeout restored."""
         self.sock.recv.side_effect = [b"\n", b"x", TimeoutError()]
         self.server._drain_pending_input(self.sock)
         self.assertEqual(self.sock.recv.call_count, 3)
-        # Last settimeout call must restore the configured timeout.
-        self.sock.settimeout.assert_called_with(self.server.timeout)
+        # Contract: short drain timeout applied, then original restored.
+        self.sock.settimeout.assert_has_calls([mock.call(_IAC_DRAIN_TIMEOUT), mock.call(7)])
 
     def test_drain_stops_at_eof_and_restores_timeout(self):
         """EOF (empty recv) stops the drain without raising."""
         self.sock.recv.side_effect = [b"\n", b""]
         self.server._drain_pending_input(self.sock)
-        self.sock.settimeout.assert_called_with(self.server.timeout)
+        self.sock.settimeout.assert_has_calls([mock.call(_IAC_DRAIN_TIMEOUT), mock.call(7)])
+
+    def test_drain_exits_at_total_budget_with_noisy_client(self):
+        """A client that never goes quiet cannot pin the thread: the drain
+        exits once _DRAIN_TOTAL_BUDGET elapses (#268 cross-review)."""
+        self.sock.recv.return_value = b"x"  # Endless chatter
+        with mock.patch(
+            "simnos.plugins.servers.telnet_server.time.monotonic",
+            # deadline calc at t=0 (budget 1.0), loop checks at 0.1 / 0.5
+            # (recv), then 1.5 (>= deadline -> exit)
+            side_effect=[0.0, 0.1, 0.5, 1.5],
+        ):
+            self.server._drain_pending_input(self.sock)
+        self.assertEqual(self.sock.recv.call_count, 2)
+        self.sock.settimeout.assert_called_with(7)
 
 
 class HandleNegotiationTest(unittest.TestCase):
@@ -471,14 +487,17 @@ class TelnetIntegrationTest(unittest.TestCase):
             server.stop()
 
     def test_telnet_wrong_credentials_drains_before_close(self):
-        """Auth failure must drain pending input before closing (#268 pin).
+        """Auth failure must deliver the message and close with FIN (#268 pin).
 
         read_line's skip_lf defers the password line's trailing LF to the
         next reader; on the failure path that reader never comes, and
         closing with unread receive data makes TCP RST the connection —
-        Windows clients then never see ``Authentication failed.``. Pin that
-        _drain_pending_input runs twice: once after the negotiation window
-        and once on the auth-failure path (the #268 fix).
+        Windows clients then never see ``Authentication failed.``. Pins:
+        (1) the failure message reaches the client, (2) the close is a
+        graceful FIN — the RST is sent on Linux too, so pre-fix the second
+        recv raised ConnectionResetError even here — and (3) the structural
+        shape: _drain_pending_input runs twice (negotiation window +
+        auth-failure path).
         """
         server, port, shell_cls = self._create_server_on_free_port()
         with mock.patch.object(server, "_drain_pending_input", wraps=server._drain_pending_input) as drain:
@@ -491,7 +510,21 @@ class TelnetIntegrationTest(unittest.TestCase):
                     with contextlib.suppress(TimeoutError):
                         sock.recv(4096)  # Drain Password prompt
                     sock.sendall(b"wrong\r\n")
-                    time.sleep(0.3)
+                    # (1) The failure message must arrive (collect until seen)
+                    deadline = time.monotonic() + 3.0
+                    buf = b""
+                    while time.monotonic() < deadline and b"Authentication failed" not in buf:
+                        try:
+                            chunk = sock.recv(4096)
+                        except TimeoutError:
+                            continue
+                        if not chunk:
+                            break  # FIN before message — assertIn below fails loudly
+                        buf += chunk
+                    self.assertIn(b"Authentication failed", buf)
+                    # (2) Graceful FIN, not RST (pre-fix: ConnectionResetError)
+                    self.assertEqual(sock.recv(4096), b"")
+                    # (3) Drain ran after negotiation AND on the failure path
                     self.assertEqual(drain.call_count, 2)
                     shell_cls.assert_not_called()
                 finally:

--- a/tests/plugins/test_telnet_server.py
+++ b/tests/plugins/test_telnet_server.py
@@ -175,8 +175,10 @@ class DrainPendingInputTest(unittest.TestCase):
         self.sock.settimeout.assert_has_calls([mock.call(_IAC_DRAIN_TIMEOUT), mock.call(7)])
 
     def test_drain_exits_at_total_budget_with_noisy_client(self):
-        """A client that never goes quiet cannot pin the thread: the drain
-        exits once _DRAIN_TOTAL_BUDGET elapses (#268 cross-review)."""
+        """A client that keeps sending data bytes is bounded: the drain
+        exits once _DRAIN_TOTAL_BUDGET elapses (#268 cross-review). The
+        deadline is only checked between _recv_byte calls — a pure-IAC
+        stream is out of this guarantee (see the constant's scope note)."""
         self.sock.recv.return_value = b"x"  # Endless chatter
         with mock.patch(
             "simnos.plugins.servers.telnet_server.time.monotonic",
@@ -510,20 +512,25 @@ class TelnetIntegrationTest(unittest.TestCase):
                     with contextlib.suppress(TimeoutError):
                         sock.recv(4096)  # Drain Password prompt
                     sock.sendall(b"wrong\r\n")
-                    # (1) The failure message must arrive (collect until seen)
+                    # Collect everything until EOF so the FIN check cannot
+                    # race a message split across recv boundaries. An RST
+                    # (pre-fix) raises ConnectionResetError here instead.
                     deadline = time.monotonic() + 3.0
                     buf = b""
-                    while time.monotonic() < deadline and b"Authentication failed" not in buf:
+                    eof = False
+                    while time.monotonic() < deadline:
                         try:
                             chunk = sock.recv(4096)
                         except TimeoutError:
                             continue
                         if not chunk:
-                            break  # FIN before message — assertIn below fails loudly
+                            eof = True
+                            break
                         buf += chunk
+                    # (1) The failure message reached the client
                     self.assertIn(b"Authentication failed", buf)
                     # (2) Graceful FIN, not RST (pre-fix: ConnectionResetError)
-                    self.assertEqual(sock.recv(4096), b"")
+                    self.assertTrue(eof)
                     # (3) Drain ran after negotiation AND on the failure path
                     self.assertEqual(drain.call_count, 2)
                     shell_cls.assert_not_called()

--- a/tests/plugins/test_telnet_server.py
+++ b/tests/plugins/test_telnet_server.py
@@ -145,6 +145,34 @@ class SkipSubnegotiationTest(unittest.TestCase):
         self.server._skip_subnegotiation(self.sock)
 
 
+class DrainPendingInputTest(unittest.TestCase):
+    """Test cases for TelnetServer._drain_pending_input() (#268 regression pin).
+
+    The auth-failure path must consume input left pending by read_line's
+    skip_lf deferral; closing with unread receive data RSTs the connection
+    and Windows clients never see the failure message.
+    """
+
+    def setUp(self):
+        self.server = _make_server()
+        self.sock = MagicMock(spec=socket.socket)
+
+    def test_drains_until_quiet_and_restores_timeout(self):
+        """Pending bytes are consumed until the socket goes quiet; the
+        configured timeout is restored afterwards."""
+        self.sock.recv.side_effect = [b"\n", b"x", TimeoutError()]
+        self.server._drain_pending_input(self.sock)
+        self.assertEqual(self.sock.recv.call_count, 3)
+        # Last settimeout call must restore the configured timeout.
+        self.sock.settimeout.assert_called_with(self.server.timeout)
+
+    def test_drain_stops_at_eof_and_restores_timeout(self):
+        """EOF (empty recv) stops the drain without raising."""
+        self.sock.recv.side_effect = [b"\n", b""]
+        self.server._drain_pending_input(self.sock)
+        self.sock.settimeout.assert_called_with(self.server.timeout)
+
+
 class HandleNegotiationTest(unittest.TestCase):
     """Test cases for TelnetServer._handle_negotiation()."""
 
@@ -441,6 +469,35 @@ class TelnetIntegrationTest(unittest.TestCase):
                 sock.close()
         finally:
             server.stop()
+
+    def test_telnet_wrong_credentials_drains_before_close(self):
+        """Auth failure must drain pending input before closing (#268 pin).
+
+        read_line's skip_lf defers the password line's trailing LF to the
+        next reader; on the failure path that reader never comes, and
+        closing with unread receive data makes TCP RST the connection —
+        Windows clients then never see ``Authentication failed.``. Pin that
+        _drain_pending_input runs twice: once after the negotiation window
+        and once on the auth-failure path (the #268 fix).
+        """
+        server, port, shell_cls = self._create_server_on_free_port()
+        with mock.patch.object(server, "_drain_pending_input", wraps=server._drain_pending_input) as drain:
+            server.start()
+            try:
+                sock, _initial_data = self._telnet_connect(port)
+                try:
+                    sock.sendall(b"wrong\r\n")
+                    time.sleep(0.2)
+                    with contextlib.suppress(TimeoutError):
+                        sock.recv(4096)  # Drain Password prompt
+                    sock.sendall(b"wrong\r\n")
+                    time.sleep(0.3)
+                    self.assertEqual(drain.call_count, 2)
+                    shell_cls.assert_not_called()
+                finally:
+                    sock.close()
+            finally:
+                server.stop()
 
     def test_telnet_connection_auth_starts_shell(self):
         """Successful auth should start the shell."""


### PR DESCRIPTION
Closes #268

## 概要

Windows で telnet 認証失敗時に `Authentication failed.` がクライアントに届かず `ConnectionResetError (WinError 10054)` で切断される回帰(v2.4.0 リリースブロッカー)を修正する。

## 根本原因(#225 G3 回帰)

`tap_bridge.read_line` は旧 telnet `_read_line` の「CR 後の trailing LF を blocking consume」を skip_lf 先送り方式(SSH 流、U3)に置換した。認証**成功**経路では pending LF を `client_to_shell_tap(initial_skip_lf=...)` が引き取るが、**失敗経路では誰も消費しないまま close** していた。

受信バッファに未読データを残した close は TCP 仕様上 FIN でなく **RST** を送る(RFC 2525 2.17)。Windows は RST 受信時にクライアント側の受信済みデータも破棄するため失敗メッセージが消失する(Linux は到着済みデータを先にアプリへ渡すため顕在化しなかった)。

## 変更内容

- **`_drain_pending_input(sock)` helper 新設**: 既存の negotiation 後 IAC drain と同パターン(`_recv_byte` ループ + 50ms idle timeout)を共用化し、接続を断念する 2 経路(auth 失敗 / auth 中の切断・timeout)で close 前に pending 入力を drain → graceful FIN
- **`_DRAIN_TOTAL_BUDGET` (1.0s)**: data byte を送り続けるクライアントが未認証のまま connection thread を保持できないよう wall-clock deadline を併用(cross-review 指摘。deadline は `_recv_byte` 呼出境界で評価 — 純 IAC stream 等の bound は #269 で追跡)
- 元 socket timeout の `gettimeout()` save/restore

## テスト

- 既存 `test_telnet_connection_wrong_credentials` は**意図的に無変更**(本回帰を Windows matrix で検出した behavior pin を維持)
- 新規 pin 4 件:
  - integration: **message 到達 + graceful FIN(EOF まで収集)+ drain 構造**の 3 点 pin — RST は Linux でも送出されるため、**drain を一時除去すると Linux でも fail することを実測検証済み**(以後この回帰クラスは Windows matrix 待ちなしで検出可能)
  - unit ×3: drain の quiet 停止 + timeout 適用/復元(assert_has_calls)、EOF 停止、budget 脱出(monotonic mock)

## 検証

- Linux full suite: **1053 passed** / 7 skipped / 1 xfailed、ty(全ツリー)/ ruff / yamllint clean
- branch full-matrix(fix commit `a24d72f` 時点): **Windows ×2 / macOS ×2 全 green**(Windows green が #268 fix の直接実証。macOS は無関係の get_free_port TOCTOU flake が 1 度出て re-run green)
- 最終 head での full-matrix 再実行: run 27302498572(merge 前に green 確認)

## レビュー

cross-review 2 round(codex / gemini / claude)実施、全指摘取り込み済み。follow-up: #269(未認証経路の入力 bound 全般、telnetlib3 移行(v3.0 P2)で自然解消の可能性あり)。

---
**AI Transparency**: This change was developed with AI assistance (Claude Code). All AI-generated changes are reviewed by a human maintainer before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
