### PR TITLE
feat: A3 runtime core — ResolvedCommand + mode エンジン + 旧形式アダプタ (#264 PR-1)

### DIFF
--- a/docs/development/creating_nos_plugin.ja.md
+++ b/docs/development/creating_nos_plugin.ja.md
@@ -288,7 +288,8 @@ callable コマンドは以下の値を返せます:
 - `None` - レスポンスなし
 - `dict` (`CommandResult`) - 以下のオプションキーを持つ辞書:
     - `"output"` - 表示する文字列
-    - `"new_prompt"` - 新しいプロンプト値（`{base_prompt}` フォーマッターが使用可能）
+    - `"new_mode"` - 遷移先の mode 名（例: `"enable"`）。シェルがその mode の
+      prompt を render します。prompt 文字列ではなく引数 `current_mode` で分岐します。
     - `"exit"` - `True` の場合、シェルセッションを終了（output は表示されない）
 
 yaml static な output と異なるルールが 2 つあります:
@@ -296,8 +297,6 @@ yaml static な output と異なるルールが 2 つあります:
 - **format は自分で行う。** シェルは callable output に `{base_prompt}` format を
   適用**しません** — handler は `base_prompt` を引数で受け取り自分で文字列を
   render します。device 出力に literal な brace が含まれていても escape 不要です。
-  (`new_prompt` は従来通りシェル側で format されます — prompt template はシェルの
-  関心事です。)
 - **raise してもよい。**「起きてはならない」状態 (想定外の prompt 等) では例外を
   投げて構いません: シェルは full traceback を server log に記録し、client には
   固定の `% Internal error` 1 行を返します — traceback が wire に出ることは

--- a/docs/development/creating_nos_plugin.md
+++ b/docs/development/creating_nos_plugin.md
@@ -302,7 +302,9 @@ A callable command can return:
 - `None` - no response
 - `dict` (`CommandResult`) - a dictionary with optional keys:
     - `"output"` - string to display
-    - `"new_prompt"` - new prompt value (can use `{base_prompt}` formatter)
+    - `"new_mode"` - name of the mode to transition to (e.g. `"enable"`); the
+      shell renders that mode's prompt. Branch on the `current_mode` argument,
+      not on the prompt string.
     - `"exit"` - if `True`, close the shell session (output is not displayed)
 
 Two rules that differ from yaml-static output:
@@ -310,8 +312,6 @@ Two rules that differ from yaml-static output:
 - **Format yourself.** The shell does *not* apply `{base_prompt}` formatting
   to callable output — handlers receive `base_prompt` as an argument and
   render their own strings. Literal braces in device output need no escaping.
-  (`new_prompt` *is* still formatted by the shell; prompt templates are the
-  shell's concern.)
 - **Raising is allowed** for "should never happen" states: the shell logs the
   full traceback server-side and answers the client with the fixed
   `% Internal error` line — no traceback ever reaches the wire.

--- a/simnos/core/command_adapter.py
+++ b/simnos/core/command_adapter.py
@@ -174,6 +174,11 @@ def adapt_commands(commands: dict, reverse_map: dict[str, str]) -> dict[str, Res
             merged = _resolve_alias(name, entry, commands)
             if merged is None:
                 continue
+            # The merge carries the target's dispatch fields (output / modes /
+            # transition), but `help` stays the alias entry's own: v2 `do_help`
+            # lists the raw (unmerged) entry, so an alias shows its own help —
+            # usually absent, i.e. blank — not the target's (#264 / D6).
+            merged["help"] = entry.get("help", "")
             entry = merged
         resolved[name] = _adapt_command(name, entry, reverse_map)
     return resolved

--- a/simnos/core/command_adapter.py
+++ b/simnos/core/command_adapter.py
@@ -97,7 +97,17 @@ def _lookup_mode(prompt_template: str, reverse_map: dict[str, str], *, where: st
     `reverse_map` keys were built by rendering the mode templates with jinja2;
     the two are equivalent for these templates (verified by the converter,
     `format_template_to_jinja`), so the lookup matches.
+
+    A malformed / unknown-field prompt (e.g. inventory data with
+    ``{hostname}``) is validated through that same converter, so it fails with
+    a context-tagged ``ValueError`` instead of a bare ``KeyError`` escaping
+    from ``str.format`` — symmetric with the output loud boundary (1st round
+    claude #2 / gemini #4).
     """
+    try:
+        format_template_to_jinja(prompt_template)
+    except ValueError as e:
+        raise ValueError(f"cannot map {where} prompt {prompt_template!r} to a mode: {e}") from e
     rendered = prompt_template.format(base_prompt=_REVERSE_SENTINEL)
     mode = reverse_map.get(rendered)
     if mode is None:
@@ -189,15 +199,22 @@ def _adapt_command(name: str, entry: dict, reverse_map: dict[str, str]) -> Resol
         new_mode = _lookup_mode(new_prompt, reverse_map, where=f"command {name!r} new_prompt")
 
     # v2 keeps the served capture in `output` and any alternates in the
-    # data-only `output_variants` (the runtime never serves them), so here
-    # `output` is the primary and `variants` carries the alternates — they are
-    # NOT `output == variants[0]`. The A3 form reconciles the two (D4); the
-    # legacy adapter stays faithful to v2's split.
+    # data-only `output_variants`. Project that onto the canonical contract
+    # (ResolvedCommand docstring): single-output commands carry no variants;
+    # multi-capture commands list every capture with `output` mirrored at
+    # `variants[0]` (variant_1) and the alternates as variant_2.. (D3, D7).
     output = _adapt_output(entry.get("output"), where=f"command {name!r}")
-    variants = tuple(
-        (f"variant_{i + 1}", _adapt_output(v, where=f"command {name!r} variant {i + 1}"))
-        for i, v in enumerate(entry.get("output_variants") or [])
-    )
+    alternates = entry.get("output_variants") or []
+    if alternates:
+        variants: tuple[tuple[str, ResolvedOutput], ...] = (
+            ("variant_1", output),
+            *(
+                (f"variant_{i + 2}", _adapt_output(v, where=f"command {name!r} variant {i + 2}"))
+                for i, v in enumerate(alternates)
+            ),
+        )
+    else:
+        variants = ()
 
     return ResolvedCommand(
         name=name,

--- a/simnos/core/command_adapter.py
+++ b/simnos/core/command_adapter.py
@@ -107,12 +107,12 @@ def _lookup_mode(prompt_template: str, reverse_map: dict[str, str], *, where: st
     try:
         format_template_to_jinja(prompt_template)
     except ValueError as e:
-        raise ValueError(f"cannot map {where} prompt {prompt_template!r} to a mode: {e}") from e
+        raise ValueError(f"cannot map {where} {prompt_template!r} to a mode: {e}") from e
     rendered = prompt_template.format(base_prompt=_REVERSE_SENTINEL)
     mode = reverse_map.get(rendered)
     if mode is None:
         raise ValueError(
-            f"cannot map {where} prompt {prompt_template!r} to a mode (known modes render to {sorted(reverse_map)!r})"
+            f"cannot map {where} {prompt_template!r} to a mode (known modes render to {sorted(reverse_map)!r})"
         )
     return mode
 
@@ -189,7 +189,7 @@ def _adapt_command(name: str, entry: dict, reverse_map: dict[str, str]) -> Resol
         modes: frozenset[str] = frozenset()
     else:
         modes = frozenset(
-            _lookup_mode(p, reverse_map, where=f"command {name!r}") for p in _prompt_list(entry.get("prompt"))
+            _lookup_mode(p, reverse_map, where=f"command {name!r} prompt") for p in _prompt_list(entry.get("prompt"))
         )
 
     new_prompt = entry.get("new_prompt")

--- a/simnos/core/command_adapter.py
+++ b/simnos/core/command_adapter.py
@@ -4,7 +4,9 @@ This is the bridge that lets PR-1 ship the new runtime representation
 (:mod:`simnos.core.resolved_command`) and mode engine while the data is still
 in the v2 ``platforms_yaml`` / py-plugin / inventory form. Every legacy inflow
 is normalized here into `ResolvedPlatform` / `ResolvedCommand`, so the shell,
-docs gen and tests see one semantics regardless of authoring form.
+tests and new consumers see one semantics regardless of authoring form. (The
+docs generator still reads the legacy yaml via ``tasks.render_template`` until
+it moves to this representation in PR-3 — D9.)
 
 The normalization faithfully replicates v2 render semantics — that fidelity
 is exactly what the migration oracle (b') verifies (v2 frozen-replica
@@ -193,8 +195,19 @@ def _adapt_command(name: str, entry: dict, reverse_map: dict[str, str]) -> Resol
     if is_default:
         modes: frozenset[str] = frozenset()
     else:
+        raw_prompt = entry.get("prompt")
+        # An explicit empty list is rejected loudly: v2 `_check_prompt([])` was
+        # always False (command unreachable), but an empty mode set here means
+        # "all modes" — the opposite. "All modes" is expressed by omitting
+        # prompt, so `[]` is an authoring error, symmetric with Decision 7's
+        # `mode: []` reject (2nd round claude #3).
+        if isinstance(raw_prompt, list) and not raw_prompt:
+            raise ValueError(
+                f"command {name!r}: explicit empty prompt list [] is rejected — "
+                "omit prompt to mean all modes (#264 / Decision 7)"
+            )
         modes = frozenset(
-            _lookup_mode(p, reverse_map, where=f"command {name!r} prompt") for p in _prompt_list(entry.get("prompt"))
+            _lookup_mode(p, reverse_map, where=f"command {name!r} prompt") for p in _prompt_list(raw_prompt)
         )
 
     new_prompt = entry.get("new_prompt")

--- a/simnos/core/command_adapter.py
+++ b/simnos/core/command_adapter.py
@@ -34,13 +34,8 @@ from simnos.core.resolved_command import (
 
 log = logging.getLogger(__name__)
 
-# Canonical mode names v2's three prompt templates map to (#264 / M2).
+# Initial mode every synthesized platform starts in (#264 / M2).
 INITIAL_MODE = "user"
-_PROMPT_ATTR_TO_MODE: tuple[tuple[str, str], ...] = (
-    ("initial_prompt", "user"),
-    ("enable_prompt", "enable"),
-    ("config_prompt", "config"),
-)
 
 # Base prompt used only to build the prompt -> mode reverse map. Any value
 # works as long as distinct mode templates render distinctly; an unusual
@@ -61,15 +56,15 @@ def synthesize_modes(
     an ambiguity the reverse lookup cannot resolve -> raises (measured 0
     occurrences in shipped data, guarded for future/external data).
     """
-    sources = {
-        "user": initial_prompt,
-        "enable": enable_prompt,
-        "config": config_prompt,
-    }
+    # v2's three prompt templates map to the canonical modes, in shell order.
+    sources: tuple[tuple[str, str | None], ...] = (
+        ("user", initial_prompt),
+        ("enable", enable_prompt),
+        ("config", config_prompt),
+    )
     modes: dict[str, ModeDef] = {}
     reverse_map: dict[str, str] = {}
-    for _attr, mode_name in _PROMPT_ATTR_TO_MODE:
-        source = sources[mode_name]
+    for mode_name, source in sources:
         if source is None:
             continue
         jinja_source, _ = format_template_to_jinja(source)
@@ -96,7 +91,13 @@ def _prompt_list(prompt) -> list[str]:
 
 
 def _lookup_mode(prompt_template: str, reverse_map: dict[str, str], *, where: str) -> str:
-    """Reverse-map one v2 prompt template string to a mode name (loud on miss)."""
+    """Reverse-map one v2 prompt template string to a mode name (loud on miss).
+
+    Command prompts render via `str.format` (the v2 mechanism) while the
+    `reverse_map` keys were built by rendering the mode templates with jinja2;
+    the two are equivalent for these templates (verified by the converter,
+    `format_template_to_jinja`), so the lookup matches.
+    """
     rendered = prompt_template.format(base_prompt=_REVERSE_SENTINEL)
     mode = reverse_map.get(rendered)
     if mode is None:
@@ -124,20 +125,12 @@ def _adapt_output(value, *, where: str) -> ResolvedOutput:
         raise ValueError(f"{where}: unsupported output type {type(value).__name__}")
     jinja_source, has_field = format_template_to_jinja(value)
     if not has_field:
-        # No render needed: the formatter already unescaped the braces.
-        literal, _ = _unescape_literal(value)
-        return ResolvedOutput(kind="literal", text=literal)
+        # No render needed; `str.format` on a field-free template collapses
+        # ``{{`` -> ``{`` and ``}}`` -> ``}`` — exactly the unescape the literal
+        # wire text needs.
+        return ResolvedOutput(kind="literal", text=value.format())
     template, required = compile_template(jinja_source)
     return ResolvedOutput(kind="template", template=template, required_vars=required)
-
-
-def _unescape_literal(value: str) -> tuple[str, frozenset[str]]:
-    """Return the verbatim wire text of a field-free v2 output string.
-
-    `str.format` on a field-free template only collapses ``{{`` -> ``{`` and
-    ``}}`` -> ``}``, which is exactly the unescape the literal needs.
-    """
-    return value.format(), frozenset()
 
 
 def _resolve_alias(name: str, entry: dict, commands: dict) -> dict | None:
@@ -195,6 +188,11 @@ def _adapt_command(name: str, entry: dict, reverse_map: dict[str, str]) -> Resol
     else:
         new_mode = _lookup_mode(new_prompt, reverse_map, where=f"command {name!r} new_prompt")
 
+    # v2 keeps the served capture in `output` and any alternates in the
+    # data-only `output_variants` (the runtime never serves them), so here
+    # `output` is the primary and `variants` carries the alternates — they are
+    # NOT `output == variants[0]`. The A3 form reconciles the two (D4); the
+    # legacy adapter stays faithful to v2's split.
     output = _adapt_output(entry.get("output"), where=f"command {name!r}")
     variants = tuple(
         (f"variant_{i + 1}", _adapt_output(v, where=f"command {name!r} variant {i + 1}"))

--- a/simnos/core/command_adapter.py
+++ b/simnos/core/command_adapter.py
@@ -1,0 +1,226 @@
+"""Legacy-form -> `ResolvedCommand` normalization core (#264 / P1-1 D6).
+
+This is the bridge that lets PR-1 ship the new runtime representation
+(:mod:`simnos.core.resolved_command`) and mode engine while the data is still
+in the v2 ``platforms_yaml`` / py-plugin / inventory form. Every legacy inflow
+is normalized here into `ResolvedPlatform` / `ResolvedCommand`, so the shell,
+docs gen and tests see one semantics regardless of authoring form.
+
+The normalization faithfully replicates v2 render semantics — that fidelity
+is exactly what the migration oracle (b') verifies (v2 frozen-replica
+projection vs adapter projection, #264 / Decision 3). The file-loader half of
+this adapter is removed in PR-3; the normalization core stays until the
+inventory commands path is reworked in #266 (Decision 9).
+
+Mode synthesis (#264 / M2): v2 declares three prompt templates
+(``initial_prompt`` / ``enable_prompt`` / ``config_prompt``); the adapter maps
+them to the canonical modes ``user`` / ``enable`` / ``config`` and reverse-maps
+each command's ``prompt`` string back to the mode name(s) it is valid in. The
+reverse lookup is exact because every shipped prompt renders to one of the
+three canonical strings (measured 100%, #264 Background).
+"""
+
+import logging
+
+from simnos.core.resolved_command import (
+    NO_OUTPUT,
+    ModeDef,
+    ResolvedCommand,
+    ResolvedOutput,
+    ResolvedPlatform,
+    compile_template,
+    format_template_to_jinja,
+)
+
+log = logging.getLogger(__name__)
+
+# Canonical mode names v2's three prompt templates map to (#264 / M2).
+INITIAL_MODE = "user"
+_PROMPT_ATTR_TO_MODE: tuple[tuple[str, str], ...] = (
+    ("initial_prompt", "user"),
+    ("enable_prompt", "enable"),
+    ("config_prompt", "config"),
+)
+
+# Base prompt used only to build the prompt -> mode reverse map. Any value
+# works as long as distinct mode templates render distinctly; an unusual
+# sentinel avoids accidental collision with literal prompt text.
+_REVERSE_SENTINEL = "\x00simnos-base-prompt\x00"
+
+
+def synthesize_modes(
+    initial_prompt: str,
+    enable_prompt: str | None,
+    config_prompt: str | None,
+) -> tuple[dict[str, ModeDef], str, dict[str, str]]:
+    """Build the mode map + initial mode + prompt->mode reverse lookup.
+
+    Returns ``(modes, initial_mode, reverse_map)`` where `reverse_map` keys
+    are rendered prompt strings (at the internal sentinel base prompt) and
+    values are mode names. Two modes rendering to the same prompt string is
+    an ambiguity the reverse lookup cannot resolve -> raises (measured 0
+    occurrences in shipped data, guarded for future/external data).
+    """
+    sources = {
+        "user": initial_prompt,
+        "enable": enable_prompt,
+        "config": config_prompt,
+    }
+    modes: dict[str, ModeDef] = {}
+    reverse_map: dict[str, str] = {}
+    for _attr, mode_name in _PROMPT_ATTR_TO_MODE:
+        source = sources[mode_name]
+        if source is None:
+            continue
+        jinja_source, _ = format_template_to_jinja(source)
+        template, _ = compile_template(jinja_source)
+        mode = ModeDef(name=mode_name, prompt_template=template)
+        modes[mode_name] = mode
+        rendered = mode.render_prompt(_REVERSE_SENTINEL)
+        if rendered in reverse_map:
+            raise ValueError(
+                f"ambiguous prompt->mode mapping: modes {reverse_map[rendered]!r} and "
+                f"{mode_name!r} both render to {rendered!r}; cannot reverse-map command prompts"
+            )
+        reverse_map[rendered] = mode_name
+    return modes, INITIAL_MODE, reverse_map
+
+
+def _prompt_list(prompt) -> list[str]:
+    """Normalize a legacy ``prompt`` value (str | list | None) to a list."""
+    if prompt is None:
+        return []
+    if isinstance(prompt, str):
+        return [prompt]
+    return list(prompt)
+
+
+def _lookup_mode(prompt_template: str, reverse_map: dict[str, str], *, where: str) -> str:
+    """Reverse-map one v2 prompt template string to a mode name (loud on miss)."""
+    rendered = prompt_template.format(base_prompt=_REVERSE_SENTINEL)
+    mode = reverse_map.get(rendered)
+    if mode is None:
+        raise ValueError(
+            f"cannot map {where} prompt {prompt_template!r} to a mode (known modes render to {sorted(reverse_map)!r})"
+        )
+    return mode
+
+
+def _adapt_output(value, *, where: str) -> ResolvedOutput:
+    """Normalize a legacy ``output`` value to a `ResolvedOutput`.
+
+    - None -> none kind
+    - callable -> handler kind
+    - str -> literal (no `{base_prompt}`) or template (with `{base_prompt}`),
+      with v2 ``{{``/``}}`` brace escapes unescaped (#264 / D6 item 2).
+    """
+    if value is None:
+        return NO_OUTPUT
+    if callable(value):
+        return ResolvedOutput(kind="handler", handler=value)
+    if not isinstance(value, str):
+        # v2 never produced non-str/non-callable static output; loud so a
+        # malformed inflow surfaces at load instead of via str(value) on wire.
+        raise ValueError(f"{where}: unsupported output type {type(value).__name__}")
+    jinja_source, has_field = format_template_to_jinja(value)
+    if not has_field:
+        # No render needed: the formatter already unescaped the braces.
+        literal, _ = _unescape_literal(value)
+        return ResolvedOutput(kind="literal", text=literal)
+    template, required = compile_template(jinja_source)
+    return ResolvedOutput(kind="template", template=template, required_vars=required)
+
+
+def _unescape_literal(value: str) -> tuple[str, frozenset[str]]:
+    """Return the verbatim wire text of a field-free v2 output string.
+
+    `str.format` on a field-free template only collapses ``{{`` -> ``{`` and
+    ``}}`` -> ``}``, which is exactly the unescape the literal needs.
+    """
+    return value.format(), frozenset()
+
+
+def _resolve_alias(name: str, entry: dict, commands: dict) -> dict | None:
+    """Replicate v2's single-level alias field-merge (#264 / D6).
+
+    v2 `_resolve_command` merged ``{**commands[target], **entry}`` (the alias
+    entry's own keys win) one level deep. A missing target degrades to None —
+    the same lenient unknown-command path as v2 (the dispatch then answers
+    with ``_default_``); shipped data has no missing targets.
+    """
+    target_name = entry["alias"]
+    target = commands.get(target_name)
+    if target is None:
+        log.warning("command %r aliases missing target %r; dropping (treated as unknown)", name, target_name)
+        return None
+    return {**target, **entry}
+
+
+def adapt_commands(commands: dict, reverse_map: dict[str, str]) -> dict[str, ResolvedCommand]:
+    """Normalize a merged legacy command dict to `ResolvedCommand` objects.
+
+    `commands` is the already-merged view (BASIC + nos + inventory), so alias
+    targets resolve within it. The prompt->mode reverse lookup uses
+    `reverse_map` from `synthesize_modes`.
+    """
+    resolved: dict[str, ResolvedCommand] = {}
+    for name, entry in commands.items():
+        if not isinstance(entry, dict):
+            raise ValueError(f"command {name!r}: expected a mapping, got {type(entry).__name__}")
+        if "alias" in entry:
+            merged = _resolve_alias(name, entry, commands)
+            if merged is None:
+                continue
+            entry = merged
+        resolved[name] = _adapt_command(name, entry, reverse_map)
+    return resolved
+
+
+def _adapt_command(name: str, entry: dict, reverse_map: dict[str, str]) -> ResolvedCommand:
+    """Normalize a single (alias-merged) legacy command entry."""
+    # `_default_` is the unconditional fallback: v2 never matches its prompt
+    # (#264 / D5), so its mode set is empty (= valid in every mode) and any
+    # authored prompt is dropped.
+    is_default = name == "_default_"
+    if is_default:
+        modes: frozenset[str] = frozenset()
+    else:
+        modes = frozenset(
+            _lookup_mode(p, reverse_map, where=f"command {name!r}") for p in _prompt_list(entry.get("prompt"))
+        )
+
+    new_prompt = entry.get("new_prompt")
+    if new_prompt is None or is_default:
+        new_mode = None
+    else:
+        new_mode = _lookup_mode(new_prompt, reverse_map, where=f"command {name!r} new_prompt")
+
+    output = _adapt_output(entry.get("output"), where=f"command {name!r}")
+    variants = tuple(
+        (f"variant_{i + 1}", _adapt_output(v, where=f"command {name!r} variant {i + 1}"))
+        for i, v in enumerate(entry.get("output_variants") or [])
+    )
+
+    return ResolvedCommand(
+        name=name,
+        modes=modes,
+        new_mode=new_mode,
+        output=output,
+        variants=variants,
+        help=entry.get("help", ""),
+        exit=bool(entry.get("exit")),
+        type="simnos",
+        source=None,
+    )
+
+
+def adapt_legacy_commands(
+    initial_prompt: str,
+    enable_prompt: str | None,
+    config_prompt: str | None,
+    commands: dict,
+) -> ResolvedPlatform:
+    """Top-level: synthesize modes + normalize a merged legacy command dict."""
+    modes, initial_mode, reverse_map = synthesize_modes(initial_prompt, enable_prompt, config_prompt)
+    resolved_commands = adapt_commands(commands, reverse_map)
+    return ResolvedPlatform(modes=modes, initial_mode=initial_mode, commands=resolved_commands)

--- a/simnos/core/command_contract.py
+++ b/simnos/core/command_contract.py
@@ -18,12 +18,12 @@ class CommandResult(TypedDict, total=False):
     """Dict form a command handler may return.
 
     A plain ``str`` return is sugar for ``{"output": <str>}`` —
-    `CMDShell._invoke_callable` normalizes it, so handlers only build a
-    dict when they need ``new_prompt`` / ``exit``.
+    `CMDShell._invoke_handler` normalizes it, so handlers only build a
+    dict when they need ``new_mode`` / ``exit``.
     """
 
     output: str | None  # body to send to the client (None = write nothing)
-    new_prompt: str  # prompt transition template ({base_prompt} allowed)
+    new_mode: str  # name of the mode to transition to (omit = no transition)
     exit: bool  # True = terminate the session
 
 
@@ -35,13 +35,13 @@ class CommandHandler(Protocol):
     then binds as ``self``. ``device`` is None for platforms without a
     device class.
 
-    The returned ``output`` must be fully rendered: cmd_shell does NOT
-    apply ``{base_prompt}`` formatting to callable output (handlers
-    receive ``base_prompt`` as an argument and format themselves) — only
-    yaml-static output strings are formatted. Literal braces in device
-    output therefore need no escaping. A returned ``new_prompt`` is the
-    one exception: prompt templates are the shell's concern, so the
-    shell formats it like any yaml ``new_prompt``.
+    The returned ``output`` is sent verbatim: cmd_shell never reformats
+    handler output (handlers receive ``base_prompt`` and render themselves),
+    so literal braces in device output need no escaping. To change mode,
+    return ``new_mode`` (a mode name, e.g. ``"enable"``); the shell renders
+    the corresponding prompt. Branch on ``current_mode`` (the mode name), not
+    on ``current_prompt`` — the latter is the rendered prompt string, kept for
+    display/embedding only.
 
     Raising is allowed for "should never happen" states (see
     ``AristaEOS.make_exit``): cmd_shell logs the full traceback and
@@ -55,6 +55,7 @@ class CommandHandler(Protocol):
         device: "BaseDevice | None",
         *,
         base_prompt: str,
+        current_mode: str,
         current_prompt: str,
         command: str,
     ) -> "str | CommandResult | None": ...

--- a/simnos/core/resolved_command.py
+++ b/simnos/core/resolved_command.py
@@ -1,0 +1,195 @@
+"""Runtime command representation (#264 / P1-1 D4).
+
+The shell, docs gen and tests consume one normalized representation —
+`ResolvedCommand` / `ResolvedOutput` — regardless of the authoring inflow
+(legacy ``platforms_yaml`` dicts, py-plugin dicts, inventory commands, or
+the future A3 ``commands/*.yaml``). The legacy adapter
+(:mod:`simnos.core.command_adapter`) normalizes the old forms into these
+dataclasses; the new A3 loader (PR-2) produces them directly.
+
+The representation is a frozen dataclass, not a pydantic model: every load
+path validates at its boundary, so runtime re-validation is unnecessary and
+a dataclass can hold a compiled ``jinja2.Template`` / a handler callable
+directly (#264 / D4).
+
+This module also owns the ``str.format`` -> jinja2 conversion the legacy
+adapter relies on: v2 rendered yaml/py output and prompt templates with
+``str.format(base_prompt=...)``, while the new runtime renders templates with
+jinja2 (``StrictUndefined``). The converter (`format_template_to_jinja`)
+makes the two equivalent for the brace-escape and ``{base_prompt}`` cases the
+legacy data actually uses (#264 / D6, D8).
+"""
+
+from dataclasses import dataclass
+import string
+from typing import TYPE_CHECKING, Literal
+
+from jinja2 import Environment, StrictUndefined, Template
+from jinja2 import meta as jinja_meta
+
+if TYPE_CHECKING:
+    from simnos.core.command_contract import CommandHandler
+
+# The single known render variable. Extracted template variables minus this
+# set become `ResolvedOutput.required_vars` — the host-facts to check at
+# start time (#265). `base_prompt` is always supplied by the shell, so it is
+# never a "missing var" (#264 / D4, 2nd round gemini #4).
+KNOWN_RENDER_VARS: frozenset[str] = frozenset({"base_prompt"})
+
+# Jinja2 environment for output/prompt templates. `keep_trailing_newline`
+# keeps the final newline jinja2 would otherwise strip (wire output is
+# compared byte-for-byte by the migration oracle); `StrictUndefined` makes an
+# undefined fact loud at render time instead of rendering an empty string
+# (#264 / D5, Decision 7). No trim/lstrip: output whitespace is significant.
+_TEMPLATE_ENV = Environment(
+    undefined=StrictUndefined,
+    autoescape=False,  # noqa: S701 — output is CLI text, not HTML
+    keep_trailing_newline=True,
+)
+
+_FORMATTER = string.Formatter()
+
+
+def _jinja_raw(literal: str) -> str:
+    """Wrap a literal segment so jinja2 emits it verbatim.
+
+    A literal segment may contain ``{``/``}`` (router output, JSON, brace
+    art) that jinja2 would otherwise read as ``{{`` / ``{%`` delimiters.
+    ``{% raw %}`` disables jinja2 parsing inside; the only sequence that
+    could break out is a literal ``{% endraw %}``, which never appears in
+    NOS CLI output — guarded loudly just in case (#264 / D6, D8).
+    """
+    if "endraw" in literal:
+        raise ValueError(f"output literal contains a jinja2 raw-block delimiter, cannot convert: {literal!r}")
+    return "{% raw %}" + literal + "{% endraw %}"
+
+
+def format_template_to_jinja(template: str) -> tuple[str, bool]:
+    """Convert a ``str.format`` template to equivalent jinja2 source.
+
+    Returns ``(jinja_source, has_base_prompt)``. The conversion is exact for
+    the constructs legacy SIMNOS data uses: ``{{`` / ``}}`` brace escapes and
+    the lone ``{base_prompt}`` field. Any other field (``{0}`` / ``{}`` /
+    ``{other}``), a format spec (``{base_prompt:>10}``), a conversion
+    (``{base_prompt!r}``) or an unbalanced brace raises ``ValueError`` — the
+    loud-fail boundary that replaces v2's silent ``str.format`` fallback for
+    such templates (#264 / D6 item 3, #162). Packaged data is verified clean
+    (0 format failures) by the migration oracle.
+
+    `string.Formatter.parse` already unescapes ``{{`` -> ``{`` in the literal
+    segments it yields, so a template with no field round-trips to its
+    unescaped literal text.
+    """
+    parts: list[str] = []
+    has_field = False
+    try:
+        segments = list(_FORMATTER.parse(template))
+    except ValueError as e:
+        # Unbalanced brace (e.g. "value is {broken"): str.format would raise
+        # the same way. Loud per D6 item 3.
+        raise ValueError(f"malformed format template {template!r}: {e}") from e
+    for literal_text, field_name, format_spec, conversion in segments:
+        if literal_text:
+            parts.append(_jinja_raw(literal_text))
+        if field_name is None:
+            continue
+        if field_name != "base_prompt" or format_spec or conversion:
+            raise ValueError(
+                f"unsupported format field in template {template!r}: "
+                f"field={field_name!r} spec={format_spec!r} conversion={conversion!r} "
+                "(only a bare {base_prompt} is supported)"
+            )
+        has_field = True
+        parts.append("{{ base_prompt }}")
+    return "".join(parts), has_field
+
+
+def compile_template(jinja_source: str) -> tuple[Template, frozenset[str]]:
+    """Compile jinja2 source and extract its non-`base_prompt` variables.
+
+    The extracted variables (minus `KNOWN_RENDER_VARS`) are the host-facts a
+    later render needs; PR-1 only carries them on `ResolvedOutput` for #265
+    to consume — it does not check them against a host context yet
+    (#264 / Decision 7).
+    """
+    required = jinja_meta.find_undeclared_variables(_TEMPLATE_ENV.parse(jinja_source))
+    return _TEMPLATE_ENV.from_string(jinja_source), frozenset(required) - KNOWN_RENDER_VARS
+
+
+@dataclass(frozen=True)
+class ResolvedOutput:
+    """Normalized output of a single command (#264 / D4).
+
+    Exactly one ``kind`` is meaningful per instance:
+
+    - ``none``: the command writes nothing (`text`/`template`/`handler` all None).
+    - ``literal``: `text` is the verbatim wire body (no render step).
+    - ``template``: `template` is a compiled jinja2 template rendered with
+      ``base_prompt`` (+ host facts in #265).
+    - ``handler``: `handler` is a callable producing the body at dispatch time.
+    """
+
+    kind: Literal["none", "literal", "template", "handler"]
+    text: str | None = None
+    template: Template | None = None
+    handler: "CommandHandler | None" = None
+    required_vars: frozenset[str] = frozenset()
+
+    def render(self, base_prompt: str) -> str | None:
+        """Render literal/template output; None for none/handler kinds.
+
+        Handler output is produced by the shell (it owns the device handle
+        and the dispatch-time error boundary), so `render` returns None for
+        it — the caller dispatches handlers separately.
+        """
+        if self.kind == "literal":
+            return self.text
+        if self.kind == "template" and self.template is not None:
+            return self.template.render(base_prompt=base_prompt)
+        return None
+
+
+# Sentinel kinds reused as module-level singletons (immutable, shareable).
+NO_OUTPUT = ResolvedOutput(kind="none")
+
+
+@dataclass(frozen=True)
+class ResolvedCommand:
+    """Normalized command, independent of the authoring form (#264 / D4).
+
+    `modes` is the set of mode names the command is valid in; an empty set
+    means "valid in every mode" (the successor of legacy ``prompt`` omission,
+    used by ``_default_`` and unconditional commands). `new_mode` is the mode
+    to transition to after running, or None for no transition.
+    """
+
+    name: str
+    modes: frozenset[str]
+    new_mode: str | None
+    output: ResolvedOutput
+    variants: tuple[tuple[str, ResolvedOutput], ...]
+    help: str
+    exit: bool
+    type: str
+    source: dict | None = None
+
+
+@dataclass(frozen=True)
+class ModeDef:
+    """A shell mode: a name plus its prompt template (#264 / D2, M2)."""
+
+    name: str
+    prompt_template: Template
+
+    def render_prompt(self, base_prompt: str) -> str:
+        """Render this mode's prompt for the given device base prompt."""
+        return self.prompt_template.render(base_prompt=base_prompt)
+
+
+@dataclass(frozen=True)
+class ResolvedPlatform:
+    """A platform's modes + resolved commands, ready for the shell (#264 / D4)."""
+
+    modes: dict[str, ModeDef]
+    initial_mode: str
+    commands: dict[str, ResolvedCommand]

--- a/simnos/core/resolved_command.py
+++ b/simnos/core/resolved_command.py
@@ -60,13 +60,15 @@ _ENDRAW_DELIMITER = re.compile(r"\{%[-+]?\s*endraw\b")
 
 
 def _jinja_raw(literal: str) -> str:
-    """Wrap a literal segment so jinja2 emits it verbatim.
+    """Wrap a literal run so jinja2 emits it verbatim.
 
-    A literal segment may contain ``{``/``}`` (router output, JSON, brace
-    art) that jinja2 would otherwise read as ``{{`` / ``{%`` delimiters.
+    A literal run may contain ``{``/``}`` (router output, JSON, brace art)
+    that jinja2 would otherwise read as ``{{`` / ``{%`` delimiters.
     ``{% raw %}`` disables jinja2 parsing inside; the only sequence that
     could break out is a literal ``{% endraw %}``, which never appears in
-    NOS CLI output — guarded loudly just in case (#264 / D6, D8).
+    NOS CLI output — guarded loudly just in case (#264 / D6, D8). The caller
+    passes the full concatenated run so this guard sees a ``{% endraw %}``
+    even when ``{{`` split it across formatter segments.
     """
     if _ENDRAW_DELIMITER.search(literal):
         raise ValueError(f"output literal contains a jinja2 raw-block delimiter, cannot convert: {literal!r}")

--- a/simnos/core/resolved_command.py
+++ b/simnos/core/resolved_command.py
@@ -21,6 +21,7 @@ legacy data actually uses (#264 / D6, D8).
 """
 
 from dataclasses import dataclass
+import re
 import string
 from typing import TYPE_CHECKING, Literal
 
@@ -36,11 +37,13 @@ if TYPE_CHECKING:
 # never a "missing var" (#264 / D4, 2nd round gemini #4).
 KNOWN_RENDER_VARS: frozenset[str] = frozenset({"base_prompt"})
 
-# Jinja2 environment for output/prompt templates. `keep_trailing_newline`
-# keeps the final newline jinja2 would otherwise strip (wire output is
-# compared byte-for-byte by the migration oracle); `StrictUndefined` makes an
+# Jinja2 environment for output/prompt templates. `StrictUndefined` makes an
 # undefined fact loud at render time instead of rendering an empty string
 # (#264 / D5, Decision 7). No trim/lstrip: output whitespace is significant.
+# `keep_trailing_newline` keeps the final newline jinja2 would otherwise strip
+# — inert for legacy-adapter inflow (its converted source always ends in
+# ``{% endraw %}`` / ``{{ base_prompt }}``, never a bare newline), but needed
+# for the hand-written ``.j2`` templates A3 authoring introduces in PR-2.
 _TEMPLATE_ENV = Environment(
     undefined=StrictUndefined,
     autoescape=False,  # noqa: S701 — output is CLI text, not HTML
@@ -48,6 +51,12 @@ _TEMPLATE_ENV = Environment(
 )
 
 _FORMATTER = string.Formatter()
+
+# A `{% endraw %}` tag (jinja2 tolerates whitespace and the +/- trim markers)
+# is the only sequence that can break out of a `{% raw %}` wrapping. Match just
+# that, not the bare word "endraw" — real CLI output can legitimately contain
+# the word without the surrounding delimiters (1st round codex #2 / claude #4a).
+_ENDRAW_DELIMITER = re.compile(r"\{%[-+]?\s*endraw\b")
 
 
 def _jinja_raw(literal: str) -> str:
@@ -59,7 +68,7 @@ def _jinja_raw(literal: str) -> str:
     could break out is a literal ``{% endraw %}``, which never appears in
     NOS CLI output — guarded loudly just in case (#264 / D6, D8).
     """
-    if "endraw" in literal:
+    if _ENDRAW_DELIMITER.search(literal):
         raise ValueError(f"output literal contains a jinja2 raw-block delimiter, cannot convert: {literal!r}")
     return "{% raw %}" + literal + "{% endraw %}"
 
@@ -79,9 +88,22 @@ def format_template_to_jinja(template: str) -> tuple[str, bool]:
     `string.Formatter.parse` already unescapes ``{{`` -> ``{`` in the literal
     segments it yields, so a template with no field round-trips to its
     unescaped literal text.
+
+    Consecutive literal segments are concatenated before being wrapped in one
+    ``{% raw %}`` block: ``{{`` splits a literal run in two (the ``{`` lands at
+    the end of one segment, the rest in the next), so wrapping per-segment
+    could leave a ``{% endraw %}`` straddling the boundary that the per-segment
+    guard cannot see. Joining first means the guard inspects the full literal.
     """
     parts: list[str] = []
     has_field = False
+    literal_run: list[str] = []
+
+    def flush_literal() -> None:
+        if literal_run:
+            parts.append(_jinja_raw("".join(literal_run)))
+            literal_run.clear()
+
     try:
         segments = list(_FORMATTER.parse(template))
     except ValueError as e:
@@ -90,9 +112,10 @@ def format_template_to_jinja(template: str) -> tuple[str, bool]:
         raise ValueError(f"malformed format template {template!r}: {e}") from e
     for literal_text, field_name, format_spec, conversion in segments:
         if literal_text:
-            parts.append(_jinja_raw(literal_text))
+            literal_run.append(literal_text)
         if field_name is None:
             continue
+        flush_literal()  # a field ends the current literal run
         if field_name != "base_prompt" or format_spec or conversion:
             raise ValueError(
                 f"unsupported format field in template {template!r}: "
@@ -101,6 +124,7 @@ def format_template_to_jinja(template: str) -> tuple[str, bool]:
             )
         has_field = True
         parts.append("{{ base_prompt }}")
+    flush_literal()
     return "".join(parts), has_field
 
 
@@ -140,7 +164,9 @@ class ResolvedOutput:
 
         Handler output is produced by the shell (it owns the device handle
         and the dispatch-time error boundary), so `render` returns None for
-        it — the caller dispatches handlers separately.
+        it — the caller dispatches handlers separately. Callers MUST branch on
+        `kind` first (handler/none and a genuinely empty body both surface as
+        None here, so a None return is not by itself "write nothing").
         """
         if self.kind == "literal":
             return self.text
@@ -161,6 +187,14 @@ class ResolvedCommand:
     means "valid in every mode" (the successor of legacy ``prompt`` omission,
     used by ``_default_`` and unconditional commands). `new_mode` is the mode
     to transition to after running, or None for no transition.
+
+    `output` is always the served/primary capture (the only one the runtime
+    sends). `variants` is the canonical contract for multi-capture commands:
+    empty for a single-output command, otherwise the full ordered capture list
+    with ``variants[0]`` mirroring `output` as the primary (``variant_1``) and
+    the alternates following (``variant_2`` ..). This is the one semantics all
+    inflows normalize to — the legacy adapter rebuilds it from v2's separate
+    ``output`` / ``output_variants`` (#264 / D3, D7).
     """
 
     name: str
@@ -188,7 +222,14 @@ class ModeDef:
 
 @dataclass(frozen=True)
 class ResolvedPlatform:
-    """A platform's modes + resolved commands, ready for the shell (#264 / D4)."""
+    """A platform's modes + resolved commands, ready for the shell (#264 / D4).
+
+    ``frozen`` prevents reassigning the fields, not mutating the `modes` /
+    `commands` dicts they point at. Consumers (notably the platform-level
+    ``functools.cache`` D6 introduces) MUST treat them as read-only; hardening
+    to a read-only mapping is deferred to that caching increment (1st round
+    codex #1).
+    """
 
     modes: dict[str, ModeDef]
     initial_mode: str

--- a/simnos/plugins/nos/platforms_py/arista_eos.py
+++ b/simnos/plugins/nos/platforms_py/arista_eos.py
@@ -17,30 +17,27 @@ class AristaEOS(BaseDevice):
     Class that keeps track of the state of the Arista EOS device.
     """
 
-    def make_show_clock(self, base_prompt, current_prompt, command):
+    def make_show_clock(self, base_prompt, current_mode, current_prompt, command):
         """Return the current time."""
         return self.render("arista_eos/show_clock.j2", time=time.strftime("%a %b %d %H:%M:%S %Y"))
 
-    def make_exit(self, base_prompt, current_prompt, command):
+    def make_exit(self, base_prompt, current_mode, current_prompt, command):
         """Exit the current level of the CLI."""
-        initial_prompt = INITIAL_PROMPT.format(base_prompt=base_prompt)
-        enable_prompt = ENABLE_PROMPT.format(base_prompt=base_prompt)
-        config_prompt = CONFIG_PROMPT.format(base_prompt=base_prompt)
-        if current_prompt in [initial_prompt, enable_prompt]:
+        if current_mode in ("user", "enable"):
             return {"exit": True}
-        if current_prompt == config_prompt:
-            return {"output": "", "new_prompt": ENABLE_PROMPT}
-        raise RuntimeError(f"make_exit does not know how to handle '{current_prompt}' prompt")
+        if current_mode == "config":
+            return {"output": "", "new_mode": "enable"}
+        raise RuntimeError(f"make_exit does not know how to handle '{current_mode}' mode")
 
-    def make_show_ip_int_br(self, base_prompt, current_prompt, command):
+    def make_show_ip_int_br(self, base_prompt, current_mode, current_prompt, command):
         """Return the IP interface brief output."""
         return self.render("arista_eos/show_ip_int_br.j2", base_prompt=base_prompt)
 
-    def make_show_running_config(self, base_prompt, current_prompt, command):
+    def make_show_running_config(self, base_prompt, current_mode, current_prompt, command):
         """Return the running configuration."""
         return self.render("arista_eos/show_running-config.j2", base_prompt=base_prompt)
 
-    def make_show_version(self, base_prompt, current_prompt, command):
+    def make_show_version(self, base_prompt, current_mode, current_prompt, command):
         """Return the system version."""
         return self.render("arista_eos/show_version.j2", base_prompt=base_prompt)
 

--- a/simnos/plugins/nos/platforms_py/cisco_ios.py
+++ b/simnos/plugins/nos/platforms_py/cisco_ios.py
@@ -17,15 +17,15 @@ class CiscoIOS(BaseDevice):
     Class that keeps track of the state of the Cisco IOS device.
     """
 
-    def make_show_clock(self, base_prompt, current_prompt, command):
+    def make_show_clock(self, base_prompt, current_mode, current_prompt, command):
         "Return String in format '*11:54:03.018 UTC Sat Apr 16 2022'"
         return time.strftime("*%H:%M:%S.000 %Z %a %b %d %Y")
 
-    def make_show_running_config(self, base_prompt, current_prompt, command):
+    def make_show_running_config(self, base_prompt, current_mode, current_prompt, command):
         "Return String of running configuration"
         return self.render("cisco_ios/show_running-config.j2", base_prompt=base_prompt)
 
-    def make_show_version(self, base_prompt, current_prompt, command):
+    def make_show_version(self, base_prompt, current_mode, current_prompt, command):
         "Return String of system hardware and software status"
         return self.render("cisco_ios/show_version.j2", base_prompt=base_prompt)
 

--- a/simnos/plugins/nos/platforms_py/huawei_smartax.py
+++ b/simnos/plugins/nos/platforms_py/huawei_smartax.py
@@ -27,7 +27,7 @@ class HuaweiSmartAX(BaseDevice):
         max_length = max(len(str(row)) for row in column)
         return [str(row).ljust(max_length) for row in column]
 
-    def make_display_board(self, base_prompt, current_prompt, command):
+    def make_display_board(self, base_prompt, current_mode, current_prompt, command):
         "Return String of board information"
         titles = [
             "SlotID",
@@ -58,23 +58,24 @@ class HuaweiSmartAX(BaseDevice):
         rows = [list(board.values()) for board in boards]
         return self.render("huawei_smartax/display_board.j2", titles=titles, rows=rows)
 
-    def _return(self, base_prompt, current_prompt, command):
+    def _return(self, base_prompt, current_mode, current_prompt, command):
         "Return to user prompt"
-        if current_prompt.endswith(">"):
-            return {"output": "", "new_prompt": INITIAL_PROMPT}
-        if current_prompt.endswith("#"):
-            return {"output": "", "new_prompt": ENABLE_PROMPT}
-        return {"output": "", "new_prompt": INITIAL_PROMPT}
+        # v2 keyed on the prompt suffix: ">" (user) stayed user, "#"
+        # (enable/config) went to enable. Mode names express that directly.
+        if current_mode == "user":
+            return {"output": "", "new_mode": "user"}
+        return {"output": "", "new_mode": "enable"}
 
-    def quit(self, base_prompt, current_prompt, command):
+    def quit(self, base_prompt, current_mode, current_prompt, command):
         "Exit from device"
         return {"exit": True}
 
-    def disable(self, base_prompt, current_prompt, command):
+    def disable(self, base_prompt, current_mode, current_prompt, command):
         "Exit exec prompt"
-        if current_prompt.endswith("#"):
-            return {"output": "", "new_prompt": INITIAL_PROMPT}
-        return {"output": "", "new_prompt": current_prompt}
+        # From enable/config drop to user; already in user = no transition.
+        if current_mode in ("enable", "config"):
+            return {"output": "", "new_mode": "user"}
+        return {"output": ""}
 
 
 commands = {

--- a/simnos/plugins/shell/cmd_shell.py
+++ b/simnos/plugins/shell/cmd_shell.py
@@ -9,16 +9,18 @@ import os
 import traceback
 from typing import cast
 
+from simnos.core.command_adapter import adapt_legacy_commands
 from simnos.core.command_contract import CommandHandler, CommandResult
 from simnos.core.nos import Nos
+from simnos.core.resolved_command import ResolvedCommand, ResolvedPlatform
 from simnos.plugins import nos
 from simnos.plugins.shell.utils import get_files_changed
 
 log = logging.getLogger(__name__)
 
-# Contract note (#244 / D3): these entries bypass the `Nos` load path and
-# its prompt normalization, so they must NOT carry a `prompt` key — the
-# read side assumes every present `prompt` is already a list.
+# Special, always-present commands fed through the same legacy adapter as the
+# NOS data (#264 / D5). They carry no `prompt`, so the adapter resolves them to
+# an empty mode set = valid in every mode.
 BASIC_COMMANDS: dict = {
     "exit": {"exit": True, "help": "Exit commands shell"},
     "_default_": {
@@ -26,13 +28,6 @@ BASIC_COMMANDS: dict = {
         "help": "Output to print for unknown commands",
     },
 }
-
-# `str.format()` failure modes caused by a malformed template. Shared as the
-# single source of truth between the lenient runtime shell (`_safe_format`)
-# and the loud build-time docs gen (`tasks.render_template`); the runtime
-# logs and degrades while build time raises (and additionally strict-rejects
-# unsupported constructs that would render fine).
-FORMAT_ERRORS = (KeyError, IndexError, ValueError, AttributeError, TypeError)
 
 # Wire response when a command handler (callable output) crashes. Real NOSes
 # never print Python tracebacks, and clients (Netmiko/KeroRoute integration
@@ -66,27 +61,51 @@ class CMDShell(Cmd):
         self.intro = intro
         self.base_prompt = base_prompt
         self.newline = newline
-        # Lenient: a malformed initial_prompt template must not kill every
-        # connection to this host; fall back to the raw template and log.
-        formatted = self._safe_format(nos.initial_prompt, where="initial_prompt")
-        self.prompt = formatted if formatted is not None else nos.initial_prompt
         self.is_running = is_running
+        # Inventory-defined commands are a third inflow alongside BASIC and the
+        # NOS data; kept in authoring form and normalized through the adapter on
+        # every (re)build (#264 / D6).
+        self._inventory_commands: dict = nos_inventory_config.get("commands", {})
+        # Builds self.platform / self.commands / self.current_mode / self.prompt.
+        # A malformed prompt template now fails loudly here (the #172 lenient
+        # fallback is gone — prompt rendering is load-time validated, #264 / D5).
+        self._rebuild()
 
-        # form commands. Inventory-defined commands are the one source
-        # that does not pass through the `Nos` load path, so their
-        # `prompt` is normalized here (str -> [str], on our own deepcopy)
-        # to uphold the lists-only read-side contract (#244 / D3).
-        self.commands = {
-            **copy.deepcopy(BASIC_COMMANDS),
-            **copy.deepcopy(nos.commands or {}),
-            **Nos.normalize_command_prompts(copy.deepcopy(nos_inventory_config.get("commands", {}))),
-        }
         # call the base constructor of cmd.Cmd, with our own stdin and stdout
         super().__init__(
             completekey=completekey,
             stdin=stdin,
             stdout=stdout,
         )
+
+    def _rebuild(self) -> None:
+        """Merge the command inflows and normalize them to `ResolvedCommand`.
+
+        The shell consumes one representation regardless of authoring form: the
+        merged dict (BASIC < NOS data < inventory, later inflows winning, same
+        precedence as before) is run through the legacy adapter. Atomic: if the
+        adapter raises (malformed data), self.* keep their prior values, so a
+        broken hot reload leaves the running session intact (#264 / D5, D6).
+        """
+        merged = {
+            **copy.deepcopy(BASIC_COMMANDS),
+            **copy.deepcopy(self.nos.commands or {}),
+            **copy.deepcopy(self._inventory_commands),
+        }
+        platform: ResolvedPlatform = adapt_legacy_commands(
+            self.nos.initial_prompt,
+            self.nos.enable_prompt,
+            self.nos.config_prompt,
+            merged,
+        )
+        self.platform = platform
+        self.commands = platform.commands
+        # Keep the user's current mode across a hot reload when it still exists;
+        # otherwise (first build, or a reload that dropped the mode) start at the
+        # platform's initial mode.
+        if getattr(self, "current_mode", None) not in platform.modes:
+            self.current_mode = platform.initial_mode
+        self.prompt = platform.modes[self.current_mode].render_prompt(self.base_prompt)
 
     def start(self):
         """Method to start the shell"""
@@ -115,18 +134,19 @@ class CMDShell(Cmd):
         half-written or malformed plugin file (e.g. an editor's partial
         save, or a file that vanished after detection). One broken file
         must not kill the SSH session nor block reloading the remaining
-        files — log and retry on the next change.
+        files — log and retry on the next change. `_rebuild` is atomic, so a
+        file that loads but fails to normalize leaves the live commands intact.
         """
         for file in changed_files:
             try:
                 self.nos.from_file(file)
+                self._rebuild()
             except Exception:
                 # Broad except, like `default()`: any plugin error must not
                 # crash the session. The traceback goes to the log so a
                 # genuine plugin bug surfacing here stays diagnosable.
                 log.error("shell '%s' failed to hot-reload %r\n%s", self.base_prompt, file, traceback.format_exc())
                 continue
-            self.commands.update(self.nos.commands)
 
     def precmd(self, line):
         """Method to return line before processing the command"""
@@ -141,20 +161,23 @@ class CMDShell(Cmd):
         """Method to return stop value to stop the shell"""
         return stop
 
+    def _in_current_mode(self, cmd: ResolvedCommand) -> bool:
+        """Whether `cmd` is valid in the current mode (empty modes = all)."""
+        return not cmd.modes or self.current_mode in cmd.modes
+
     def do_help(self, arg):
-        """Method to return help for commands"""
+        """Method to return help for commands visible in the current mode"""
         lines = {}  # dict of {cmd: cmd_help}
         width = 0  # record longest command width for padding
-        # form help for all commands
-        for cmd, cmd_data in self.commands.items():
+        for name, cmd in self.commands.items():
             # skip special commands
-            if cmd.startswith("_") and cmd.endswith("_"):
+            if name.startswith("_") and name.endswith("_"):
                 continue
-            # skip commands that does not match current prompt
-            if not self._check_prompt(cmd_data.get("prompt"), command=cmd):
+            # skip commands not valid in the current mode
+            if not self._in_current_mode(cmd):
                 continue
-            lines[cmd] = cmd_data.get("help", "")
-            width = max(width, len(cmd))
+            lines[name] = cmd.help
+            width = max(width, len(name))
         # form help lines
         help_msg = []
         for k, v in lines.items():
@@ -162,86 +185,27 @@ class CMDShell(Cmd):
             help_msg.append(f"{k}{padding}{v}")
         self.writeline(self.newline.join(help_msg))
 
-    def _safe_format(self, template: str, *, where: str) -> str | None:
-        """Format `template` with `base_prompt`; return None on failure.
+    def _apply_new_mode(self, mode_name: str, command: str) -> None:
+        """Transition to `mode_name`; an unknown name keeps the current mode.
 
-        The runtime shell is intentionally lenient: yaml templating errors
-        are logged but never crash the session nor leak tracebacks to the
-        wire. The build-time counterpart `tasks.render_template` shares the
-        `FORMAT_ERRORS` catch set but raises `RuntimeError` — and is
-        additionally strict about unsupported constructs that would render
-        fine (e.g. `{base_prompt!r}`). Yaml authors may use only
-        `{base_prompt}` substitution and `{{` / `}}` escapes; see
-        docs/development/creating_new_platforms.md.
-
-        :param template: format template string from yaml / plugin data
-        :param where: caller context for the error log; include the command
-            name when available (e.g. ``f"output for command {line!r}"``)
+        Static transitions (`ResolvedCommand.new_mode`) are validated at load,
+        so they always resolve. A handler-returned `new_mode` is runtime data,
+        so an unknown one is lenient: log and stay put (#264 / D5).
         """
-        try:
-            return template.format(base_prompt=self.base_prompt)
-        except FORMAT_ERRORS as e:
+        mode = self.platform.modes.get(mode_name)
+        if mode is None:
             log.error(
-                "shell '%s' error formatting %s %r: %r",
+                "shell '%s' command %r returned unknown mode %r; staying in %r",
                 self.base_prompt,
-                where,
-                template,
-                e,
+                command,
+                mode_name,
+                self.current_mode,
             )
-            return None
+            return
+        self.current_mode = mode_name
+        self.prompt = mode.render_prompt(self.base_prompt)
 
-    def _check_prompt(self, prompt_: list[str] | None, command: str = ""):
-        """
-        Helper method to check if prompt_ matches current prompt
-
-        :param prompt_: (list of strings, or None) prompt to check — every
-            load path normalizes a bare-str authoring form to a list
-            before commit (#244 / D3), so no str branch is needed here
-        :param command: command name for the error log; callers without it
-            keep working (the log just omits the command context)
-        """
-        # prompt_ is None if no 'prompt' key defined for command
-        if prompt_ is None:
-            return True
-        candidates = prompt_
-        where = f"prompt for command {command!r}" if command else "prompt"
-        # A broken candidate is just a non-match; the remaining candidates
-        # are still evaluated independently.
-        for candidate in candidates:
-            formatted = self._safe_format(candidate, where=where)
-            if formatted is not None and self.prompt == formatted:
-                return True
-        return False
-
-    def _apply_new_prompt(self, template: str, command: str) -> None:
-        """Transition the prompt; a broken template keeps the current one.
-
-        Shared by the callable-dict and cmd_data `new_prompt` paths of
-        `default()`: a format failure means no prompt transition (the
-        session stays on the current prompt); see `_safe_format`.
-        """
-        new_prompt = self._safe_format(template, where=f"new_prompt for command {command!r}")
-        if new_prompt is not None:
-            self.prompt = new_prompt
-
-    def _resolve_command(self, command: str) -> dict | None:
-        """Return the merged cmd_data for `command`, or None if unknown.
-
-        Alias resolution happens here too: a missing alias target is the
-        same lenient unknown-command path as a missing command (both used
-        to be one broad `except KeyError`) — the caller answers with the
-        `_default_` output, never with the handler-crash response.
-        """
-        try:
-            cmd_data = self.commands[command]
-            if "alias" in cmd_data:
-                cmd_data = {**self.commands[cmd_data["alias"]], **cmd_data}
-        except KeyError:
-            log.error("shell.default '%s' command '%s' not found", self.base_prompt, [command])
-            return None
-        return cmd_data
-
-    def _invoke_callable(self, func: CommandHandler, command: str) -> CommandResult:
+    def _invoke_handler(self, handler: CommandHandler, command: str) -> CommandResult:
         """Invoke a command handler and normalize its return to CommandResult.
 
         A plain str (or None) return is sugar for `{"output": <value>}`;
@@ -251,100 +215,70 @@ class CMDShell(Cmd):
         contract violations are caught statically (Protocol) and by the
         e2e callable sweep, not at runtime on the hot path.
         """
-        ret = func(
+        ret = handler(
             self.nos.device,
             base_prompt=self.base_prompt,
+            current_mode=self.current_mode,
             current_prompt=self.prompt,
             command=command,
         )
         if isinstance(ret, dict):
             return ret
-        # Declare the wrapped value as str | None for the type checker
-        # (it cannot narrow the TypedDict member out of the union by
-        # isinstance). The declaration matches the *contract*, not a
-        # runtime guarantee — a contract-breaking return (list / int)
-        # is wrapped as-is and absorbed by the lenient output path.
+        # Declare the wrapped value as str | None for the type checker (it
+        # cannot narrow the TypedDict member out of the union by isinstance).
         return {"output": cast("str | None", ret)}
 
-    def _render_output(self, ret, command: str, *, format_output: bool) -> None:
-        """Write `ret` to the client; only yaml-static output is formatted.
-
-        `ret` is untyped on purpose: the lenient path also carries
-        contract-breaking handler returns (see `_invoke_callable`), which
-        `writeline`'s `str(value)` absorbs. The caller must not pass
-        None though — `default()` guards with `if ret is not None`
-        ("write nothing"), this helper always writes.
-
-        Callable output is passed through verbatim (`format_output=False`):
-        handlers receive `base_prompt` as an argument and format
-        themselves (see `CommandHandler`), so a second `.format()` here
-        would only mis-render device output containing literal braces or
-        an accidental `{base_prompt}` (#241 / D-b). For yaml-static
-        output, a format failure falls back to the raw template
-        (information beats dropping the whole output); lenient policy in
-        `_safe_format`.
-        """
-        if not format_output:
-            self.writeline(ret)
-            return
-        formatted = self._safe_format(ret, where=f"output for command {command!r}")
-        self.writeline(formatted if formatted is not None else ret)
-
     def default(self, line):
-        """Dispatch `line`: resolve -> prompt check -> invoke -> render.
+        """Dispatch `line`: resolve -> mode check -> render/invoke -> transition.
 
-        The exception boundary is the `_invoke_callable` block only:
-        resolve / alias / prompt check / new_prompt never raise (KeyError
-        degrades inside `_resolve_command`, format errors are caught
-        inside `_safe_format`), so `HANDLER_ERROR_OUTPUT` is structurally
-        guaranteed to mean "a command handler crashed" and nothing else.
+        The exception boundary is the `_invoke_handler` block only: resolution,
+        the mode check and the transition never raise (an unknown command is a
+        plain dict miss, an unknown handler mode degrades inside
+        `_apply_new_mode`), so `HANDLER_ERROR_OUTPUT` structurally means "a
+        command handler crashed" and nothing else (#241 / #264).
         """
         log.debug("shell.default '%s' running command '%s'", self.base_prompt, [line])
-        from_callable = False
-        cmd_data = self._resolve_command(line)
-        if cmd_data is not None and self._check_prompt(cmd_data.get("prompt"), command=line):
-            if cmd_data.get("exit"):
+        cmd = self.commands.get(line)
+        if cmd is not None and self._in_current_mode(cmd):
+            if cmd.exit:
                 return True
-            ret = cmd_data.get("output")
+            output = cmd.output
+            transition = cmd.new_mode
         else:
-            if cmd_data is not None:
+            if cmd is not None:
                 log.warning(
-                    "'%s' command prompt '%s' not matching current prompt '%s'",
+                    "'%s' command not valid in current mode '%s' (valid modes: %s)",
                     line,
-                    # Always a list here: a mismatch requires a non-None,
-                    # normalized prompt (#244 / D3).
-                    ", ".join(cmd_data.get("prompt", [])),
-                    self.prompt,
+                    self.current_mode,
+                    ", ".join(sorted(cmd.modes)) if cmd.modes else "all",
                 )
-            # Unknown command and prompt mismatch both answer with the
-            # `_default_` output — a silent shell would make clients
-            # (e.g. Netmiko) wait for a timeout instead.
-            ret = self.commands["_default_"]["output"]
-            cmd_data = None  # the `_default_` answer never applies cmd_data's new_prompt
-        if callable(ret):
-            from_callable = True
+            # Unknown command and mode mismatch both answer with the `_default_`
+            # output — a silent shell would make clients (e.g. Netmiko) wait for
+            # a timeout. The `_default_` answer never applies a transition.
+            output = self.commands["_default_"].output
+            transition = None
+        if output.kind == "handler" and output.handler is not None:
             try:
-                result = self._invoke_callable(ret, line)
+                result = self._invoke_handler(output.handler, line)
             except Exception:
                 # Same shape as the hot-reload guard (#232): full traceback
                 # to the log, the session survives, and the client gets a
                 # real-NOS-style one-liner instead of a Python traceback.
-                log.error(
-                    "shell '%s' command %r handler crashed\n%s",
-                    self.base_prompt,
-                    line,
-                    traceback.format_exc(),
-                )
+                log.error("shell '%s' command %r handler crashed\n%s", self.base_prompt, line, traceback.format_exc())
                 result = {"output": HANDLER_ERROR_OUTPUT}
-            if "new_prompt" in result:
-                self._apply_new_prompt(result["new_prompt"], line)
             if result.get("exit"):
                 return True
-            ret = result.get("output")
-        if cmd_data is not None and "new_prompt" in cmd_data:
-            self._apply_new_prompt(cmd_data["new_prompt"], line)
+            # A handler transition applies only when the command has no static
+            # one (a static `new_mode` was the last write in the v2 order).
+            if transition is None:
+                transition = result.get("new_mode")
+            body = result.get("output")
+        else:
+            body = output.render(self.base_prompt)
+        if transition is not None:
+            self._apply_new_mode(transition, line)
         if not self.is_running.is_set():
             return True
-        if ret is not None:
-            self._render_output(ret, line, format_output=not from_callable)
+        if body is not None:
+            self.writeline(body)
         return False

--- a/simnos/plugins/shell/cmd_shell.py
+++ b/simnos/plugins/shell/cmd_shell.py
@@ -127,6 +127,10 @@ class CMDShell(Cmd):
     def emptyline(self):
         """This method to do nothing if empty line entered"""
 
+    # `Nos` state `from_file` mutates; snapshotted per reloaded file so a file
+    # that loads but fails to normalize can be rolled back (2nd round codex #1).
+    _NOS_RELOAD_ATTRS = ("name", "initial_prompt", "enable_prompt", "config_prompt", "auth", "device")
+
     def reload_commands(self, changed_files: list):
         """Method to reload commands
 
@@ -134,17 +138,30 @@ class CMDShell(Cmd):
         half-written or malformed plugin file (e.g. an editor's partial
         save, or a file that vanished after detection). One broken file
         must not kill the SSH session nor block reloading the remaining
-        files — log and retry on the next change. `_rebuild` is atomic, so a
-        file that loads but fails to normalize leaves the live commands intact.
+        files — log and retry on the next change.
+
+        `from_file` commits to `self.nos` *before* the adapter validates it in
+        `_rebuild`, so a file that loads under the legacy schema but fails
+        normalization (e.g. a canonical-外 prompt) would leave broken commands
+        in `self.nos` and re-fail every later file in the batch. Snapshot the
+        mutated nos state and roll it back on failure to keep the per-file
+        contract; `_rebuild` itself is atomic, so live `self.commands` is never
+        touched by a failed reload (2nd round codex #1).
         """
         for file in changed_files:
+            snapshot_commands = dict(self.nos.commands)
+            snapshot_attrs = {attr: getattr(self.nos, attr) for attr in self._NOS_RELOAD_ATTRS}
             try:
                 self.nos.from_file(file)
                 self._rebuild()
             except Exception:
                 # Broad except, like `default()`: any plugin error must not
-                # crash the session. The traceback goes to the log so a
-                # genuine plugin bug surfacing here stays diagnosable.
+                # crash the session. Roll back the partial nos mutation so the
+                # broken file does not poison subsequent reloads, then log the
+                # traceback so a genuine plugin bug stays diagnosable.
+                self.nos.commands = snapshot_commands
+                for attr, value in snapshot_attrs.items():
+                    setattr(self.nos, attr, value)
                 log.error("shell '%s' failed to hot-reload %r\n%s", self.base_prompt, file, traceback.format_exc())
                 continue
 
@@ -166,7 +183,17 @@ class CMDShell(Cmd):
         return not cmd.modes or self.current_mode in cmd.modes
 
     def do_help(self, arg):
-        """Method to return help for commands visible in the current mode"""
+        """List help for commands valid in the current mode.
+
+        Intentional refinement over v2 (2nd round claude #2): v2 `do_help`
+        read the raw unmerged entries, so an alias without its own prompt was
+        listed in *every* mode even where typing it fell through to
+        `_default_`. Listing by the resolved mode set instead matches
+        dispatchability — e.g. arista_eos's prompt-less aliases (``config
+        term``) now appear only in their target mode. Dispatch behavior is
+        unchanged (v2 already matched on the merged prompt); only the help
+        listing is affected.
+        """
         lines = {}  # dict of {cmd: cmd_help}
         width = 0  # record longest command width for padding
         for name, cmd in self.commands.items():
@@ -252,6 +279,11 @@ class CMDShell(Cmd):
                     self.current_mode,
                     ", ".join(sorted(cmd.modes)) if cmd.modes else "all",
                 )
+            else:
+                # Keep the unknown-command trail v2 logged (observability for
+                # typo / undefined-command diagnosis); the wire answer is the
+                # same `_default_` output (2nd round claude #5).
+                log.debug("shell.default '%s' command %r not found", self.base_prompt, line)
             # Unknown command and mode mismatch both answer with the `_default_`
             # output — a silent shell would make clients (e.g. Netmiko) wait for
             # a timeout. The `_default_` answer never applies a transition.

--- a/tasks.py
+++ b/tasks.py
@@ -194,24 +194,29 @@ WARNING_MESSAGE = """
 
 
 def render_template(template: str, platform: str, command: str, field: str) -> str:
-    """Render a YAML string template the same way the runtime shell does.
+    """Render a YAML string template for the docs generator (build time).
 
-    Uses `str.format(base_prompt=platform)` to match `cmd_shell.default`:
-    substitutes `{base_prompt}` and unescapes `{{` / `}}` literals from
-    `sync_ntc_commands.escape_format_braces` preventive escape.
+    Uses `str.format(base_prompt=platform)` against the legacy
+    ``platforms_yaml`` data: substitutes `{base_prompt}` and unescapes
+    `{{` / `}}` literals from `sync_ntc_commands.escape_format_braces`.
 
-    Build time is strict: besides re-raising the `FORMAT_ERRORS` catch set
-    shared with the lenient runtime `cmd_shell._safe_format`, this rejects
-    unsupported constructs that `str.format()` would happily render (e.g.
-    `{base_prompt!r}` or `{base_prompt:>20}`) — only a plain
+    Build time is strict: besides re-raising the `FORMAT_ERRORS` catch set,
+    this rejects unsupported constructs that `str.format()` would happily
+    render (e.g. `{base_prompt!r}` or `{base_prompt:>20}`) — only a plain
     `{base_prompt}` field and `{{` / `}}` escapes are supported. Every
     failure surfaces as `RuntimeError` carrying the platform / command /
     field context, so CI failures pinpoint the offending YAML entry
     instead of dumping a contextless stack trace.
+
+    The runtime shell no longer uses `str.format` (it renders the A3
+    `ResolvedCommand` representation, #264); this build-time path still reads
+    the legacy yaml and is replaced when the docs generator moves to the new
+    loader (#264 PR-3 / D9). `FORMAT_ERRORS` is the frozen `str.format`
+    failure set, kept here until then.
     """
-    # Lazy import: keep `invoke --list` / lint-only tasks fast (the existing
-    # tasks.py convention, see netmiko_check); cached after the first call.
-    from simnos.plugins.shell.cmd_shell import FORMAT_ERRORS
+    # str.format failure modes, formerly shared with the runtime shell's
+    # _safe_format (removed in #264). Local to this build-time renderer now.
+    FORMAT_ERRORS = (KeyError, IndexError, ValueError, AttributeError, TypeError)
 
     try:
         # Strict authoring check first: a malformed template raises ValueError

--- a/tests/assets/module.py
+++ b/tests/assets/module.py
@@ -20,11 +20,11 @@ class TestModule(BaseDevice):
     Class that keeps track of the state of the TestModule device.
     """
 
-    def make_show_clock(self, base_prompt, current_prompt, command):
+    def make_show_clock(self, base_prompt, current_mode, current_prompt, command):
         """Return the current time."""
         return str(time.ctime())
 
-    def make_show_version(self, base_prompt, current_prompt, command):
+    def make_show_version(self, base_prompt, current_mode, current_prompt, command):
         """Return the system version."""
         return "TestModule version 1.0"
 

--- a/tests/core/test_command_adapter.py
+++ b/tests/core/test_command_adapter.py
@@ -76,6 +76,16 @@ class TestAdaptCommandModes:
         with pytest.raises(ValueError, match="cannot map"):
             adapt_commands({"weird": {"output": "x", "prompt": "alien$"}}, reverse)
 
+    def test_explicit_empty_prompt_list_is_loud(self):
+        """`prompt: []` is rejected, not silently treated as all-modes (#264 / claude #3).
+
+        v2 `_check_prompt([])` was always False (unreachable); an empty mode set
+        means the opposite ("all modes"), so the inversion must be loud.
+        """
+        _, _, reverse = _cisco_modes()
+        with pytest.raises(ValueError, match=r"empty prompt list"):
+            adapt_commands({"cmd": {"output": "x", "prompt": []}}, reverse)
+
     def test_format_failing_prompt_is_context_tagged_loud(self):
         """An unknown-field prompt fails with a context-tagged ValueError, not a bare KeyError."""
         _, _, reverse = _cisco_modes()

--- a/tests/core/test_command_adapter.py
+++ b/tests/core/test_command_adapter.py
@@ -76,6 +76,17 @@ class TestAdaptCommandModes:
         with pytest.raises(ValueError, match="cannot map"):
             adapt_commands({"weird": {"output": "x", "prompt": "alien$"}}, reverse)
 
+    def test_format_failing_prompt_is_context_tagged_loud(self):
+        """An unknown-field prompt fails with a context-tagged ValueError, not a bare KeyError."""
+        _, _, reverse = _cisco_modes()
+        with pytest.raises(ValueError, match=r"command 'weird'"):
+            adapt_commands({"weird": {"output": "x", "prompt": "{hostname}>"}}, reverse)
+
+    def test_unmappable_new_prompt_is_loud(self):
+        _, _, reverse = _cisco_modes()
+        with pytest.raises(ValueError, match="new_prompt"):
+            adapt_commands({"go": {"output": None, "prompt": "{base_prompt}>", "new_prompt": "alien$"}}, reverse)
+
     def test_new_prompt_maps_to_new_mode(self):
         _, _, reverse = _cisco_modes()
         resolved = adapt_commands(
@@ -124,6 +135,17 @@ class TestAdaptOutput:
         assert out.kind == "template"
         assert out.render("R9") == "host R9"
 
+    def test_non_dict_entry_is_loud(self):
+        _, _, reverse = _cisco_modes()
+        with pytest.raises(ValueError, match="expected a mapping"):
+            adapt_commands({"bad": ["not", "a", "dict"]}, reverse)
+
+    def test_non_str_non_callable_output_is_loud(self):
+        """v2 output is only str/callable/None; anything else fails at load, not via str() on wire."""
+        _, _, reverse = _cisco_modes()
+        with pytest.raises(ValueError, match="unsupported output type"):
+            adapt_commands({"cmd": {"output": 123, "prompt": "{base_prompt}>"}}, reverse)
+
     def test_callable_output_is_handler(self):
         _, _, reverse = _cisco_modes()
         handler = lambda device, **kw: "dynamic"  # noqa: E731
@@ -132,15 +154,29 @@ class TestAdaptOutput:
         assert out.kind == "handler"
         assert out.handler is handler
 
-    def test_output_variants_named(self):
+    def test_output_variants_canonical_contract(self):
+        """variants[0] mirrors `output` (variant_1); alternates follow as variant_2.. (D3/D7)."""
         _, _, reverse = _cisco_modes()
         resolved = adapt_commands(
             {"cmd": {"output": "primary", "output_variants": ["a", "b"], "prompt": "{base_prompt}>"}}, reverse
         )
         rc = resolved["cmd"]
         assert rc.output.text == "primary"
-        assert [name for name, _ in rc.variants] == ["variant_1", "variant_2"]
-        assert [o.text for _, o in rc.variants] == ["a", "b"]
+        assert [name for name, _ in rc.variants] == ["variant_1", "variant_2", "variant_3"]
+        assert [o.text for _, o in rc.variants] == ["primary", "a", "b"]
+        assert rc.variants[0][1] is rc.output  # primary mirrored at variants[0]
+
+    def test_single_output_has_no_variants(self):
+        """A command without output_variants carries an empty variants tuple."""
+        _, _, reverse = _cisco_modes()
+        resolved = adapt_commands({"cmd": {"output": "only", "prompt": "{base_prompt}>"}}, reverse)
+        assert resolved["cmd"].variants == ()
+
+    def test_template_output_required_vars_excludes_base_prompt(self):
+        """A {base_prompt}-only output template carries no host facts (#265 placeholder)."""
+        _, _, reverse = _cisco_modes()
+        resolved = adapt_commands({"cmd": {"output": "host {base_prompt}", "prompt": "{base_prompt}>"}}, reverse)
+        assert resolved["cmd"].output.required_vars == frozenset()
 
 
 class TestAdaptAlias:

--- a/tests/core/test_command_adapter.py
+++ b/tests/core/test_command_adapter.py
@@ -189,9 +189,26 @@ class TestAdaptAlias:
             "sh clock": {"alias": "show clock"},
         }
         resolved = adapt_commands(commands, reverse)
-        assert resolved["sh clock"].output.text == "12:00"
-        assert resolved["sh clock"].help == "clock"
+        assert resolved["sh clock"].output.text == "12:00"  # dispatch fields from target
+        assert resolved["sh clock"].help == ""  # help is the alias's own (see test_alias_help_is_own_not_target)
         assert resolved["sh clock"].modes == frozenset({"user"})
+
+    def test_alias_help_is_own_not_target(self):
+        """An alias shows its own help (blank if absent), not the target's (#264 / D6).
+
+        v2 `do_help` lists the raw unmerged entry, so this is the observable
+        help; the dispatch fields still come from the target.
+        """
+        _, _, reverse = _cisco_modes()
+        commands = {
+            "show clock": {"output": "12:00", "help": "clock", "prompt": "{base_prompt}>"},
+            "sh clock": {"alias": "show clock"},
+            "sc": {"alias": "show clock", "help": "own help"},
+        }
+        resolved = adapt_commands(commands, reverse)
+        assert resolved["sh clock"].help == ""  # no own help -> blank
+        assert resolved["sc"].help == "own help"  # own help kept
+        assert resolved["sh clock"].output.text == "12:00"  # dispatch still from target
 
     def test_alias_entry_keys_win(self):
         """An alias entry's own fields override the target's (#264 / D6)."""

--- a/tests/core/test_command_adapter.py
+++ b/tests/core/test_command_adapter.py
@@ -1,0 +1,195 @@
+"""Unit tests for the legacy-form normalization core (#264 / P1-1 D6).
+
+Covers mode synthesis + prompt->mode reverse lookup, command normalization
+(prompt/new_prompt/output/variants/alias), and the loud boundaries. The
+whole-dataset equivalence (all 50 platforms vs v2) is the migration oracle
+(b') added in PR-1's later increment; these unit tests pin the pieces.
+"""
+
+import pytest
+
+from simnos.core.command_adapter import (
+    adapt_commands,
+    adapt_legacy_commands,
+    synthesize_modes,
+)
+
+CISCO_PROMPTS = ("{base_prompt}>", "{base_prompt}#", "{base_prompt}(config)#")
+
+
+def _cisco_modes():
+    """The canonical 3-mode reverse map shared by several tests."""
+    return synthesize_modes(*CISCO_PROMPTS)
+
+
+class TestSynthesizeModes:
+    """Mode synthesis from v2's three prompt templates (#264 / M2)."""
+
+    def test_three_modes(self):
+        modes, initial, reverse = _cisco_modes()
+        assert set(modes) == {"user", "enable", "config"}
+        assert initial == "user"
+        assert set(reverse.values()) == {"user", "enable", "config"}
+
+    def test_two_modes_when_no_config(self):
+        modes, _, _ = synthesize_modes("{base_prompt}>", "{base_prompt}#", None)
+        assert set(modes) == {"user", "enable"}
+
+    def test_one_mode_when_only_initial(self):
+        modes, initial, _ = synthesize_modes("{base_prompt}>", None, None)
+        assert set(modes) == {"user"}
+        assert initial == "user"
+
+    def test_ambiguous_modes_raise(self):
+        """Two modes rendering to the same prompt cannot be reverse-mapped."""
+        with pytest.raises(ValueError, match="ambiguous"):
+            synthesize_modes("{base_prompt}#", "{base_prompt}#", None)
+
+    def test_mode_prompt_renders_with_base_prompt(self):
+        modes, _, _ = _cisco_modes()
+        assert modes["config"].render_prompt("R1") == "R1(config)#"
+
+
+class TestAdaptCommandModes:
+    """prompt -> mode membership reverse lookup."""
+
+    def test_single_prompt_to_single_mode(self):
+        _, _, reverse = _cisco_modes()
+        resolved = adapt_commands({"show run": {"output": "x", "prompt": "{base_prompt}#"}}, reverse)
+        assert resolved["show run"].modes == frozenset({"enable"})
+
+    def test_prompt_list_to_mode_set(self):
+        _, _, reverse = _cisco_modes()
+        resolved = adapt_commands(
+            {"show clock": {"output": "x", "prompt": ["{base_prompt}>", "{base_prompt}#"]}}, reverse
+        )
+        assert resolved["show clock"].modes == frozenset({"user", "enable"})
+
+    def test_prompt_omitted_is_empty_modes(self):
+        """A command with no prompt is valid in every mode (empty set)."""
+        _, _, reverse = _cisco_modes()
+        resolved = adapt_commands({"cmd": {"output": "x"}}, reverse)
+        assert resolved["cmd"].modes == frozenset()
+
+    def test_unmappable_prompt_is_loud(self):
+        _, _, reverse = _cisco_modes()
+        with pytest.raises(ValueError, match="cannot map"):
+            adapt_commands({"weird": {"output": "x", "prompt": "alien$"}}, reverse)
+
+    def test_new_prompt_maps_to_new_mode(self):
+        _, _, reverse = _cisco_modes()
+        resolved = adapt_commands(
+            {"enable": {"output": None, "prompt": "{base_prompt}>", "new_prompt": "{base_prompt}#"}}, reverse
+        )
+        assert resolved["enable"].new_mode == "enable"
+
+    def test_no_new_prompt_is_none(self):
+        _, _, reverse = _cisco_modes()
+        resolved = adapt_commands({"show run": {"output": "x", "prompt": "{base_prompt}#"}}, reverse)
+        assert resolved["show run"].new_mode is None
+
+
+class TestAdaptDefault:
+    """`_default_` is the unconditional fallback (#264 / D5)."""
+
+    def test_default_modes_empty_and_prompt_dropped(self):
+        """Even an authored prompt on `_default_` is dropped (v2 never matches it)."""
+        _, _, reverse = _cisco_modes()
+        resolved = adapt_commands(
+            {"_default_": {"output": "% Unknown", "prompt": "{base_prompt}#", "new_prompt": "{base_prompt}>"}}, reverse
+        )
+        assert resolved["_default_"].modes == frozenset()
+        assert resolved["_default_"].new_mode is None
+
+
+class TestAdaptOutput:
+    """`output` normalization to ResolvedOutput kinds."""
+
+    def test_none_output(self):
+        _, _, reverse = _cisco_modes()
+        resolved = adapt_commands({"enable": {"output": None, "prompt": "{base_prompt}>"}}, reverse)
+        assert resolved["enable"].output.kind == "none"
+
+    def test_str_output_literal(self):
+        _, _, reverse = _cisco_modes()
+        resolved = adapt_commands({"cmd": {"output": "static {{esc}}", "prompt": "{base_prompt}>"}}, reverse)
+        out = resolved["cmd"].output
+        assert out.kind == "literal"
+        assert out.text == "static {esc}"  # v2 brace unescape
+
+    def test_str_output_with_base_prompt_is_template(self):
+        _, _, reverse = _cisco_modes()
+        resolved = adapt_commands({"cmd": {"output": "host {base_prompt}", "prompt": "{base_prompt}>"}}, reverse)
+        out = resolved["cmd"].output
+        assert out.kind == "template"
+        assert out.render("R9") == "host R9"
+
+    def test_callable_output_is_handler(self):
+        _, _, reverse = _cisco_modes()
+        handler = lambda device, **kw: "dynamic"  # noqa: E731
+        resolved = adapt_commands({"cmd": {"output": handler, "prompt": "{base_prompt}>"}}, reverse)
+        out = resolved["cmd"].output
+        assert out.kind == "handler"
+        assert out.handler is handler
+
+    def test_output_variants_named(self):
+        _, _, reverse = _cisco_modes()
+        resolved = adapt_commands(
+            {"cmd": {"output": "primary", "output_variants": ["a", "b"], "prompt": "{base_prompt}>"}}, reverse
+        )
+        rc = resolved["cmd"]
+        assert rc.output.text == "primary"
+        assert [name for name, _ in rc.variants] == ["variant_1", "variant_2"]
+        assert [o.text for _, o in rc.variants] == ["a", "b"]
+
+
+class TestAdaptAlias:
+    """Single-level alias field-merge, replicating v2 (#264 / D6)."""
+
+    def test_alias_merges_target_fields(self):
+        _, _, reverse = _cisco_modes()
+        commands = {
+            "show clock": {"output": "12:00", "help": "clock", "prompt": "{base_prompt}>"},
+            "sh clock": {"alias": "show clock"},
+        }
+        resolved = adapt_commands(commands, reverse)
+        assert resolved["sh clock"].output.text == "12:00"
+        assert resolved["sh clock"].help == "clock"
+        assert resolved["sh clock"].modes == frozenset({"user"})
+
+    def test_alias_entry_keys_win(self):
+        """An alias entry's own fields override the target's (#264 / D6)."""
+        _, _, reverse = _cisco_modes()
+        commands = {
+            "show ip int brief": {"output": "brief", "prompt": ["{base_prompt}>", "{base_prompt}#"]},
+            "do show ip int brief": {"alias": "show ip int brief", "prompt": "{base_prompt}(config)#"},
+        }
+        resolved = adapt_commands(commands, reverse)
+        # output inherited from target, but prompt (mode) overridden by the alias entry
+        assert resolved["do show ip int brief"].output.text == "brief"
+        assert resolved["do show ip int brief"].modes == frozenset({"config"})
+
+    def test_missing_alias_target_dropped(self):
+        """A missing target degrades to unknown (dropped from the resolved dict)."""
+        _, _, reverse = _cisco_modes()
+        resolved = adapt_commands({"broken": {"alias": "no such target"}}, reverse)
+        assert "broken" not in resolved
+
+
+class TestAdaptLegacyCommands:
+    """Top-level `adapt_legacy_commands` wires modes + commands together."""
+
+    def test_returns_resolved_platform(self):
+        platform = adapt_legacy_commands(
+            "{base_prompt}>",
+            "{base_prompt}#",
+            "{base_prompt}(config)#",
+            {
+                "enable": {"output": None, "prompt": "{base_prompt}>", "new_prompt": "{base_prompt}#"},
+                "_default_": {"output": "% Unknown"},
+            },
+        )
+        assert platform.initial_mode == "user"
+        assert set(platform.modes) == {"user", "enable", "config"}
+        assert platform.commands["enable"].new_mode == "enable"
+        assert platform.commands["_default_"].modes == frozenset()

--- a/tests/core/test_migration_oracle.py
+++ b/tests/core/test_migration_oracle.py
@@ -19,6 +19,21 @@ the set of modes the command is visible in, the transition target mode, and
 fallback v2 never prompt-matches, so its mode visibility / transition are
 excluded from the comparison (Decision 3 / D5).
 
+Scope: this gate covers the **static / mechanically-converted** surface
+(string output, prompt->mode, static new_prompt->new_mode). Callable handler
+output is collapsed to a sentinel — handler dynamic transitions
+(``make_exit`` / ``_return`` / ``disable``) are NOT projected here, because the
+v2 handler code was rewritten in place (no frozen v2 handler exists to compare
+against); those conversions are pinned per-mode by the device-class tests in
+tests/plugins/nos/ (2nd round codex #2 / claude #6).
+
+Two further fidelity limits, harmless on shipped data (claude #6):
+- `_v2_new_mode` projects a canonical-外 new_prompt to None (no transition);
+  the adapter loud-raises on the same input, so the comparison is never
+  reached (shipped data is 100% canonical).
+- do_help's alias-visibility refinement (claude #2) is shared by the replica
+  (both read merged modes), so it is not a comparison axis here.
+
 One-shot gate — removable once the A3 migration completes (PR-3).
 """
 

--- a/tests/core/test_migration_oracle.py
+++ b/tests/core/test_migration_oracle.py
@@ -1,0 +1,155 @@
+"""Migration oracle (b'): adapter projection == v2 frozen-replica projection.
+
+#264 / P1-1 Decision 3 (b'). PR-1 (the shell rewire increment) removes v2's
+``str.format`` render semantics and prompt-string matching from the runtime, so
+this test carries a **frozen reimplementation** of them and asserts, across all
+shipped platforms, that the legacy adapter
+(:func:`simnos.core.command_adapter.adapt_legacy_commands`) projects every
+command to the same client-observable behavior v2 produced.
+
+This pins "adapter == v2" *independently of the adapter's own code*: the
+comparison input is the raw legacy command dict run through the frozen replica,
+not anything the adapter computed — which is what stops the gate from
+degenerating into the adapter self-checking (Decision 3, 1st round claude #3).
+
+Projection (Decision 3): for a fixed ``base_prompt``, the rendered output as
+``splitlines()`` (wire-equivalent: ``writeline`` absorbs trailing newlines),
+the set of modes the command is visible in, the transition target mode, and
+``exit`` / ``help`` / variant count. ``_default_`` is the unconditional
+fallback v2 never prompt-matches, so its mode visibility / transition are
+excluded from the comparison (Decision 3 / D5).
+
+One-shot gate — removable once the A3 migration completes (PR-3).
+"""
+
+import copy
+
+import pytest
+
+from simnos.core.command_adapter import adapt_legacy_commands
+from simnos.core.nos import Nos
+from simnos.plugins.nos import available_platforms, nos_plugins
+from simnos.plugins.shell.cmd_shell import BASIC_COMMANDS
+
+# Fixed device prompt for the projection; any value with distinct canonical
+# renders works (Decision 3 "固定 base_prompt").
+_FIXED = "oracle"
+# Sentinels kept out of the str/list value space so they compare by identity.
+_HANDLER = "<<handler>>"
+_ALL_MODES = "<<all-modes>>"
+# Frozen copy of v2's `str.format` failure modes (cmd_shell.FORMAT_ERRORS as of
+# PR-1) — the shell increment deletes the original, this replica must not.
+_V2_FORMAT_ERRORS = (KeyError, IndexError, ValueError, AttributeError, TypeError)
+
+
+def _v2_format(template: str):
+    """v2 `_safe_format`: `str.format` with a silent raw fallback on failure."""
+    try:
+        return template.format(base_prompt=_FIXED)
+    except _V2_FORMAT_ERRORS:
+        return template
+
+
+def _rendered_modes(nos: Nos) -> dict[str, str]:
+    """Render each canonical mode prompt the way v2 would (str.format)."""
+    sources = {"user": nos.initial_prompt, "enable": nos.enable_prompt, "config": nos.config_prompt}
+    return {name: tmpl.format(base_prompt=_FIXED) for name, tmpl in sources.items() if tmpl}
+
+
+def _v2_visible_modes(prompt_value, rendered_modes: dict[str, str]):
+    """v2 `_check_prompt` replica: which canonical modes match the prompt(s)."""
+    if prompt_value is None:
+        return _ALL_MODES
+    candidates = [prompt_value] if isinstance(prompt_value, str) else prompt_value
+    visible = set()
+    for candidate in candidates:
+        try:
+            rendered = candidate.format(base_prompt=_FIXED)
+        except _V2_FORMAT_ERRORS:
+            continue  # _safe_format returns None -> never a match
+        visible |= {name for name, mode_prompt in rendered_modes.items() if rendered == mode_prompt}
+    return visible
+
+
+def _v2_new_mode(new_prompt, rendered_modes: dict[str, str]) -> str | None:
+    """v2 transition replica: the mode whose prompt the new_prompt renders to."""
+    if new_prompt is None:
+        return None
+    rendered = _v2_format(new_prompt)
+    for name, mode_prompt in rendered_modes.items():
+        if rendered == mode_prompt:
+            return name
+    return None
+
+
+def _v2_output(value):
+    """Project a legacy output value the way the wire would observe it."""
+    if value is None:
+        return None
+    if callable(value):
+        return _HANDLER
+    return _v2_format(value).splitlines()
+
+
+def _replica_projection(merged: dict, rendered_modes: dict[str, str]) -> dict[str, dict]:
+    """Project every (alias-merged) legacy command via the frozen v2 replica."""
+    projection: dict[str, dict] = {}
+    for name, entry in merged.items():
+        if "alias" in entry:
+            target = merged.get(entry["alias"])
+            if target is None:
+                continue  # missing target -> dropped (v2 unknown-command path)
+            entry = {**target, **entry}
+        is_default = name == "_default_"
+        variants = entry.get("output_variants")
+        projection[name] = {
+            "output": _v2_output(entry.get("output")),
+            # `_default_` is never prompt-matched by v2 -> exclude from compare.
+            "modes": None if is_default else _v2_visible_modes(entry.get("prompt"), rendered_modes),
+            "new_mode": None if is_default else _v2_new_mode(entry.get("new_prompt"), rendered_modes),
+            "exit": bool(entry.get("exit")),
+            "help": entry.get("help", ""),
+            "variant_count": (len(variants) + 1) if variants else 0,
+        }
+    return projection
+
+
+def _adapter_projection(commands: dict) -> dict[str, dict]:
+    """Project every adapter-resolved command into the same comparison shape."""
+    projection: dict[str, dict] = {}
+    for name, rc in commands.items():
+        out = rc.output
+        if out.kind == "handler":
+            rendered = _HANDLER
+        elif out.kind == "none":
+            rendered = None
+        else:
+            body = out.render(_FIXED)
+            rendered = body.splitlines() if body is not None else None
+        is_default = name == "_default_"
+        projection[name] = {
+            "output": rendered,
+            "modes": None if is_default else (_ALL_MODES if not rc.modes else set(rc.modes)),
+            "new_mode": rc.new_mode,
+            "exit": rc.exit,
+            "help": rc.help,
+            "variant_count": len(rc.variants),
+        }
+    return projection
+
+
+@pytest.mark.parametrize("platform", available_platforms)
+def test_adapter_matches_v2_replica(platform):
+    """Every shipped command projects identically under v2-replica and adapter."""
+    nos = Nos(filename=nos_plugins[platform])
+    # The shell merges BASIC commands under the platform's own (which win).
+    merged = {**copy.deepcopy(BASIC_COMMANDS), **copy.deepcopy(nos.commands)}
+
+    rendered_modes = _rendered_modes(nos)
+    replica = _replica_projection(merged, rendered_modes)
+    resolved = adapt_legacy_commands(nos.initial_prompt, nos.enable_prompt, nos.config_prompt, merged)
+    adapter = _adapter_projection(resolved.commands)
+
+    assert set(adapter) == set(replica), f"{platform}: command set differs"
+    mismatches = {name: (replica[name], adapter[name]) for name in replica if replica[name] != adapter[name]}
+    assert not mismatches, f"{platform}: {len(mismatches)} command(s) diverge from v2: {sorted(mismatches)}"

--- a/tests/core/test_migration_oracle.py
+++ b/tests/core/test_migration_oracle.py
@@ -95,6 +95,9 @@ def _replica_projection(merged: dict, rendered_modes: dict[str, str]) -> dict[st
     """Project every (alias-merged) legacy command via the frozen v2 replica."""
     projection: dict[str, dict] = {}
     for name, entry in merged.items():
+        # v2 `do_help` reads the raw (unmerged) entry, so an alias's observable
+        # help is its own, not the target's (#264 / D6).
+        own_help = entry.get("help", "")
         if "alias" in entry:
             target = merged.get(entry["alias"])
             if target is None:
@@ -108,7 +111,7 @@ def _replica_projection(merged: dict, rendered_modes: dict[str, str]) -> dict[st
             "modes": None if is_default else _v2_visible_modes(entry.get("prompt"), rendered_modes),
             "new_mode": None if is_default else _v2_new_mode(entry.get("new_prompt"), rendered_modes),
             "exit": bool(entry.get("exit")),
-            "help": entry.get("help", ""),
+            "help": own_help,
             "variant_count": (len(variants) + 1) if variants else 0,
         }
     return projection

--- a/tests/core/test_netmiko_init_compat.py
+++ b/tests/core/test_netmiko_init_compat.py
@@ -204,6 +204,14 @@ def _classify_callable_commands(
     """
     initial_prompt = nos.initial_prompt.format(base_prompt=base_prompt)
     enable_prompt = (nos.enable_prompt or "").format(base_prompt=base_prompt)
+    # Rendered prompt -> canonical mode name, so callables get the `current_mode`
+    # their (now mode-based) branches need (#264): a dict-returning callable such
+    # as make_exit raises on an unknown mode, so the probe must pass a valid one.
+    mode_by_prompt = {initial_prompt: "user"}
+    if enable_prompt:
+        mode_by_prompt[enable_prompt] = "enable"
+    if nos.config_prompt:
+        mode_by_prompt[nos.config_prompt.format(base_prompt=base_prompt)] = "config"
 
     initial_cmds: list[tuple[str, str]] = []
     enable_cmds: list[tuple[str, str]] = []
@@ -216,20 +224,33 @@ def _classify_callable_commands(
         prompts = [prompts] if isinstance(prompts, str) else (prompts or [])
         formatted = [p.format(base_prompt=base_prompt) for p in prompts]
         if initial_prompt in formatted:
-            current_prompt, bucket = initial_prompt, initial_cmds
+            current_prompt, current_mode, bucket = initial_prompt, "user", initial_cmds
         elif enable_prompt and enable_prompt in formatted:
-            current_prompt, bucket = enable_prompt, enable_cmds
+            current_prompt, current_mode, bucket = enable_prompt, "enable", enable_cmds
         else:
             # Outside the sweep phases. Probe with the command's own
             # declared prompt to apply the eligibility contract: a dict
             # return means mode/exit logic (unit-test scope at any
             # prompt); only a str return here is real e2e coverage loss.
             probe_prompt = formatted[0] if formatted else initial_prompt
-            probe = output(nos.device, base_prompt=base_prompt, current_prompt=probe_prompt, command=cmd_name)
+            probe_mode = mode_by_prompt.get(probe_prompt, "user")
+            probe = output(
+                nos.device,
+                base_prompt=base_prompt,
+                current_mode=probe_mode,
+                current_prompt=probe_prompt,
+                command=cmd_name,
+            )
             if isinstance(probe, str):
                 unclassified.append(cmd_name)
             continue
-        expected = output(nos.device, base_prompt=base_prompt, current_prompt=current_prompt, command=cmd_name)
+        expected = output(
+            nos.device,
+            base_prompt=base_prompt,
+            current_mode=current_mode,
+            current_prompt=current_prompt,
+            command=cmd_name,
+        )
         if not isinstance(expected, str):
             continue  # dict-returning mode/exit callables -> unit tests cover these
         bucket.append((cmd_name, expected))

--- a/tests/core/test_resolved_command.py
+++ b/tests/core/test_resolved_command.py
@@ -1,0 +1,110 @@
+"""Unit tests for the runtime command representation (#264 / P1-1 D4).
+
+Covers the `str.format` -> jinja2 converter (exactness vs v2 and its loud
+boundary) and `ResolvedOutput.render` per kind.
+"""
+
+import pytest
+
+from simnos.core.resolved_command import (
+    ResolvedOutput,
+    compile_template,
+    format_template_to_jinja,
+)
+
+
+class TestFormatTemplateToJinja:
+    """`format_template_to_jinja` must match `str.format` for legacy forms."""
+
+    @pytest.mark.parametrize(
+        "template",
+        [
+            "plain text",
+            "hostname {base_prompt}",
+            "{base_prompt} uptime is 1 day",
+            "a {{ b }} literal",
+            "={{RA, Tunnel, }}",
+            "line1\nline2\n",
+            "{base_prompt}>",
+            "{base_prompt}(config)#",
+            "Hostname: {base_prompt}\nFQDN:     {base_prompt}",
+            "{{base_prompt}}",
+            'JSON {{"k": 1}} end',
+            "",
+        ],
+    )
+    def test_render_matches_str_format(self, template):
+        """The compiled jinja template renders identically to `str.format`."""
+        base_prompt = "R1-device"
+        jinja_source, _ = format_template_to_jinja(template)
+        compiled, _ = compile_template(jinja_source)
+        assert compiled.render(base_prompt=base_prompt) == template.format(base_prompt=base_prompt)
+
+    def test_has_field_flag(self):
+        """`has_base_prompt` reflects whether a `{base_prompt}` field is present."""
+        _, has = format_template_to_jinja("hostname {base_prompt}")
+        assert has is True
+        _, has = format_template_to_jinja("a {{ b }} literal")
+        assert has is False
+
+    @pytest.mark.parametrize(
+        "bad",
+        [
+            "value is {unknown}",  # unsupported field
+            "pos {}",  # positional field
+            "idx {0}",  # numbered field
+            "spec {base_prompt:>5}",  # format spec
+            "conv {base_prompt!r}",  # conversion
+            "unbalanced {broken",  # malformed brace
+        ],
+    )
+    def test_loud_on_unsupported_or_malformed(self, bad):
+        """Unsupported fields / malformed braces raise (the #162 loud boundary)."""
+        with pytest.raises(ValueError):
+            format_template_to_jinja(bad)
+
+    def test_endraw_injection_guarded(self):
+        """A literal carrying a jinja raw-block delimiter raises, not silently breaks.
+
+        The escaped form ``{{% endraw %}}`` collapses (under `str.format`) to a
+        literal ``{% endraw %}``, the one sequence that could break out of the
+        ``{% raw %}`` wrapping — guarded loudly.
+        """
+        with pytest.raises(ValueError, match="raw-block"):
+            format_template_to_jinja("text {{% endraw %}} more")
+
+
+class TestCompileTemplate:
+    """`compile_template` extracts host facts, excluding `base_prompt`."""
+
+    def test_base_prompt_excluded_from_required_vars(self):
+        """`base_prompt` is shell-supplied, never a required host fact (#265)."""
+        _, required = compile_template("{{ base_prompt }}>")
+        assert required == frozenset()
+
+    def test_other_vars_kept_as_required(self):
+        """Non-`base_prompt` template vars are kept for #265 host-facts checking."""
+        _, required = compile_template("{{ base_prompt }} {{ hostname }} {{ serial }}")
+        assert required == frozenset({"hostname", "serial"})
+
+
+class TestResolvedOutputRender:
+    """`ResolvedOutput.render` per kind."""
+
+    def test_literal_returns_text(self):
+        out = ResolvedOutput(kind="literal", text="static body")
+        assert out.render("bp") == "static body"
+
+    def test_none_returns_none(self):
+        out = ResolvedOutput(kind="none")
+        assert out.render("bp") is None
+
+    def test_template_renders_with_base_prompt(self):
+        compiled, _ = compile_template("hostname {{ base_prompt }}")
+        out = ResolvedOutput(kind="template", template=compiled)
+        assert out.render("R7") == "hostname R7"
+
+    def test_handler_render_returns_none(self):
+        """Handler output is produced by the shell, not by `render`."""
+        out = ResolvedOutput(kind="handler", handler=lambda device, **kw: "x")
+        assert out.render("bp") is None

--- a/tests/core/test_resolved_command.py
+++ b/tests/core/test_resolved_command.py
@@ -73,6 +73,18 @@ class TestFormatTemplateToJinja:
         with pytest.raises(ValueError, match="raw-block"):
             format_template_to_jinja("text {{% endraw %}} more")
 
+    def test_plain_endraw_word_is_allowed(self):
+        """The bare word ``endraw`` (no jinja delimiters) is valid literal output.
+
+        Guards against the over-broad substring check (1st round codex #2 /
+        claude #4a): real CLI output can contain the word without the
+        ``{% endraw %}`` delimiters.
+        """
+        source, has = format_template_to_jinja("status: endraw counter not reset")
+        compiled, _ = compile_template(source)
+        assert has is False
+        assert compiled.render(base_prompt="x") == "status: endraw counter not reset"
+
 
 class TestCompileTemplate:
     """`compile_template` extracts host facts, excluding `base_prompt`."""

--- a/tests/plugins/nos/device_helpers.py
+++ b/tests/plugins/nos/device_helpers.py
@@ -1,9 +1,9 @@
 """
 Shared helpers for the device-class unit tests in this package (T-14 / #230).
 
-Each test_<nos>.py invokes plugin callables with the same 4-arg contract
-as `cmd_shell.default` (device, base_prompt=, current_prompt=, command=);
-this module holds that invocation and the common base_prompt so the
+Each test_<nos>.py invokes plugin callables with the same contract as
+`cmd_shell.default` (device, base_prompt=, current_mode=, current_prompt=,
+command=); this module holds that invocation and the common base_prompt so the
 per-platform files stay focused on their pins.
 """
 
@@ -14,11 +14,16 @@ __all__ = ["BASE_PROMPT", "call_command"]
 BASE_PROMPT = "router"
 
 
-def call_command(nos: Nos, command: str, current_prompt: str, base_prompt: str = BASE_PROMPT):
-    """Invoke a callable command with the cmd_shell 4-arg contract."""
+def call_command(nos: Nos, command: str, current_mode: str, current_prompt: str = "", base_prompt: str = BASE_PROMPT):
+    """Invoke a callable command with the cmd_shell handler contract (#264).
+
+    Handlers branch on `current_mode` (the mode name); `current_prompt` (the
+    rendered prompt) is display-only and rarely used, so it defaults to blank.
+    """
     return nos.commands[command]["output"](
         nos.device,
         base_prompt=base_prompt,
+        current_mode=current_mode,
         current_prompt=current_prompt,
         command=command,
     )

--- a/tests/plugins/nos/test_arista_eos.py
+++ b/tests/plugins/nos/test_arista_eos.py
@@ -15,16 +15,7 @@ import pytest
 
 from simnos.core.nos import Nos
 from simnos.plugins.nos import nos_plugins
-from simnos.plugins.nos.platforms_py.arista_eos import (
-    CONFIG_PROMPT,
-    ENABLE_PROMPT,
-    INITIAL_PROMPT,
-)
 from tests.plugins.nos.device_helpers import BASE_PROMPT, call_command
-
-INITIAL = INITIAL_PROMPT.format(base_prompt=BASE_PROMPT)
-ENABLE = ENABLE_PROMPT.format(base_prompt=BASE_PROMPT)
-CONFIG = CONFIG_PROMPT.format(base_prompt=BASE_PROMPT)
 
 
 @pytest.fixture(scope="module")
@@ -40,20 +31,20 @@ def test_show_clock_format(nos):
     'Sat Apr 16 11:54:03 2022' (same shape as tests/core/test_netmiko.py
     pins for the test-asset show clock).
     """
-    out = call_command(nos, "show clock", ENABLE)
+    out = call_command(nos, "show clock", "enable")
     assert re.match(r"^\w{3} \w{3} \d{2} \d{2}:\d{2}:\d{2} \d{4}$", out.splitlines()[0])
     assert "Timezone: UTC" in out
     assert "Clock source: local" in out
 
 
 def test_show_version_content(nos):
-    out = call_command(nos, "show version", ENABLE)
+    out = call_command(nos, "show version", "enable")
     assert "cEOSLab" in out
     assert "{" not in out
 
 
 def test_show_running_config_content(nos):
-    out = call_command(nos, "show running-config", ENABLE)
+    out = call_command(nos, "show running-config", "enable")
     assert f"hostname {BASE_PROMPT}" in out  # {{base_prompt}} resolved
     assert "{" not in out
 
@@ -61,24 +52,24 @@ def test_show_running_config_content(nos):
 @pytest.mark.parametrize("command", ["show ip int brief", "show ip interface brief"])
 def test_show_ip_int_brief_content(nos, command):
     """Both spellings are distinct entries backed by the same make_show_ip_int_br."""
-    out = call_command(nos, command, ENABLE)
+    out = call_command(nos, command, "enable")
     assert "Interface" in out
     assert "Ethernet1" in out
     assert "{" not in out
 
 
 class TestMakeExit:
-    """Pin the per-prompt branches of the dict-returning `make_exit`."""
+    """Pin the per-mode branches of the dict-returning `make_exit` (#264)."""
 
-    def test_initial_prompt_exits(self, nos):
-        assert call_command(nos, "exit", INITIAL) == {"exit": True}
+    def test_user_mode_exits(self, nos):
+        assert call_command(nos, "exit", "user") == {"exit": True}
 
-    def test_enable_prompt_exits(self, nos):
-        assert call_command(nos, "exit", ENABLE) == {"exit": True}
+    def test_enable_mode_exits(self, nos):
+        assert call_command(nos, "exit", "enable") == {"exit": True}
 
-    def test_config_prompt_drops_to_enable(self, nos):
-        assert call_command(nos, "exit", CONFIG) == {"output": "", "new_prompt": ENABLE_PROMPT}
+    def test_config_mode_drops_to_enable(self, nos):
+        assert call_command(nos, "exit", "config") == {"output": "", "new_mode": "enable"}
 
-    def test_unknown_prompt_raises(self, nos):
-        with pytest.raises(RuntimeError, match=r"make_exit does not know how to handle 'bogus\$' prompt"):
-            call_command(nos, "exit", "bogus$")
+    def test_unknown_mode_raises(self, nos):
+        with pytest.raises(RuntimeError, match=r"make_exit does not know how to handle 'bogus' mode"):
+            call_command(nos, "exit", "bogus")

--- a/tests/plugins/nos/test_cisco_ios.py
+++ b/tests/plugins/nos/test_cisco_ios.py
@@ -15,10 +15,7 @@ import pytest
 
 from simnos.core.nos import Nos
 from simnos.plugins.nos import nos_plugins
-from simnos.plugins.nos.platforms_py.cisco_ios import ENABLE_PROMPT
 from tests.plugins.nos.device_helpers import BASE_PROMPT, call_command
-
-ENABLE = ENABLE_PROMPT.format(base_prompt=BASE_PROMPT)
 
 
 @pytest.fixture(scope="module")
@@ -32,18 +29,18 @@ def test_show_clock_format(nos):
 
     Example: '*11:54:03.000 UTC Sat Apr 16 2022'.
     """
-    out = call_command(nos, "show clock", ENABLE)
+    out = call_command(nos, "show clock", "enable")
     assert re.match(r"^\*\d{2}:\d{2}:\d{2}\.000 .+ \d{4}$", out)
 
 
 def test_show_version_content(nos):
-    out = call_command(nos, "show version", ENABLE)
+    out = call_command(nos, "show version", "enable")
     assert "Cisco IOS XE Software" in out
     assert f"{BASE_PROMPT} uptime is" in out  # {{base_prompt}} resolved
     assert "{" not in out  # no unresolved placeholder survives rendering
 
 
 def test_show_running_config_content(nos):
-    out = call_command(nos, "show running-config", ENABLE)
+    out = call_command(nos, "show running-config", "enable")
     assert f"hostname {BASE_PROMPT}" in out
     assert "{" not in out

--- a/tests/plugins/nos/test_huawei_smartax.py
+++ b/tests/plugins/nos/test_huawei_smartax.py
@@ -13,11 +13,7 @@ import pytest
 
 from simnos.core.nos import Nos
 from simnos.plugins.nos import nos_plugins
-from simnos.plugins.nos.platforms_py.huawei_smartax import ENABLE_PROMPT, INITIAL_PROMPT
-from tests.plugins.nos.device_helpers import BASE_PROMPT, call_command
-
-INITIAL = INITIAL_PROMPT.format(base_prompt=BASE_PROMPT)
-ENABLE = ENABLE_PROMPT.format(base_prompt=BASE_PROMPT)
+from tests.plugins.nos.device_helpers import call_command
 
 
 @pytest.fixture(scope="module")
@@ -38,7 +34,7 @@ def test_default_configuration_provides_boards(nos):
 
 
 def test_display_board_table_structure(nos):
-    out = call_command(nos, "display board", INITIAL)
+    out = call_command(nos, "display board", "user")
     lines = out.splitlines()
     header_lines = [line for line in lines if "SlotID" in line]
     assert len(header_lines) == 1
@@ -55,29 +51,30 @@ def test_display_board_table_structure(nos):
 
 
 class TestModeCallables:
-    """Pin the per-prompt branches of the dict-returning mode callables.
+    """Pin the per-mode branches of the dict-returning mode callables (#264).
 
-    The branches dispatch on the current_prompt *suffix* ('>' / '#' /
-    other), so 'bogus$' exercises the fallback branch.
+    The branches dispatch on `current_mode`: `_return` keeps user but sends
+    enable/config to enable; `disable` drops enable/config to user and is a
+    no-op (no transition) in user mode.
     """
 
-    def test_return_from_initial_prompt(self, nos):
-        assert call_command(nos, "return", INITIAL) == {"output": "", "new_prompt": INITIAL_PROMPT}
+    def test_return_from_user_mode(self, nos):
+        assert call_command(nos, "return", "user") == {"output": "", "new_mode": "user"}
 
-    def test_return_from_enable_prompt(self, nos):
-        assert call_command(nos, "return", ENABLE) == {"output": "", "new_prompt": ENABLE_PROMPT}
+    def test_return_from_enable_mode(self, nos):
+        assert call_command(nos, "return", "enable") == {"output": "", "new_mode": "enable"}
 
-    def test_return_from_other_prompt(self, nos):
-        assert call_command(nos, "return", "bogus$") == {"output": "", "new_prompt": INITIAL_PROMPT}
+    def test_return_from_config_mode(self, nos):
+        assert call_command(nos, "return", "config") == {"output": "", "new_mode": "enable"}
 
-    def test_disable_from_enable_prompt(self, nos):
-        assert call_command(nos, "disable", ENABLE) == {"output": "", "new_prompt": INITIAL_PROMPT}
+    def test_disable_from_enable_mode(self, nos):
+        assert call_command(nos, "disable", "enable") == {"output": "", "new_mode": "user"}
 
-    def test_disable_from_other_prompt_keeps_prompt(self, nos):
-        assert call_command(nos, "disable", "bogus$") == {"output": "", "new_prompt": "bogus$"}
+    def test_disable_from_user_mode_no_transition(self, nos):
+        assert call_command(nos, "disable", "user") == {"output": ""}
 
     def test_quit_exits(self, nos):
-        assert call_command(nos, "quit", INITIAL) == {"exit": True}
+        assert call_command(nos, "quit", "user") == {"exit": True}
 
 
 class TestAddWhitespaces:

--- a/tests/plugins/test_cmd_shell.py
+++ b/tests/plugins/test_cmd_shell.py
@@ -215,6 +215,23 @@ class TestCmdShell(TestCase):
         ]
         writeline.assert_called_once_with("\r\n".join(expected_output))
 
+    def test_do_help_alias_hidden_outside_target_modes(self):
+        """do_help lists a prompt-less alias only in its target modes (#264 / claude #2).
+
+        Intentional refinement over v2 (which listed prompt-less aliases in
+        every mode via the raw unmerged entry): `sh clock` aliases `show clock`
+        (modes user/enable), so it is listed in user mode but hidden in config.
+        Dispatch was already mode-scoped in v2; only the help listing changes.
+        """
+        shell = CMDShell(**self.arguments)  # current_mode == "user"
+        writeline = set_attr(shell, "writeline", Mock())
+        shell.do_help("")
+        self.assertIn("sh clock", writeline.call_args[0][0])
+        shell.current_mode = "config"
+        writeline.reset_mock()
+        shell.do_help("")
+        self.assertNotIn("sh clock", writeline.call_args[0][0])
+
     def test__in_current_mode_empty_modes_always_visible(self):
         """A command with no declared modes is valid in every mode (#264 / D5).
 
@@ -317,6 +334,34 @@ class TestCmdShell(TestCase):
         self.assertEqual(shell.current_mode, "user")  # unchanged
         self.assertTrue(any("unknown mode 'nope'" in msg for msg in captured.output))
         writeline.assert_called_once_with("body")
+
+    def test_default_static_new_mode_wins_over_handler(self):
+        """A command's static new_mode overrides a handler-returned one (#264 / claude #8).
+
+        Replicates v2's write order (handler new_prompt applied first, the
+        command's own new_prompt last): when a command declares new_mode AND
+        its handler returns a different one, the static one is the final state.
+        """
+        self.arguments["is_running"].set()
+        self.arguments["nos"] = Nos(
+            dict_args={
+                "name": "synth",
+                "initial_prompt": "{base_prompt}>",
+                "enable_prompt": "{base_prompt}#",
+                "config_prompt": "{base_prompt}(config)#",
+                "commands": {
+                    "cmd": {
+                        "output": lambda device, **kwargs: {"output": "", "new_mode": "config"},
+                        "new_prompt": "{base_prompt}#",  # static -> enable, wins
+                        "prompt": "{base_prompt}>",
+                    },
+                },
+            }
+        )
+        shell = CMDShell(**self.arguments)
+        set_attr(shell, "writeline", Mock())
+        shell.default("cmd")
+        self.assertEqual(shell.current_mode, "enable")  # static new_mode, not handler's "config"
 
     def test_default_callable_dict_exit(self):
         """Callable dict with exit=True signals shell termination."""
@@ -718,6 +763,31 @@ class HotReloadTest(TestCase):
         self.assertEqual(len(captured.output), 1)
         self.assertIn("broken.yaml", captured.output[0])
         self.assertIn("healthy", shell.commands)
+
+    def test_reload_commands_adapter_failure_rolls_back_and_unblocks_rest(self):
+        """A file that loads but fails normalization is rolled back from nos (#264 / codex #1).
+
+        `from_file` commits to `self.nos` before `_rebuild` validates via the
+        adapter, so a canonical-外 prompt that passes the legacy schema but
+        fails normalization would, without rollback, persist in `nos.commands`
+        and re-fail every later file in the batch. The per-file rollback must
+        drop it so a following healthy file still applies.
+        """
+        shell = CMDShell(**self.arguments)
+
+        def fake_from_file(filename):
+            if filename == "bad.yaml":
+                # passes pydantic, fails the adapter (no mode renders to this)
+                shell.nos.commands["bad cmd"] = {"output": "x", "prompt": "{base_prompt}ALIEN>"}
+            else:
+                shell.nos.commands["good cmd"] = {"output": "ok", "prompt": "{base_prompt}>"}
+
+        set_attr(shell.nos, "from_file", Mock(side_effect=fake_from_file))
+        with self.assertLogs("simnos.plugins.shell.cmd_shell", level="ERROR") as captured:
+            shell.reload_commands(["bad.yaml", "good.yaml"])
+        self.assertEqual(len(captured.output), 1)  # only the bad file
+        self.assertNotIn("bad cmd", shell.nos.commands)  # rolled back, not poisoning the batch
+        self.assertIn("good cmd", shell.commands)  # the healthy file still applied
 
     def test_reload_commands_broken_file_last_still_applies_rest(self):
         """The per-file guard is order-independent: broken file last.

--- a/tests/plugins/test_cmd_shell.py
+++ b/tests/plugins/test_cmd_shell.py
@@ -338,10 +338,9 @@ class TestCmdShell(TestCase):
     def _make_prompt_form_shell(self, prompt_value):
         """Build a shell whose 'cmd' command uses the given `prompt` authoring form.
 
-        Both a bare str and a list are valid authoring sugar for `prompt`
-        (#244 / P-12c); these pins guard that the two forms keep
-        dispatching identically across the load-path normalization
-        (str -> [str] inside `Nos`).
+        Both a bare str and a list are valid authoring sugar for `prompt`;
+        these pins guard that the two forms resolve to the same mode set and
+        dispatch identically through the adapter (#264 / D6).
         """
         self.arguments["is_running"].set()
         self.arguments["nos"] = Nos(
@@ -362,7 +361,7 @@ class TestCmdShell(TestCase):
         return shell
 
     def test_default_prompt_str_authoring_dispatches(self):
-        """A bare-str `prompt` matches the current prompt and dispatches."""
+        """A bare-str `prompt` resolves to the current mode and dispatches."""
         shell = self._make_prompt_form_shell("{base_prompt}>")
         writeline = set_attr(shell, "writeline", Mock())
         stop = shell.default("cmd")
@@ -370,21 +369,19 @@ class TestCmdShell(TestCase):
         writeline.assert_called_once_with("form ok")
 
     def test_default_prompt_list_authoring_dispatches(self):
-        """A list `prompt` matches the current prompt and dispatches."""
+        """A list `prompt` resolves to a mode set including the current mode."""
         shell = self._make_prompt_form_shell(["{base_prompt}>", "{base_prompt}#"])
         writeline = set_attr(shell, "writeline", Mock())
         stop = shell.default("cmd")
         self.assertFalse(stop)
         writeline.assert_called_once_with("form ok")
 
-    def test_inventory_commands_prompt_str_is_normalized_and_dispatches(self):
-        """Inventory-defined commands get the same str -> [str] normalization.
+    def test_inventory_commands_resolve_through_adapter_and_dispatch(self):
+        """Inventory-defined commands are normalized through the adapter too.
 
-        Pins the third commands inflow (#244 / D3, found during
-        implementation): `nos_inventory_config["commands"]` bypasses the
-        `Nos` load path, so the shell normalizes it at init — without
-        this, a bare-str prompt would be iterated char by char after the
-        read-side isinstance branch removal (a silent never-match).
+        Pins the third commands inflow (#264 / D6): `nos_inventory_config
+        ["commands"]` is merged and adapted at shell (re)build like the BASIC
+        and NOS inflows, so its prompt resolves to a mode set and dispatches.
         """
         self.arguments["is_running"].set()
         self.arguments["nos_inventory_config"] = {
@@ -605,15 +602,11 @@ class TestCmdShell(TestCase):
         self.assertIn("Traceback", captured.output[0])
 
     def test_default_callable_dict_output_passed_through_unformatted(self):
-        """Callable-dict output skips `_safe_format` entirely (#241 / D-b).
+        """Callable-dict output is written verbatim, never re-rendered (#241 / D-b).
 
-        New contract pin (rewritten from the pre-#241 raw-fallback pin):
-        handlers format themselves, so brace-containing device output is
-        written verbatim — no format attempt, hence **no error log**
-        (the old chain logged a FORMAT_ERRORS failure before falling back
-        to the same raw string). The skip applies to dict output exactly
-        like str returns: the flag is set at invoke time, not by return
-        shape.
+        Handlers render themselves, so brace-containing device output reaches
+        the wire untouched — the shell applies no template step to handler
+        output, hence **no error log**. Holds for dict and str returns alike.
         """
         shell = self._make_callable_dict_shell(lambda device, **kwargs: {"output": "value is {base_prompt.foo}"})
         writeline = set_attr(shell, "writeline", Mock())
@@ -623,12 +616,11 @@ class TestCmdShell(TestCase):
         writeline.assert_called_once_with("value is {base_prompt.foo}")
 
     def test_default_callable_str_output_passed_through_unformatted(self):
-        """Callable str output skips `_safe_format` too (#241 / D-b).
+        """Callable str output is written verbatim too (#241 / D-b).
 
         The str-return twin of the dict pin above: literal braces in a
         handler's rendered output (e.g. JSON-ish device output) reach the
-        wire untouched instead of tripping FORMAT_ERRORS into a logged
-        raw fallback.
+        wire untouched, with no render step and no error log.
         """
         shell = self._make_callable_dict_shell(lambda device, **kwargs: "literal {brace} stays")
         writeline = set_attr(shell, "writeline", Mock())
@@ -637,15 +629,19 @@ class TestCmdShell(TestCase):
         self.assertFalse(stop)
         writeline.assert_called_once_with("literal {brace} stays")
 
-    def test_default_command_new_prompt(self):
-        """Test that the default method does nothing."""
+    def test_default_command_transitions_mode(self):
+        """A command with a new_mode transitions the shell and re-renders the prompt.
+
+        `enable` (yaml_nos) declares new_mode=enable; dispatching it from the
+        initial user mode moves current_mode to enable and the prompt to
+        "test#" (the enable prompt rendered at base_prompt "test").
+        """
         self.arguments["is_running"].set()
         shell = CMDShell(**self.arguments)
-        # writeline guard only (stdout is None); this test asserts on prompt,
-        # not on the mock (return unused → bare set_attr).
-        set_attr(shell, "writeline", Mock())
+        set_attr(shell, "writeline", Mock())  # stdout is None; guard only
         shell.default("enable")
-        shell.prompt = "test#"
+        self.assertEqual(shell.current_mode, "enable")
+        self.assertEqual(shell.prompt, "test#")
 
     def test_default_command_exit(self):
         """Test that the default method does nothing."""

--- a/tests/plugins/test_cmd_shell.py
+++ b/tests/plugins/test_cmd_shell.py
@@ -125,13 +125,13 @@ class TestCmdShell(TestCase):
                 base_prompt="test",
             )
 
-    def test_init_broken_initial_prompt_falls_back_to_raw(self):
-        """A malformed initial_prompt template must not crash construction.
+    def test_init_broken_initial_prompt_is_loud(self):
+        """A malformed initial_prompt template now fails loudly at construction.
 
-        Pins #172: `__init__` used to call `.format()` unguarded, so a
-        broken template killed every connection to the host. The lenient
-        fallback keeps the session usable (raw template as prompt) and
-        logs the error for diagnosis.
+        Inverts the old #172 lenient fallback: prompt templates are load-time
+        validated (#264 / D5), so a broken one (`{base_prompt.foo}>` — an
+        unsupported attribute access) raises in the adapter via `_rebuild`
+        instead of degrading to a raw-template prompt.
         """
         self.arguments["nos"] = Nos(
             dict_args={
@@ -140,11 +140,8 @@ class TestCmdShell(TestCase):
                 "commands": {"_default_": {"output": "% Unknown", "help": "default"}},
             }
         )
-        with self.assertLogs("simnos.plugins.shell.cmd_shell", level="ERROR") as captured:
-            shell = CMDShell(**self.arguments)
-        self.assertEqual(shell.prompt, "{base_prompt.foo}>")
-        self.assertEqual(len(captured.output), 1)
-        self.assertTrue(any("error formatting initial_prompt" in msg for msg in captured.output))
+        with self.assertRaises(ValueError):
+            CMDShell(**self.arguments)
 
     def test_start(self):
         """Test that the start method calls cmdloop."""
@@ -218,41 +215,32 @@ class TestCmdShell(TestCase):
         ]
         writeline.assert_called_once_with("\r\n".join(expected_output))
 
-    def test__check_prompt_is_none(self):
-        """Test that the _check_prompt method returns the prompt."""
-        shell = CMDShell(**self.arguments)
-        # pylint: disable=protected-access
-        self.assertTrue(shell._check_prompt(None))
+    def test__in_current_mode_empty_modes_always_visible(self):
+        """A command with no declared modes is valid in every mode (#264 / D5).
 
-    def test__check_prompt_str_is_normalized_before_reaching_here(self):
-        """A bare-str prompt never reaches `_check_prompt` at runtime.
-
-        Pins the lists-only read-side contract (#244 / D3): every load
-        path (yaml/py via `Nos`, inventory commands at shell init)
-        normalizes str -> [str] before commit, so the str branch was
-        removed here. The authoring sugar itself is covered end-to-end by
-        test_default_prompt_str_authoring_dispatches.
+        Successor of the old `_check_prompt(None) -> True`: a command whose
+        authoring omitted `prompt` resolves to an empty mode set, which the
+        engine treats as "valid everywhere" (BASIC `exit` is such a command).
         """
-        self.arguments["is_running"].set()
         shell = CMDShell(**self.arguments)
-        # yaml_nos.yaml authors prompts as bare strings; the shell must
-        # see them as lists after the load-path normalization.
-        prompt = shell.commands["show clock"]["prompt"]
-        self.assertIsInstance(prompt, list)
+        self.assertEqual(shell.commands["exit"].modes, frozenset())
+        self.assertTrue(shell._in_current_mode(shell.commands["exit"]))
+        shell.current_mode = "config"
+        self.assertTrue(shell._in_current_mode(shell.commands["exit"]))
 
-    def test__check_prompt_is_list(self):
-        """Test that the _check_prompt method returns the prompt."""
-        shell = CMDShell(**self.arguments)
-        # pylint: disable=protected-access
-        self.assertTrue(shell._check_prompt(["{base_prompt}>"]))
+    def test__in_current_mode_membership(self):
+        """A command is visible only in the modes it declares (#264 / D5).
 
-    def test__check_prompt_is_not_prompt(self):
-        """Test that the _check_prompt method returns False."""
-        shell = CMDShell(**self.arguments)
-        # pylint: disable=protected-access
-        # list form (the read-side contract is lists-only, #244/D3); formats to
-        # "test" which does not match the current prompt "test>", so -> False.
-        self.assertFalse(shell._check_prompt(["{base_prompt}"]))
+        Replaces the `_check_prompt` string-match unit: `show clock`
+        (authored for the user/enable prompts) is visible in those modes and
+        hidden in config.
+        """
+        shell = CMDShell(**self.arguments)  # current_mode == "user"
+        clock = shell.commands["show clock"]
+        self.assertEqual(clock.modes, frozenset({"user", "enable"}))
+        self.assertTrue(shell._in_current_mode(clock))
+        shell.current_mode = "config"
+        self.assertFalse(shell._in_current_mode(clock))
 
     def test_default_command_correct(self):
         """Test that the default method does nothing."""
@@ -282,44 +270,53 @@ class TestCmdShell(TestCase):
     def _make_callable_dict_shell(self, output_callable):
         """Build a shell whose 'cmd' command output is `output_callable`.
 
-        Consumer-side pins for the callable dispatch branch of
-        `default()` — originally the dict-returning cases (new_prompt
-        update / exit / output extraction, the counterpart of the
-        producer-side device-class tests in tests/plugins/nos/, T-14 /
-        #230), since #241 also the str-passthrough (D-b) and crash (D4)
-        pins. Plugin-loaded str returns are additionally covered by
-        test_default_command_is_function above.
+        Consumer-side pins for the handler dispatch branch of `default()` —
+        the dict-returning cases (new_mode transition / exit / output
+        extraction, the counterpart of the producer-side device-class tests
+        in tests/plugins/nos/, T-14 / #230), plus the str-passthrough (D-b)
+        and crash (D4) pins. The synthetic platform declares all three
+        canonical modes so handlers can transition (#264 / D5).
         """
         self.arguments["is_running"].set()
         self.arguments["nos"] = Nos(
             dict_args={
                 "name": "synth",
                 "initial_prompt": "{base_prompt}>",
+                "enable_prompt": "{base_prompt}#",
+                "config_prompt": "{base_prompt}(config)#",
                 "commands": {
                     "cmd": {
                         "output": output_callable,
                         "help": "dict-returning callable",
                         "prompt": "{base_prompt}>",
                     },
-                    "_default_": {
-                        "output": "% Unknown",
-                        "help": "default",
-                        "prompt": "{base_prompt}>",
-                    },
+                    "_default_": {"output": "% Unknown", "help": "default"},
                 },
             }
         )
         shell = CMDShell(**self.arguments)
         return shell
 
-    def test_default_callable_dict_new_prompt(self):
-        """Callable dict with new_prompt updates the prompt (formatted)."""
-        shell = self._make_callable_dict_shell(lambda device, **kwargs: {"output": "", "new_prompt": "{base_prompt}#"})
+    def test_default_callable_dict_new_mode(self):
+        """Callable dict with new_mode transitions the shell to that mode."""
+        shell = self._make_callable_dict_shell(lambda device, **kwargs: {"output": "", "new_mode": "enable"})
         writeline = set_attr(shell, "writeline", Mock())
         stop = shell.default("cmd")
         self.assertFalse(stop)
+        self.assertEqual(shell.current_mode, "enable")
         self.assertEqual(shell.prompt, "test#")
         writeline.assert_called_once_with("")
+
+    def test_default_callable_dict_unknown_new_mode_is_lenient(self):
+        """A handler returning an unknown mode logs and stays put (#264 / D5)."""
+        shell = self._make_callable_dict_shell(lambda device, **kwargs: {"output": "body", "new_mode": "nope"})
+        writeline = set_attr(shell, "writeline", Mock())
+        with self.assertLogs("simnos.plugins.shell.cmd_shell", level="ERROR") as captured:
+            stop = shell.default("cmd")
+        self.assertFalse(stop)
+        self.assertEqual(shell.current_mode, "user")  # unchanged
+        self.assertTrue(any("unknown mode 'nope'" in msg for msg in captured.output))
+        writeline.assert_called_once_with("body")
 
     def test_default_callable_dict_exit(self):
         """Callable dict with exit=True signals shell termination."""
@@ -351,6 +348,7 @@ class TestCmdShell(TestCase):
             dict_args={
                 "name": "synth",
                 "initial_prompt": "{base_prompt}>",
+                "enable_prompt": "{base_prompt}#",
                 "commands": {
                     "cmd": {
                         "output": "form ok",
@@ -400,7 +398,9 @@ class TestCmdShell(TestCase):
         }
         shell = CMDShell(**self.arguments)
         writeline = set_attr(shell, "writeline", Mock())
-        self.assertEqual(shell.commands["inv cmd"]["prompt"], ["{base_prompt}>"])
+        # The inventory command is normalized through the adapter like any
+        # inflow: its "{base_prompt}>" prompt resolves to the user mode.
+        self.assertEqual(shell.commands["inv cmd"].modes, frozenset({"user"}))
         stop = shell.default("inv cmd")
         self.assertFalse(stop)
         writeline.assert_called_once_with("inventory ok")
@@ -424,80 +424,62 @@ class TestCmdShell(TestCase):
     def test_default_alias_target_missing_falls_back_default(self):
         """An alias whose target command is gone degrades to `_default_`.
 
-        Pins #241 (G4/D4 例外境界): the alias-merge KeyError is a lenient
-        unknown-command path — it must answer with the `_default_` output
-        like any unknown command, never with the handler-crash response.
-        Guards the `_resolve_command` decomposition against widening the
-        exception boundary (1st design review 🦊 #2).
+        The adapter drops a broken alias at load (logged), so it never reaches
+        `self.commands`; typing it is then an unknown command answered with the
+        `_default_` output, never a handler-crash response (#264 / D6).
         """
         self.arguments["is_running"].set()
-        shell = CMDShell(**self.arguments)
+        with self.assertLogs("simnos.core.command_adapter", level="WARNING"):
+            self.arguments["nos"] = Nos(
+                dict_args={
+                    "name": "synth",
+                    "initial_prompt": "{base_prompt}>",
+                    "commands": {
+                        "broken alias": {"alias": "no such target"},
+                        "_default_": {"output": "% Invalid input", "help": "default"},
+                    },
+                }
+            )
+            shell = CMDShell(**self.arguments)
+        self.assertNotIn("broken alias", shell.commands)
         writeline = set_attr(shell, "writeline", Mock())
-        shell.commands["broken alias"] = {"alias": "no such target"}
         shell.default("broken alias")
-        writeline.assert_called_once_with("% Invalid input detected at '^' marker.")
+        writeline.assert_called_once_with("% Invalid input")
 
-    def test_resolve_command_unknown_returns_none(self):
-        """`_resolve_command` degrades an unknown command to None.
+    def test_invoke_handler_str_return_normalized(self):
+        """`_invoke_handler` wraps a str return into a CommandResult dict.
 
-        Unit pin for the #241 decomposition: the unknown-command KeyError
-        is consumed inside the helper so `default()` needs no try block
-        around resolution.
+        Pins the consumer-side normalization (#241/D2, #264): a plain str
+        return is sugar for `{"output": <str>}`, so the dispatch body only
+        ever consumes the dict form.
         """
         shell = CMDShell(**self.arguments)
-        # pylint: disable=protected-access
-        self.assertIsNone(shell._resolve_command("no such command"))
-
-    def test_resolve_command_alias_target_missing_returns_none(self):
-        """`_resolve_command` degrades a missing alias target to None.
-
-        Unit counterpart of test_default_alias_target_missing_falls_back
-        _default (#241): the alias-merge KeyError must stay inside the
-        helper, on the same lenient path as an unknown command.
-        """
-        shell = CMDShell(**self.arguments)
-        shell.commands["broken alias"] = {"alias": "no such target"}
-        # pylint: disable=protected-access
-        self.assertIsNone(shell._resolve_command("broken alias"))
-
-    def test_resolve_command_alias_merges_target(self):
-        """`_resolve_command` merges the alias target under the alias keys.
-
-        Pins the `{**commands[target], **cmd_data}` merge order (#241):
-        the alias entry's own keys win over the target's.
-        """
-        shell = CMDShell(**self.arguments)
-        # pylint: disable=protected-access
-        merged = shell._resolve_command("sh clock")
-        assert merged is not None
-        self.assertEqual(merged["output"], "*21:01:33.000 AET 01 01 01 2022")
-        self.assertEqual(merged["alias"], "show clock")
-
-    def test_invoke_callable_str_return_normalized(self):
-        """`_invoke_callable` wraps a str return into a CommandResult dict.
-
-        Pins the #241/D2 consumer-side normalization: a plain str return
-        is sugar for `{"output": <str>}`, so the dispatch body only ever
-        consumes the dict form.
-        """
-        shell = CMDShell(**self.arguments)
-        # pylint: disable=protected-access
-        result = shell._invoke_callable(lambda device, **kwargs: "body", "cmd")
+        result = shell._invoke_handler(lambda device, **kwargs: "body", "cmd")
         self.assertEqual(result, {"output": "body"})
 
-    def test_invoke_callable_none_return_normalized(self):
-        """`_invoke_callable` wraps a None return (= write nothing) too."""
+    def test_invoke_handler_none_return_normalized(self):
+        """`_invoke_handler` wraps a None return (= write nothing) too."""
         shell = CMDShell(**self.arguments)
-        # pylint: disable=protected-access
-        result = shell._invoke_callable(lambda device, **kwargs: None, "cmd")
+        result = shell._invoke_handler(lambda device, **kwargs: None, "cmd")
         self.assertEqual(result, {"output": None})
 
-    def test_invoke_callable_dict_return_passthrough(self):
-        """`_invoke_callable` passes a CommandResult dict through unchanged."""
+    def test_invoke_handler_dict_return_passthrough(self):
+        """`_invoke_handler` passes a CommandResult dict through unchanged."""
         shell = CMDShell(**self.arguments)
-        # pylint: disable=protected-access
-        result = shell._invoke_callable(lambda device, **kwargs: {"output": "x", "exit": True}, "cmd")
+        result = shell._invoke_handler(lambda device, **kwargs: {"output": "x", "exit": True}, "cmd")
         self.assertEqual(result, {"output": "x", "exit": True})
+
+    def test_invoke_handler_receives_current_mode(self):
+        """`_invoke_handler` passes the current mode name to the handler (#264)."""
+        shell = CMDShell(**self.arguments)
+        seen = {}
+
+        def handler(device, **kwargs):
+            seen.update(kwargs)
+            return "ok"
+
+        shell._invoke_handler(handler, "cmd")
+        self.assertEqual(seen["current_mode"], shell.current_mode)
 
     def _make_callable_default_shell(self):
         """Build a shell whose `_default_` output is a callable.
@@ -505,16 +487,15 @@ class TestCmdShell(TestCase):
         No shipped plugin has a callable `_default_` (yaml cannot express
         one; the py plugins use strings), but the Python API
         (`SimNOS(inventory=dict)`) can reach it — these pins fix the #241
-        unification: both the unknown-command and the prompt-mismatch
-        fallback invoke the callable through `_invoke_callable` (the old
-        code degraded to a fixed error string / leaked the function repr
-        respectively).
+        unification: both the unknown-command and the mode-mismatch fallback
+        invoke the callable through `_invoke_handler`.
         """
         self.arguments["is_running"].set()
         self.arguments["nos"] = Nos(
             dict_args={
                 "name": "synth",
                 "initial_prompt": "{base_prompt}>",
+                "enable_prompt": "{base_prompt}#",
                 "commands": {
                     "known": {
                         "output": "static",
@@ -539,35 +520,34 @@ class TestCmdShell(TestCase):
         self.assertFalse(stop)
         writeline.assert_called_once_with("dynamic unknown: nope")
 
-    def test_default_callable_default_invoked_on_prompt_mismatch(self):
-        """A prompt mismatch invokes a callable `_default_` (#241).
+    def test_default_callable_default_invoked_on_mode_mismatch(self):
+        """A mode mismatch invokes a callable `_default_` (#241 / #264).
 
-        The old code never invoked it on this path — `_safe_format`
-        swallowed the AttributeError and the function repr leaked to the
-        wire. The unification fixes that display bug.
+        `known` is enable-only; typed in user mode it misses, and the fallback
+        invokes the callable `_default_` through `_invoke_handler`.
         """
         shell = self._make_callable_default_shell()
         writeline = set_attr(shell, "writeline", Mock())
-        stop = shell.default("known")  # requires "test#", current prompt is "test>"
+        stop = shell.default("known")  # valid only in enable, current mode is user
         self.assertFalse(stop)
         writeline.assert_called_once_with("dynamic unknown: known")
 
     def test_default_callable_default_dict_return_gets_full_dispatch(self):
-        """A dict-returning callable `_default_` gets the same dispatch (#241).
+        """A dict-returning callable `_default_` gets the same dispatch (#241 / #264).
 
-        Pins that the unification is complete: a callable `_default_`
-        flows through `_invoke_callable` like any handler, so its dict
-        return's `new_prompt` (and `exit`) take effect. Unreachable in
-        the old code (the callable was never invoked on these paths).
+        Pins that the unification is complete: a callable `_default_` flows
+        through `_invoke_handler` like any handler, so its dict return's
+        `new_mode` (and `exit`) take effect.
         """
         self.arguments["is_running"].set()
         self.arguments["nos"] = Nos(
             dict_args={
                 "name": "synth",
                 "initial_prompt": "{base_prompt}>",
+                "enable_prompt": "{base_prompt}#",
                 "commands": {
                     "_default_": {
-                        "output": lambda device, **kwargs: {"output": "locked out", "new_prompt": "{base_prompt}#"},
+                        "output": lambda device, **kwargs: {"output": "locked out", "new_mode": "enable"},
                         "help": "dict-returning callable default",
                     },
                 },
@@ -577,6 +557,7 @@ class TestCmdShell(TestCase):
         writeline = set_attr(shell, "writeline", Mock())
         stop = shell.default("nope")
         self.assertFalse(stop)
+        self.assertEqual(shell.current_mode, "enable")
         self.assertEqual(shell.prompt, "test#")
         writeline.assert_called_once_with("locked out")
 
@@ -623,162 +604,6 @@ class TestCmdShell(TestCase):
         self.assertIn("RuntimeError: boom-for-log", captured.output[0])
         self.assertIn("Traceback", captured.output[0])
 
-    def test_default_silent_fallback_on_keyerror(self):
-        """`KeyError` failure mode of `.format()` is silently logged.
-
-        Pins #162: `cmd_shell.default()` is intentionally lenient about
-        yaml format errors (silent log + raw passthrough), in contrast
-        to `tasks.render_template` which raises `RuntimeError` at build
-        time. The runtime catch set is kept aligned with the build-time
-        counterpart at `(KeyError, IndexError, ValueError)`, so both
-        paths cover the same `str.format()` failure modes; only the
-        action (raise vs silent) differs.
-        """
-        self.arguments["is_running"].set()
-        shell = CMDShell(**self.arguments)
-        writeline = set_attr(shell, "writeline", Mock())
-        shell.commands["broken_key_cmd"] = {
-            "output": "value is {unknown_key}",
-            "prompt": ["{base_prompt}>"],
-        }
-        with self.assertLogs("simnos.plugins.shell.cmd_shell", level="ERROR") as captured:
-            shell.default("broken_key_cmd")
-        self.assertEqual(len(captured.output), 1)
-        self.assertTrue(any("error formatting output" in msg and "broken_key_cmd" in msg for msg in captured.output))
-        writeline.assert_called_once_with("value is {unknown_key}")
-
-    def test_default_silent_fallback_on_valueerror(self):
-        """`ValueError` failure mode of `.format()` is silently logged.
-
-        Pins #162: covers the malformed-brace path (a bare `{` with no
-        closing `}`). Same lenient-runtime contract as the `KeyError`
-        case — the catch set `(KeyError, IndexError, ValueError)`
-        mirrors `tasks.render_template`.
-        """
-        self.arguments["is_running"].set()
-        shell = CMDShell(**self.arguments)
-        writeline = set_attr(shell, "writeline", Mock())
-        shell.commands["broken_brace_cmd"] = {
-            "output": "value is {broken",
-            "prompt": ["{base_prompt}>"],
-        }
-        with self.assertLogs("simnos.plugins.shell.cmd_shell", level="ERROR") as captured:
-            shell.default("broken_brace_cmd")
-        self.assertEqual(len(captured.output), 1)
-        self.assertTrue(any("error formatting output" in msg and "broken_brace_cmd" in msg for msg in captured.output))
-        writeline.assert_called_once_with("value is {broken")
-
-    def test_default_silent_fallback_on_indexerror(self):
-        """`IndexError` failure mode of `.format()` is silently logged.
-
-        Pins #162: covers the positional-placeholder path (`{}` / `{N}`
-        against an empty positional-args tuple). Same lenient-runtime
-        contract as the other two cases; together the three tests pin
-        each member of the catch set `(KeyError, IndexError, ValueError)`
-        shared with `tasks.render_template`.
-        """
-        self.arguments["is_running"].set()
-        shell = CMDShell(**self.arguments)
-        writeline = set_attr(shell, "writeline", Mock())
-        shell.commands["broken_pos_cmd"] = {
-            "output": "value is {}",
-            "prompt": ["{base_prompt}>"],
-        }
-        with self.assertLogs("simnos.plugins.shell.cmd_shell", level="ERROR") as captured:
-            shell.default("broken_pos_cmd")
-        self.assertEqual(len(captured.output), 1)
-        self.assertTrue(any("error formatting output" in msg and "broken_pos_cmd" in msg for msg in captured.output))
-        writeline.assert_called_once_with("value is {}")
-
-    def test_default_silent_fallback_on_attributeerror(self):
-        """`AttributeError` failure mode of `.format()` is silently logged.
-
-        Pins #171: attribute access (`{base_prompt.foo}`) used to escape
-        the 3-tuple catch set — and the output format sits *outside* the
-        broad try block of `default()`, so this crashed the whole shell
-        session instead of just leaking a traceback. Now covered by the
-        shared 5-tuple `FORMAT_ERRORS`.
-        """
-        self.arguments["is_running"].set()
-        shell = CMDShell(**self.arguments)
-        writeline = set_attr(shell, "writeline", Mock())
-        shell.commands["broken_attr_cmd"] = {
-            "output": "value is {base_prompt.foo}",
-            "prompt": ["{base_prompt}>"],
-        }
-        with self.assertLogs("simnos.plugins.shell.cmd_shell", level="ERROR") as captured:
-            shell.default("broken_attr_cmd")
-        self.assertEqual(len(captured.output), 1)
-        self.assertTrue(any("error formatting output" in msg and "broken_attr_cmd" in msg for msg in captured.output))
-        writeline.assert_called_once_with("value is {base_prompt.foo}")
-
-    def test_default_silent_fallback_on_typeerror(self):
-        """`TypeError` failure mode of `.format()` is silently logged.
-
-        Pins #171: item access on the str argument (`{base_prompt[bad]}`)
-        raises `TypeError` ("string indices must be integers"), the fifth
-        and last member of `FORMAT_ERRORS`. Together the five fallback
-        tests pin every member of the catch set shared with
-        `tasks.render_template`.
-        """
-        self.arguments["is_running"].set()
-        shell = CMDShell(**self.arguments)
-        writeline = set_attr(shell, "writeline", Mock())
-        shell.commands["broken_item_cmd"] = {
-            "output": "value is {base_prompt[bad]}",
-            "prompt": ["{base_prompt}>"],
-        }
-        with self.assertLogs("simnos.plugins.shell.cmd_shell", level="ERROR") as captured:
-            shell.default("broken_item_cmd")
-        self.assertEqual(len(captured.output), 1)
-        self.assertTrue(any("error formatting output" in msg and "broken_item_cmd" in msg for msg in captured.output))
-        writeline.assert_called_once_with("value is {base_prompt[bad]}")
-
-    def test_default_new_prompt_format_failure_keeps_prompt(self):
-        """A broken cmd_data new_prompt does not transition the prompt.
-
-        Pins #172: the new_prompt format used to bubble into the broad
-        `except Exception`, leaking a traceback into the user output.
-        Now the failure is a silent log, the session stays on the current
-        prompt, and the command output is still written normally.
-        """
-        self.arguments["is_running"].set()
-        shell = CMDShell(**self.arguments)
-        writeline = set_attr(shell, "writeline", Mock())
-        shell.commands["broken_np_cmd"] = {
-            "output": "mode change attempted",
-            "prompt": ["{base_prompt}>"],
-            "new_prompt": "{base_prompt.foo}#",
-        }
-        with self.assertLogs("simnos.plugins.shell.cmd_shell", level="ERROR") as captured:
-            stop = shell.default("broken_np_cmd")
-        self.assertFalse(stop)
-        self.assertEqual(shell.prompt, "test>")
-        self.assertEqual(len(captured.output), 1)
-        self.assertTrue(any("error formatting new_prompt" in msg and "broken_np_cmd" in msg for msg in captured.output))
-        writeline.assert_called_once_with("mode change attempted")
-
-    def test_default_callable_dict_new_prompt_format_failure(self):
-        """A broken callable-dict new_prompt does not transition the prompt.
-
-        Pins #172 (callable dict path, symmetric to the cmd_data path
-        above): format failure is a silent log + no transition, and no
-        traceback reaches the wire. The callable's own exceptions are
-        out of scope here — they answer with HANDLER_ERROR_OUTPUT since
-        #241/D4 (see test_default_handler_crash_writes_fixed_error_line).
-        """
-        shell = self._make_callable_dict_shell(
-            lambda device, **kwargs: {"output": "body", "new_prompt": "{base_prompt.foo}#"}
-        )
-        writeline = set_attr(shell, "writeline", Mock())
-        with self.assertLogs("simnos.plugins.shell.cmd_shell", level="ERROR") as captured:
-            stop = shell.default("cmd")
-        self.assertFalse(stop)
-        self.assertEqual(shell.prompt, "test>")
-        self.assertEqual(len(captured.output), 1)
-        self.assertTrue(any("error formatting new_prompt" in msg and "'cmd'" in msg for msg in captured.output))
-        writeline.assert_called_once_with("body")
-
     def test_default_callable_dict_output_passed_through_unformatted(self):
         """Callable-dict output skips `_safe_format` entirely (#241 / D-b).
 
@@ -811,72 +636,6 @@ class TestCmdShell(TestCase):
             stop = shell.default("cmd")
         self.assertFalse(stop)
         writeline.assert_called_once_with("literal {brace} stays")
-
-    def test_default_broken_prompt_treated_as_non_match(self):
-        """A command with a broken prompt template is just unreachable.
-
-        Pins #172: `_check_prompt` used to leak the format error into the
-        broad `except Exception` (traceback in output). Now the broken
-        candidate is a logged non-match and the shell answers with the
-        unknown-command output, session intact.
-        """
-        self.arguments["is_running"].set()
-        shell = CMDShell(**self.arguments)
-        writeline = set_attr(shell, "writeline", Mock())
-        # Injected directly into shell.commands (bypassing the load
-        # paths), so the list form is used per the #244 / D3 contract.
-        shell.commands["broken_prompt_cmd"] = {
-            "output": "should not appear",
-            "prompt": ["{base_prompt.foo}>"],
-        }
-        with self.assertLogs("simnos.plugins.shell.cmd_shell", level="ERROR") as captured:
-            shell.default("broken_prompt_cmd")
-        self.assertEqual(len(captured.output), 1)
-        self.assertTrue(any("error formatting prompt" in msg and "broken_prompt_cmd" in msg for msg in captured.output))
-        writeline.assert_called_once_with("% Invalid input detected at '^' marker.")
-
-    def test_do_help_broken_prompt_command_hidden(self):
-        """`do_help` survives a broken prompt template (command hidden).
-
-        Pins #172: the `do_help` -> `_check_prompt` path had *no* guard at
-        all — a single broken prompt yaml crashed the session on `help`.
-        Now the broken command is silently omitted from the help listing.
-        """
-        self.arguments["is_running"].set()
-        shell = CMDShell(**self.arguments)
-        writeline = set_attr(shell, "writeline", Mock())
-        # Direct injection -> list form per the #244 / D3 contract.
-        shell.commands["broken_prompt_cmd"] = {
-            "output": "x",
-            "prompt": ["{base_prompt.foo}>"],
-            "help": "never listed",
-        }
-        with self.assertLogs("simnos.plugins.shell.cmd_shell", level="ERROR") as captured:
-            shell.do_help("")
-        self.assertEqual(len(captured.output), 1)
-        help_text = writeline.call_args[0][0]
-        self.assertNotIn("broken_prompt_cmd", help_text)
-        self.assertIn("show clock", help_text)  # healthy commands still listed
-
-    def test_default_list_prompt_partial_breakage_still_matches(self):
-        """A broken candidate in a prompt list does not poison the rest.
-
-        Pins the per-candidate independent evaluation of `_check_prompt`
-        (#172 design improvement): previously one broken element raised
-        out of the `any()` generator and failed the whole match; now the
-        healthy element still matches and the command works.
-        """
-        self.arguments["is_running"].set()
-        shell = CMDShell(**self.arguments)
-        writeline = set_attr(shell, "writeline", Mock())
-        shell.commands["partial_prompt_cmd"] = {
-            "output": "reached",
-            "prompt": ["{base_prompt.foo}>", "{base_prompt}>"],
-        }
-        with self.assertLogs("simnos.plugins.shell.cmd_shell", level="ERROR") as captured:
-            shell.default("partial_prompt_cmd")
-        self.assertEqual(len(captured.output), 1)  # the broken candidate, once
-        writeline.assert_called_once_with("reached")
 
     def test_default_command_new_prompt(self):
         """Test that the default method does nothing."""

--- a/tests/test_gen_docs_platform_commands.py
+++ b/tests/test_gen_docs_platform_commands.py
@@ -17,9 +17,11 @@ Also pin the sweep semantics so that deleting a yaml causes the matching
 markdown to be removed on the next regeneration, while hand-authored
 `index.md` / `index.ja.md` are preserved.
 
-Since #171/#172 the catch set is the 5-tuple `FORMAT_ERRORS` shared with
-the lenient runtime (`cmd_shell._safe_format`), and the platform-yaml
-template sweep below keeps the "build-time loud" side CI-resident.
+The catch set is the 5-tuple `FORMAT_ERRORS` local to
+`tasks.render_template` (the runtime shell dropped `str.format` /
+`_safe_format` in #264; this build-time docs path keeps reading the legacy
+yaml until PR-3), and the platform-yaml template sweep below keeps the
+"build-time loud" side CI-resident.
 """
 
 import os
@@ -38,7 +40,7 @@ def _yaml_platforms() -> list[str]:
 
 
 class TestRenderTemplate:
-    """Pin formatting semantics shared with `cmd_shell.default`."""
+    """Pin the build-time docs `str.format` semantics (tasks.render_template)."""
 
     def test_substitutes_base_prompt(self):
         """`{base_prompt}` must be replaced by the platform name."""
@@ -142,19 +144,17 @@ class TestRenderTemplate:
 
 
 class TestPlatformYamlTemplateSweep:
-    """CI-resident loud counterpart of the lenient runtime (#171/#172).
+    """CI-resident loud check over the legacy platform-yaml templates.
 
-    The runtime shell silently logs malformed `{base_prompt}` templates
-    (`cmd_shell._safe_format`), so a yaml authoring mistake in this repo
-    would otherwise surface only as a runtime log line. This sweep renders
-    every str template field of every platform yaml through
-    `render_template`, turning such a mistake into a contextual
-    RuntimeError in CI.
+    A malformed `{base_prompt}` template in a shipped yaml would surface late
+    (the legacy adapter loud-fails at load since #264, or v2 logged at
+    runtime). This sweep renders every str template field of every platform
+    yaml through the build-time `render_template`, turning such a mistake into
+    a contextual RuntimeError in CI.
 
     Covered fields: top-level initial_prompt / enable_prompt /
-    config_prompt (the latter two are not formatted by cmd_shell today,
-    but are written as `{base_prompt}` templates in yaml — covered
-    preventively) + per-command output (str only; callable outputs are
+    config_prompt (all written as `{base_prompt}` templates in yaml) +
+    per-command output (str only; callable outputs are
     covered by the T-14 / #230 device-class tests) / prompt (each list
     candidate gets an indexed field name like `prompt[0]`) / new_prompt.
     """


### PR DESCRIPTION
🐙claude:

## 概要

v3.0 epic #263 の P1-1(コマンドデータ層の A3 形式移行)の **PR-1 = runtime core**。
確定設計 `design/20260611_061730_..._issue-264-p1-1-command-data-layer-a3.md`(cross-review 2 round + final-refactor 済)に基づく。

**データは未移行のまま**、新しい runtime 表現とアダプタを導入し、旧 `platforms_yaml` / py-plugin / inventory の全 inflow を 1 semantics に正規化する。挙動等価(wire 出力 + mode 遷移)を保ったまま、`str.format` ベースの prompt 文字列照合エンジンを mode メンバシップエンジンへ置換する。

## スコープ(本 PR でやること)

| 増分 | 内容 |
|---|---|
| 1 | `core/resolved_command.py`: `ResolvedOutput`/`ResolvedCommand`/`ModeDef`/`ResolvedPlatform`(frozen dataclass)+ `str.format`→jinja2 厳密変換器 |
| 1 | `core/command_adapter.py`: 旧形式正規化 core(mode 合成・prompt→mode 逆引き・alias 1段 merge・output 正規化・`_default_` mode drop) |
| 2 | `tests/core/test_migration_oracle.py`: oracle (b')。v2 render semantics の凍結レプリカ投影 vs アダプタ投影を全 50 platform / 1,189 commands で全件照合(自己照合回避) |
| 3 | `plugins/shell/cmd_shell.py`: mode エンジン化(`_safe_format`/`_check_prompt`/`_resolve_command`/`_apply_new_prompt` 全廃 → `current_mode` membership + `new_mode` 遷移) |
| 3 | `core/command_contract.py`: handler 契約 `new_prompt`→`new_mode`、`current_mode` 引数追加 |
| 3 | py plugin 3 件(cisco_ios/arista_eos/huawei_smartax): handler の prompt 文字列分岐 → `current_mode` 分岐へ手動改修 |

## スコープ外(後続)

- A3 loader / authoring schema / 変換スクリプト / cisco_ios pilot 移行 → **PR-2**
- 全 49 platform 一括移行 + 旧 `platforms_yaml/` 削除 → **PR-3**
- platform 単位 cache(`functools.cache`)+ inventory 正規化を Host.start() 時 1 回へ → **PR-2**(per-connection `_rebuild` のコスト持ち越し、cross-review claude #7)
- facts スキーマ / host 文脈突合 → #265、inventory 刷新 / アダプタ正規化 core 削除 → #266

## 意図的な behavior 変更(挙動等価の例外、すべて文書化済)

1. **#162 silent fallback 廃止**: `str.format` 失敗テンプレートは旧 silent raw passthrough → **load 時 loud fail**。packaged データは oracle (b') で 0 件確認、踏み得るのは外部 inventory のみ。
2. **`prompt: []`(明示空リスト)を loud reject**: 旧は到達不能(常に False)、新では誤解を招く「全 mode 可」になり得るため reject(Decision 7 の `mode:[] reject` と対称)。
3. **do_help の alias 可視性**: own prompt 無 alias は resolved modes でのみ列挙(旧は raw entry で全 mode 列挙)。dispatch 挙動は不変、help 列挙のみ dispatch 可能性と一致する refinement。

## 検証

- **migration oracle (b')**: 全 50 platform / 1,189 commands で adapter 投影 == v2 凍結レプリカ投影(output splitlines wire 等価 + mode 可視性集合 + 遷移先 + exit/help/variant)。mutation で検出性確認済。
- **full suite**(`pytest tests/ -n auto`、docker 除く): **1,149 passed / 7 skipped / 1 xfailed**。netmiko integration 全 50 platform 疎通 + callable 出力 round-trip + hot-reload + docs gen を含む。
- ruff check + format / ty(whole project)green。
- (yamllint / lint-platform-yaml は本 PR で yaml を 0 変更のため対象外、CI 側で実行)

## レビュー履歴

cross-review 2 round(codex / gemini / claude、claude reviewer は Fable 5):
- 1st round(増分1)= SHOULD FIX → loud 境界対称化 / variants 契約確定 / endraw guard narrow 等 全取り込み
- 2nd round(増分2+3)= SHOULD FIX → hot-reload atomicity(snapshot/rollback)/ `prompt:[]` loud / handler 契約 doc 追随 等 全取り込み

net 行数: 旧 `str.format` 経路除去で **+1,542 / -687**(test 書き換え + 旧内部 API 削除込み)。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
