### PR TITLE
feat: A3 platform の dev hot-reload を実装 — dir rollup + ownership filter (#274)

### DIFF
--- a/simnos/plugins/shell/cmd_shell.py
+++ b/simnos/plugins/shell/cmd_shell.py
@@ -99,6 +99,12 @@ class CMDShell(Cmd):
         resolved_platform=None,
     ):
         self.nos: Nos = nos
+        # Platform name captured at build time for the hot-reload ownership filter
+        # (#264 #274 / D6). A later foreign py reload can overwrite live `nos.name`
+        # (`_from_module` commit phase), so the filter must compare against this
+        # frozen value, not `self.nos.name`, or a hijacked name would permanently
+        # skip this session's own A3 platform reload.
+        self._platform_name: str = nos.name
         self.ruler = ruler
         self.intro = intro
         self.base_prompt = base_prompt
@@ -183,9 +189,17 @@ class CMDShell(Cmd):
 
     # `Nos` state `from_file` mutates; snapshotted per reloaded file so a file
     # that loads but fails to normalize can be rolled back (2nd round codex #1).
-    _NOS_RELOAD_ATTRS = ("name", "initial_prompt", "enable_prompt", "config_prompt", "auth", "device")
+    _NOS_RELOAD_ATTRS = (
+        "name",
+        "initial_prompt",
+        "enable_prompt",
+        "config_prompt",
+        "auth",
+        "device",
+        "resolved_platform",
+    )
 
-    def reload_commands(self, changed_files: list):
+    def reload_commands(self, reload_targets: list):
         """Method to reload commands
 
         Lenient per file: hot reload is a dev feature and may observe a
@@ -205,13 +219,24 @@ class CMDShell(Cmd):
         The A3 platform parse is cached by `load_platform_dir`; drop that cache
         first so a reload re-reads the changed files instead of the stale parse
         (#264 / D6 cache bypass). No-op for legacy yaml/py reloads.
+
+        `reload_targets` are reload units (A3 platform dirs / `.py` modules), not
+        raw changed files (#274 / D1). A dir target for a *different* platform is
+        skipped (#274 / D6 ownership filter): the watcher sees the whole
+        `plugins/nos` tree, so without this a sibling platform's edit — or a
+        `git checkout` touching many platforms — would `_from_platform_dir`-replace
+        this session's `resolved_platform` and hijack it onto another NOS.
         """
         load_platform_dir.cache_clear()
-        for file in changed_files:
+        for target in reload_targets:
+            if os.path.isdir(target) and os.path.basename(target) != self._platform_name:
+                # Foreign A3 platform dir — not this session's platform. Skipping
+                # keeps a sibling edit / git checkout from hijacking the session.
+                continue
             snapshot_commands = dict(self.nos.commands)
             snapshot_attrs = {attr: getattr(self.nos, attr) for attr in self._NOS_RELOAD_ATTRS}
             try:
-                self.nos.from_file(file)
+                self.nos.from_file(target)
                 self._rebuild()
             except Exception:
                 # Broad except, like `default()`: any plugin error must not
@@ -221,16 +246,16 @@ class CMDShell(Cmd):
                 self.nos.commands = snapshot_commands
                 for attr, value in snapshot_attrs.items():
                     setattr(self.nos, attr, value)
-                log.error("shell '%s' failed to hot-reload %r\n%s", self.base_prompt, file, traceback.format_exc())
+                log.error("shell '%s' failed to hot-reload %r\n%s", self.base_prompt, target, traceback.format_exc())
                 continue
 
     def precmd(self, line):
         """Method to return line before processing the command"""
         if os.environ.get("SIMNOS_RELOAD_COMMANDS"):
-            changed_files = get_files_changed(nos.__path__[0])
-            if changed_files:
-                log.debug("Reloading... Files changed: %s", changed_files)
-                self.reload_commands(changed_files)
+            reload_targets = get_files_changed(nos.__path__[0])
+            if reload_targets:
+                log.debug("Reloading... Reload targets: %s", reload_targets)
+                self.reload_commands(reload_targets)
         return line
 
     def postcmd(self, stop, line):

--- a/simnos/plugins/shell/cmd_shell.py
+++ b/simnos/plugins/shell/cmd_shell.py
@@ -187,7 +187,7 @@ class CMDShell(Cmd):
     def emptyline(self):
         """This method to do nothing if empty line entered"""
 
-    # `Nos` state `from_file` mutates; snapshotted per reloaded file so a file
+    # `Nos` state `from_file` mutates; snapshotted per reload target so a target
     # that loads but fails to normalize can be rolled back (2nd round codex #1).
     _NOS_RELOAD_ATTRS = (
         "name",

--- a/simnos/plugins/shell/cmd_shell.py
+++ b/simnos/plugins/shell/cmd_shell.py
@@ -100,7 +100,7 @@ class CMDShell(Cmd):
     ):
         self.nos: Nos = nos
         # Platform name captured at build time for the hot-reload ownership filter
-        # (#264 #274 / D6). A later foreign py reload can overwrite live `nos.name`
+        # (#274 / D6). A later foreign py reload can overwrite live `nos.name`
         # (`_from_module` commit phase), so the filter must compare against this
         # frozen value, not `self.nos.name`, or a hijacked name would permanently
         # skip this session's own A3 platform reload.

--- a/simnos/plugins/shell/utils.py
+++ b/simnos/plugins/shell/utils.py
@@ -120,8 +120,14 @@ def resolve_reload_targets(files: list[str], root: str) -> list[str]:
     for file in files:
         parts = os.path.normpath(file).split(os.sep)
         platform_dir = _a3_platform_dir(parts, root_parts)
-        if platform_dir is not None and os.path.isdir(platform_dir):
-            targets.add(platform_dir)
+        if platform_dir is not None:
+            # An A3 path is claimed here even when its platform dir is gone
+            # (whole-platform deletion): falling through to the legacy `.j2`
+            # branch would fabricate a bogus py path for an A3 `commands/*.j2`.
+            if os.path.isdir(platform_dir):
+                targets.add(platform_dir)
+            else:
+                log.debug("hot-reload: ignoring path of deleted platform %s", file)
         elif file.endswith(".j2"):
             targets.add(_legacy_jinja_to_py(file))
         elif file.endswith(".py"):

--- a/simnos/plugins/shell/utils.py
+++ b/simnos/plugins/shell/utils.py
@@ -3,7 +3,10 @@ This module is intended to be used
 a collection of utilities for the shell.
 """
 
+import logging
 import os
+
+log = logging.getLogger(__name__)
 
 
 def get_files_under_directory(directory):
@@ -14,7 +17,9 @@ def get_files_under_directory(directory):
             continue
         files += [os.path.join(root, filename) for filename in filenames]
     files = [file for file in files if os.path.isfile(file)]
-    files = [file for file in files if file.endswith((".py", ".j2", ".yaml"))]
+    # `.txt` is the A3 literal-capture extension (#274 / D2): editing a command's
+    # output file must trigger a reload like editing its yaml does.
+    files = [file for file in files if file.endswith((".py", ".j2", ".yaml", ".txt"))]
     files = [file for file in files if not file.endswith("__init__.py")]
     return files
 
@@ -64,38 +69,102 @@ def get_files_recently_modified(files: list[str], files_lasttime_changed_old: di
     return files_recently_modified
 
 
-def change_jinja_to_corresponding_py(files: list[str]):
-    """Method to change j2 files to corresponding py files"""
-    jinja_files = [file for file in files if file.endswith(".j2")]
-    files: set = {file for file in files if not file.endswith(".j2")}
-    for filepath in jinja_files:
-        if "configurations" in filepath:
-            base_filepath = filepath.rsplit("/", 2)[0]
-            platform = os.path.basename(filepath).replace(".yaml.j2", "").replace(".yaml", "")
-            files.add(f"{base_filepath}/{platform}.py")
+def _legacy_jinja_to_py(filepath: str) -> str:
+    """Map one legacy py-plugin `.j2` template to its corresponding `.py` module.
+
+    Preserves the pre-#274 conversion: a `configurations/<platform>.yaml.j2`
+    config template and a `templates/<platform>/<cmd>.j2` output template both
+    reload by re-importing the platform's `.py` module. Only reached for `.j2`
+    paths that are NOT under an A3 platform dir (those are rolled up to the dir
+    by `resolve_reload_targets` first — A3 priority).
+    """
+    if "configurations" in filepath:
+        base_filepath = filepath.rsplit("/", 2)[0]
+        platform = os.path.basename(filepath).replace(".yaml.j2", "").replace(".yaml", "")
+        return f"{base_filepath}/{platform}.py"
+    split = filepath.rsplit("/", 3)
+    return f"{split[0]}/{split[2]}.py"
+
+
+def _a3_platform_dir(parts: list[str], root_parts: list[str]) -> str | None:
+    """Return the A3 platform dir a changed-file path belongs to, or None.
+
+    `parts` / `root_parts` are `os.sep`-split paths. A match needs the path to be
+    `<root>/platforms/<p>/<at least one more segment>` — the `len >= n + 3` guard
+    keeps a stray `platforms/foo.yaml` (a file directly under `platforms/`) from
+    being rolled up to a bogus dir, and the exact `"platforms"` segment match
+    (not substring) keeps `platforms_py/...` out (#274 / D1).
+    """
+    n = len(root_parts)
+    if len(parts) >= n + 3 and parts[:n] == root_parts and parts[n] == "platforms":
+        return os.sep.join(parts[: n + 2])
+    return None
+
+
+def resolve_reload_targets(files: list[str], root: str) -> list[str]:
+    """Map changed files to the reload units `Nos.from_file` accepts (#274 / D1).
+
+    A3 command data lives in `<root>/platforms/<p>/{platform.yaml,commands/*}`;
+    `from_file` reloads a *platform dir*, not an individual command file, so any
+    changed file under `platforms/<p>/` is rolled up to that dir. This branch is
+    first (A3 priority) so an A3 `commands/*.j2` is not misrouted to a py path by
+    the legacy `.j2` mapping. py plugins (and their adjacent `.j2`
+    config/templates) map to their `.py` module. A path that is neither — a
+    non-plugin file, or a whole-platform deletion whose dir is gone — is dropped
+    (`from_file` would only raise on it) and logged for "why didn't my edit
+    reload?" troubleshooting. Targets are deduped and sorted (deterministic
+    order; the merge is order-invariant for commands, last-writer for scalars).
+    """
+    root_parts = os.path.normpath(root).split(os.sep)
+    targets: set[str] = set()
+    for file in files:
+        parts = os.path.normpath(file).split(os.sep)
+        platform_dir = _a3_platform_dir(parts, root_parts)
+        if platform_dir is not None and os.path.isdir(platform_dir):
+            targets.add(platform_dir)
+        elif file.endswith(".j2"):
+            targets.add(_legacy_jinja_to_py(file))
+        elif file.endswith(".py"):
+            targets.add(file)
         else:
-            split: list[str] = filepath.rsplit("/", 3)
-            corresponding_py_module = f"{split[0]}/{split[2]}.py"
-            files.add(corresponding_py_module)
-    return list(files)
+            log.debug("hot-reload: ignoring non-reloadable changed path %s", file)
+    return sorted(targets)
 
 
 # Module-level cache for get_files_changed. Previously stored as a
 # function attribute (get_files_changed.files_lasttime_changed_old),
 # which defeats static type analysis. Moved to module scope so ty can
-# track the type properly.
+# track the type properly. `_watch_root` pairs the snapshot with the directory
+# it was taken under so a changed watch root re-seeds instead of reporting every
+# prior-root path as a deletion (#274 / D7).
 _files_lasttime_changed_old: dict[str, float] = {}
+_watch_root: str | None = None
 
 
-def get_files_changed(directory: str):
-    """Method to get files changed under a directory"""
-    global _files_lasttime_changed_old
-    files_changed: list[str] = []
-    files_under_directory: list[str] = get_files_under_directory(directory)
-    if not _files_lasttime_changed_old:
+def get_files_changed(directory: str) -> list[str]:
+    """Return the reload targets for files changed under `directory` (#274 / D1, D7).
+
+    First observation of a (new) watch root only seeds the snapshot and returns
+    no targets — a diff needs a prior baseline. Subsequent polls report new,
+    modified, and deleted paths, rolled up to reload targets by
+    `resolve_reload_targets`. Deletion matters for A3 (a removed `commands/*`
+    file is a command removal); the platform dir is still healthy so the rollup
+    reloads it and the removal propagates.
+    """
+    global _files_lasttime_changed_old, _watch_root
+    files_under_directory = get_files_under_directory(directory)
+    # Re-seed (no diff) on first ever poll or when the watch root changes, so a
+    # stale prior-root snapshot does not surface every old path as a deletion.
+    if _watch_root != directory or not _files_lasttime_changed_old:
+        _watch_root = directory
         _files_lasttime_changed_old = get_files_lasttime_changed(files_under_directory)
+        return []
+    files_changed: list[str] = []
     files_changed += get_new_files(list(_files_lasttime_changed_old.keys()), files_under_directory)
     files_changed += get_files_recently_modified(files_under_directory, _files_lasttime_changed_old)
-    files_changed = change_jinja_to_corresponding_py(files_changed)
+    # Deletion (D7): paths in the prior snapshot that are gone from this walk.
+    current = set(files_under_directory)
+    files_changed += [path for path in _files_lasttime_changed_old if path not in current]
+    targets = resolve_reload_targets(files_changed, directory)
     _files_lasttime_changed_old = get_files_lasttime_changed(files_under_directory)
-    return files_changed
+    return targets

--- a/simnos/plugins/shell/utils.py
+++ b/simnos/plugins/shell/utils.py
@@ -69,21 +69,29 @@ def get_files_recently_modified(files: list[str], files_lasttime_changed_old: di
     return files_recently_modified
 
 
-def _legacy_jinja_to_py(filepath: str) -> str:
-    """Map one legacy py-plugin `.j2` template to its corresponding `.py` module.
+def _legacy_jinja_to_py(filepath: str) -> str | None:
+    """Map a legacy py-plugin `.j2` template to its `.py` module, or None.
 
-    Preserves the pre-#274 conversion: a `configurations/<platform>.yaml.j2`
-    config template and a `templates/<platform>/<cmd>.j2` output template both
-    reload by re-importing the platform's `.py` module. Only reached for `.j2`
-    paths that are NOT under an A3 platform dir (those are rolled up to the dir
-    by `resolve_reload_targets` first — A3 priority).
+    Recognizes the two shipped legacy shapes only, by segment position:
+
+    - ``<base>/configurations/<platform>.yaml.j2`` -> ``<base>/<platform>.py``
+    - ``<base>/templates/<platform>/<cmd>.j2``     -> ``<base>/<platform>.py``
+
+    Any other `.j2` (e.g. a stray ``README.j2`` under the watch root) returns
+    None so the caller drops it — mapping it blindly would fabricate a bogus
+    py path that `from_file` can only fail on (1st round codex #1). Only
+    reached for `.j2` paths NOT under an A3 platform dir (those are rolled up
+    by `resolve_reload_targets` first — A3 priority). POSIX ``/`` separators
+    are a pre-existing assumption of the legacy py-plugin layout (unlike the
+    ``os.sep``-aware `_a3_platform_dir`).
     """
-    if "configurations" in filepath:
-        base_filepath = filepath.rsplit("/", 2)[0]
-        platform = os.path.basename(filepath).replace(".yaml.j2", "").replace(".yaml", "")
-        return f"{base_filepath}/{platform}.py"
-    split = filepath.rsplit("/", 3)
-    return f"{split[0]}/{split[2]}.py"
+    parts = filepath.split("/")
+    if len(parts) >= 3 and parts[-2] == "configurations":
+        platform = parts[-1].replace(".yaml.j2", "").replace(".yaml", "")
+        return "/".join([*parts[:-2], f"{platform}.py"])
+    if len(parts) >= 4 and parts[-3] == "templates":
+        return "/".join([*parts[:-3], f"{parts[-2]}.py"])
+    return None
 
 
 def _a3_platform_dir(parts: list[str], root_parts: list[str]) -> str | None:
@@ -108,12 +116,13 @@ def resolve_reload_targets(files: list[str], root: str) -> list[str]:
     `from_file` reloads a *platform dir*, not an individual command file, so any
     changed file under `platforms/<p>/` is rolled up to that dir. This branch is
     first (A3 priority) so an A3 `commands/*.j2` is not misrouted to a py path by
-    the legacy `.j2` mapping. py plugins (and their adjacent `.j2`
-    config/templates) map to their `.py` module. A path that is neither — a
-    non-plugin file, or a whole-platform deletion whose dir is gone — is dropped
-    (`from_file` would only raise on it) and logged for "why didn't my edit
-    reload?" troubleshooting. Targets are deduped and sorted (deterministic
-    order; the merge is order-invariant for commands, last-writer for scalars).
+    the legacy `.j2` mapping. py plugins (and their adjacent legacy-shape `.j2`
+    config/templates) map to their `.py` module. Everything else is dropped — a
+    non-plugin file, an unrecognized `.j2`, or a whole-platform deletion whose
+    dir is gone (`from_file` would only raise on it) — and logged for "why
+    didn't my edit reload?" troubleshooting. Targets are deduped and sorted
+    (deterministic order; the merge is order-invariant for commands,
+    last-writer for scalars).
     """
     root_parts = os.path.normpath(root).split(os.sep)
     targets: set[str] = set()
@@ -127,9 +136,9 @@ def resolve_reload_targets(files: list[str], root: str) -> list[str]:
             if os.path.isdir(platform_dir):
                 targets.add(platform_dir)
             else:
-                log.debug("hot-reload: ignoring path of deleted platform %s", file)
-        elif file.endswith(".j2"):
-            targets.add(_legacy_jinja_to_py(file))
+                log.debug("hot-reload: ignoring %s (platform dir %s is gone)", file, platform_dir)
+        elif file.endswith(".j2") and (py_target := _legacy_jinja_to_py(file)) is not None:
+            targets.add(py_target)
         elif file.endswith(".py"):
             targets.add(file)
         else:
@@ -156,6 +165,13 @@ def get_files_changed(directory: str) -> list[str]:
     `resolve_reload_targets`. Deletion matters for A3 (a removed `commands/*`
     file is a command removal); the platform dir is still healthy so the rollup
     reloads it and the removal propagates.
+
+    Known dev-mode limitation: the snapshot is consume-once and shared by every
+    shell in the process. The first session to poll consumes a change, and the
+    ownership filter (#274 / D6) may then discard it — on a multi-host reload
+    server another platform's edit can be consumed-and-dropped before any
+    session of that platform observes it. Per-shell snapshots are the future
+    fix (pre-existing single-host assumption, 1st code review claude #2).
     """
     global _files_lasttime_changed_old, _watch_root
     files_under_directory = get_files_under_directory(directory)

--- a/simnos/plugins/shell/utils.py
+++ b/simnos/plugins/shell/utils.py
@@ -86,8 +86,8 @@ def _legacy_jinja_to_py(filepath: str) -> str | None:
     ``os.sep``-aware `_a3_platform_dir`).
     """
     parts = filepath.split("/")
-    if len(parts) >= 3 and parts[-2] == "configurations":
-        platform = parts[-1].replace(".yaml.j2", "").replace(".yaml", "")
+    if len(parts) >= 3 and parts[-2] == "configurations" and parts[-1].endswith(".yaml.j2"):
+        platform = parts[-1][: -len(".yaml.j2")]
         return "/".join([*parts[:-2], f"{platform}.py"])
     if len(parts) >= 4 and parts[-3] == "templates":
         return "/".join([*parts[:-3], f"{parts[-2]}.py"])

--- a/simnos/plugins/shell/utils.py
+++ b/simnos/plugins/shell/utils.py
@@ -175,9 +175,12 @@ def get_files_changed(directory: str) -> list[str]:
     """
     global _files_lasttime_changed_old, _watch_root
     files_under_directory = get_files_under_directory(directory)
-    # Re-seed (no diff) on first ever poll or when the watch root changes, so a
-    # stale prior-root snapshot does not surface every old path as a deletion.
-    if _watch_root != directory or not _files_lasttime_changed_old:
+    # Re-seed (no diff) on the first poll of a watch root, so a stale
+    # prior-root snapshot does not surface every old path as a deletion. The
+    # root is the only seed key: an empty snapshot is a legitimate baseline
+    # (a root with no watched files yet), and treating it as "unseeded" would
+    # swallow the first file ever added to it (1st code review codex #2).
+    if _watch_root != directory:
         _watch_root = directory
         _files_lasttime_changed_old = get_files_lasttime_changed(files_under_directory)
         return []

--- a/tests/plugins/test_cmd_shell_a3.py
+++ b/tests/plugins/test_cmd_shell_a3.py
@@ -225,6 +225,28 @@ class TestA3HotReload:
         shell.precmd("show clock")  # second poll: detects the edit, reloads the dir
         assert shell.commands["show version"].output.render("R1") == "Cisco IOS Software, Version 16.0\n"
 
+    def test_a3_new_command_file_appears_via_precmd(self, tmp_path, monkeypatch):
+        """E2E: a brand-new command yaml surfaces its command on the next poll.
+
+        Complements the edit test above: this drives the *new-file* detection
+        (`get_new_files`, key diff — no mtime involved) through rollup and
+        reload, a chain no other test exercises (1st code review claude #3).
+        """
+        watch_root = tmp_path / "nos"
+        platform_dir = _a3_platform(watch_root / "platforms")
+        shell = _shell_for(Nos(filename=str(platform_dir)))
+        monkeypatch.setenv("SIMNOS_RELOAD_COMMANDS", "1")
+        monkeypatch.setattr(cmd_shell_module, "nos", SimpleNamespace(__path__=[str(watch_root)]))
+        shell.precmd("show clock")  # first poll: seed only
+        assert "show clock" not in shell.commands
+        _write(
+            platform_dir / "commands" / "show_clock.yaml",
+            "command: show clock\ntype: simnos\nmode: [user]\noutput: show_clock.txt\n",
+        )
+        _write(platform_dir / "commands" / "show_clock.txt", "12:00:00 UTC\n")
+        shell.precmd("show clock")  # second poll: new files detected, dir reloaded
+        assert shell.commands["show clock"].output.render("R1") == "12:00:00 UTC\n"
+
     def test_post_commit_rebuild_failure_rolls_back_resolved_platform(self, tmp_path, caplog):
         """A reload that loads but fails `_rebuild` restores `resolved_platform` (D3).
 

--- a/tests/plugins/test_cmd_shell_a3.py
+++ b/tests/plugins/test_cmd_shell_a3.py
@@ -4,13 +4,23 @@ PR-1 covered the legacy adapter end of `_rebuild`; these pin the new A3 branch:
 `Nos._from_platform_dir` loads a platform dir into `resolved_platform`, and the
 shell merges the still-legacy inflows (BASIC, py-module commands, inventory)
 over the A3 statics with the right precedence and the A3 modes.
+
+`TestA3HotReload` pins the #274 dev hot-reload path on top: watcher rollup to a
+platform-dir target, the ownership filter, the `resolved_platform` rollback,
+and the mode-degrade contract — all against tmp platforms (the real tree is
+never mutated, so no xdist serialization is needed).
 """
 
+import os
 import threading
+import time
+from types import SimpleNamespace
 
 import pytest
 
 from simnos.core.nos import Nos
+from simnos.plugins.shell import cmd_shell as cmd_shell_module
+from simnos.plugins.shell import utils as shell_utils
 from simnos.plugins.shell.cmd_shell import CMDShell, build_resolved_platform
 
 
@@ -168,3 +178,130 @@ class TestShellA3Path:
             shell._rebuild()
         assert shell.commands is good_commands  # unchanged reference
         assert shell.prompt == good_prompt
+
+
+def _touch_future(path):
+    """Bump a file's mtime past the watcher's snapshot (defeats coarse mtime ties)."""
+    future = time.time() + 10
+    os.utime(path, (future, future))
+
+
+class TestA3HotReload:
+    """Dev hot-reload over A3 platforms (#274).
+
+    Covers the four designed behaviors: an A3 edit propagating through the real
+    `precmd` watch path (D1/D2), the post-commit `_rebuild` failure rolling back
+    `resolved_platform` (D3), the ownership filter with its build-time anchor
+    (D6), and the current-mode degrade on a reload that dropped the mode.
+    """
+
+    @pytest.fixture(autouse=True)
+    def _reset_watcher(self):
+        # The watcher snapshot is module-global; reset around each test so a
+        # prior test's (or the real tree's) snapshot never leaks phantom
+        # changes/deletions into these tmp-root polls (#274 / D7).
+        shell_utils._files_lasttime_changed_old.clear()
+        shell_utils._watch_root = None
+        yield
+        shell_utils._files_lasttime_changed_old.clear()
+        shell_utils._watch_root = None
+
+    def test_a3_edit_propagates_via_precmd(self, tmp_path, monkeypatch):
+        """E2E: editing an A3 output file reaches the session through `precmd`.
+
+        Drives the real watch path (seed poll -> edit -> second poll), with the
+        watch root swapped to the tmp tree by replacing the `nos` module binding
+        in cmd_shell (safer than mutating the live package's `__path__`).
+        """
+        watch_root = tmp_path / "nos"
+        platform_dir = _a3_platform(watch_root / "platforms")
+        shell = _shell_for(Nos(filename=str(platform_dir)))
+        monkeypatch.setenv("SIMNOS_RELOAD_COMMANDS", "1")
+        monkeypatch.setattr(cmd_shell_module, "nos", SimpleNamespace(__path__=[str(watch_root)]))
+        shell.precmd("show clock")  # first poll: seed only
+        target_txt = platform_dir / "commands" / "show_version.txt"
+        _write(target_txt, "Cisco IOS Software, Version 16.0\n")
+        _touch_future(target_txt)
+        shell.precmd("show clock")  # second poll: detects the edit, reloads the dir
+        assert shell.commands["show version"].output.render("R1") == "Cisco IOS Software, Version 16.0\n"
+
+    def test_post_commit_rebuild_failure_rolls_back_resolved_platform(self, tmp_path, caplog):
+        """A reload that loads but fails `_rebuild` restores `resolved_platform` (D3).
+
+        The broken-yaml case fails *before* `_from_platform_dir` assigns, so it
+        cannot pin the D3 attr; this is the post-commit path — the platform
+        loses a mode that a legacy inflow's prompt still maps to, so `from_file`
+        succeeds and `_rebuild`'s `adapt_commands` raises. Without
+        `resolved_platform` in `_NOS_RELOAD_ATTRS` the modeless platform would
+        survive the rollback and poison every later rebuild.
+        """
+        platform_dir = _a3_platform(tmp_path)
+        inventory = {"commands": {"conf cmd": {"output": "X", "prompt": "{base_prompt}(config)#"}}}
+        nos_obj = Nos(filename=str(platform_dir))
+        shell = _shell_for(nos_obj, inventory_config=inventory)
+        old_platform = nos_obj.resolved_platform
+        old_commands = shell.commands
+        # Drop the config mode: load still succeeds (no A3 command references
+        # it), but the inventory prompt above no longer reverse-maps.
+        _write(
+            platform_dir / "platform.yaml",
+            'modes:\n  user:\n    prompt: "{{ base_prompt }}>"\n'
+            '  enable:\n    prompt: "{{ base_prompt }}#"\n'
+            "initial_mode: user\n",
+        )
+        with caplog.at_level("ERROR", logger="simnos.plugins.shell.cmd_shell"):
+            shell.reload_commands([str(platform_dir)])
+        assert len(caplog.records) == 1
+        assert nos_obj.resolved_platform is old_platform  # rolled back, not the modeless parse
+        assert shell.commands is old_commands  # live session untouched
+
+    def test_foreign_platform_dir_is_skipped(self, tmp_path):
+        """The ownership filter keeps a sibling platform's reload out (D6)."""
+        watch_root = tmp_path / "nos"
+        own_dir = _a3_platform(watch_root / "platforms")
+        foreign_dir = watch_root / "platforms" / "arista_eos"
+        _write(foreign_dir / "platform.yaml", 'modes:\n  user:\n    prompt: "{{ base_prompt }}%"\ninitial_mode: user\n')
+        _write(foreign_dir / "commands" / "default.yaml", "command: _default_\ntype: simnos\n")
+        nos_obj = Nos(filename=str(own_dir))
+        shell = _shell_for(nos_obj)
+        old_platform = nos_obj.resolved_platform
+        shell.reload_commands([str(foreign_dir)])
+        assert nos_obj.name == "cisco_ios"  # not hijacked
+        assert nos_obj.resolved_platform is old_platform
+
+    def test_ownership_anchor_survives_live_name_overwrite(self, tmp_path):
+        """The filter compares against the build-time anchor, not live `nos.name` (D6).
+
+        A foreign py reload can overwrite live `nos.name` (its commit phase sets
+        the module's NAME); if the filter read `nos.name` it would then skip
+        this session's own platform forever. The captured `_platform_name` is
+        immune to that overwrite.
+        """
+        platform_dir = _a3_platform(tmp_path)
+        nos_obj = Nos(filename=str(platform_dir))
+        shell = _shell_for(nos_obj)
+        nos_obj.name = "arista_eos"  # simulate the foreign-py NAME overwrite
+        _write(platform_dir / "commands" / "show_version.txt", "Reloaded fine\n")
+        shell.reload_commands([str(platform_dir)])
+        assert shell.commands["show version"].output.render("R1") == "Reloaded fine\n"  # not skipped
+
+    def test_removed_mode_degrades_to_initial(self, tmp_path):
+        """A reload that drops the current mode resets the session to initial_mode."""
+        platform_dir = _a3_platform(tmp_path)
+        shell = _shell_for(Nos(filename=str(platform_dir)))
+        shell.default("enable")
+        assert shell.current_mode == "enable"
+        # Rewrite the platform as user-only (and retarget/remove the commands
+        # that referenced the enable mode, so the reload itself succeeds).
+        _write(
+            platform_dir / "platform.yaml",
+            'modes:\n  user:\n    prompt: "{{ base_prompt }}>"\ninitial_mode: user\n',
+        )
+        (platform_dir / "commands" / "enable.yaml").unlink()
+        _write(
+            platform_dir / "commands" / "show_version.yaml",
+            "command: show version\ntype: ntc\nmode: [user]\noutput: show_version.txt\n",
+        )
+        shell.reload_commands([str(platform_dir)])
+        assert shell.current_mode == "user"
+        assert shell.prompt == "R1>"

--- a/tests/plugins/test_shell_utils.py
+++ b/tests/plugins/test_shell_utils.py
@@ -179,6 +179,21 @@ class ShellUtilsTest(TestCase):
         self.assertFalse(targets)
 
 
+def test_get_files_under_directory_filters_extensions(tmp_path):
+    """Watched extensions are included and everything else is excluded (#274 / D2).
+
+    Pinned against a tmp tree because the real `plugins/nos` tree contains no
+    non-watched files, making an `all(endswith(...))` over it vacuously true for
+    exclusion. `.bak` exclusion is load-bearing: the hot-reload integration test
+    (`HotReloadTest._atomic_write`) parks backup copies on `.bak` precisely so a
+    mid-write file is never visible to a reload watcher (#232).
+    """
+    for name in ("keep.py", "keep.j2", "keep.yaml", "keep.txt", "skip.bak", "skip.md", "__init__.py"):
+        (tmp_path / name).write_text("x", encoding="utf-8")
+    files = {os.path.basename(f) for f in get_files_under_directory(str(tmp_path))}
+    assert files == {"keep.py", "keep.j2", "keep.yaml", "keep.txt"}
+
+
 # --- resolve_reload_targets (#274 / D1) --------------------------------------
 #
 # `resolve_reload_targets` maps changed files to the reload units `from_file`
@@ -242,21 +257,6 @@ def test_resolve_targets_legacy_jinja_templates(tmp_path):
     root = _make_nos_tree(tmp_path)
     j2 = str(root / "platforms_py" / "templates" / "cisco_ios" / "show_run.j2")
     assert resolve_reload_targets([j2], str(root)) == [str(root / "platforms_py" / "cisco_ios.py")]
-
-
-def test_get_files_under_directory_filters_extensions(tmp_path):
-    """Watched extensions are included and everything else is excluded (#274 / D2).
-
-    Pinned against a tmp tree because the real `plugins/nos` tree contains no
-    non-watched files, making an `all(endswith(...))` over it vacuously true for
-    exclusion. `.bak` exclusion is load-bearing: the hot-reload integration test
-    (`HotReloadTest._atomic_write`) parks backup copies on `.bak` precisely so a
-    mid-write file is never visible to a reload watcher (#232).
-    """
-    for name in ("keep.py", "keep.j2", "keep.yaml", "keep.txt", "skip.bak", "skip.md", "__init__.py"):
-        (tmp_path / name).write_text("x", encoding="utf-8")
-    files = {os.path.basename(f) for f in get_files_under_directory(str(tmp_path))}
-    assert files == {"keep.py", "keep.j2", "keep.yaml", "keep.txt"}
 
 
 def test_resolve_targets_drops_non_plugin_and_stray(tmp_path):

--- a/tests/plugins/test_shell_utils.py
+++ b/tests/plugins/test_shell_utils.py
@@ -244,12 +244,40 @@ def test_resolve_targets_legacy_jinja_templates(tmp_path):
     assert resolve_reload_targets([j2], str(root)) == [str(root / "platforms_py" / "cisco_ios.py")]
 
 
+def test_get_files_under_directory_filters_extensions(tmp_path):
+    """Watched extensions are included and everything else is excluded (#274 / D2).
+
+    Pinned against a tmp tree because the real `plugins/nos` tree contains no
+    non-watched files, making an `all(endswith(...))` over it vacuously true for
+    exclusion. `.bak` exclusion is load-bearing: the hot-reload integration test
+    (`HotReloadTest._atomic_write`) parks backup copies on `.bak` precisely so a
+    mid-write file is never visible to a reload watcher (#232).
+    """
+    for name in ("keep.py", "keep.j2", "keep.yaml", "keep.txt", "skip.bak", "skip.md", "__init__.py"):
+        (tmp_path / name).write_text("x", encoding="utf-8")
+    files = {os.path.basename(f) for f in get_files_under_directory(str(tmp_path))}
+    assert files == {"keep.py", "keep.j2", "keep.yaml", "keep.txt"}
+
+
 def test_resolve_targets_drops_non_plugin_and_stray(tmp_path):
     """Non-plugin files and a stray file directly under `platforms/` are dropped."""
     root = _make_nos_tree(tmp_path)
     assert resolve_reload_targets([str(root / "README.txt")], str(root)) == []
     # `platforms/foo.yaml` has no `<p>/` level (min-segment guard) -> dropped.
     assert resolve_reload_targets([str(root / "platforms" / "foo.yaml")], str(root)) == []
+
+
+def test_resolve_targets_drops_unrecognized_jinja(tmp_path):
+    """A `.j2` outside the two legacy py-plugin shapes is dropped, not mapped.
+
+    Blindly mapping (the old behavior) would fabricate a bogus `.py` target for
+    e.g. a stray `README.j2` and re-introduce the every-poll error log the drop
+    branch exists to prevent (1st code review codex #1).
+    """
+    root = _make_nos_tree(tmp_path)
+    stray = str(root / "README.j2")
+    unknown_shape = str(root / "platforms_py" / "notes" / "foo.j2")
+    assert resolve_reload_targets([stray, unknown_shape], str(root)) == []
 
 
 def test_resolve_targets_drops_deleted_platform_dir(tmp_path):

--- a/tests/plugins/test_shell_utils.py
+++ b/tests/plugins/test_shell_utils.py
@@ -325,3 +325,19 @@ def test_get_files_changed_detects_deletion(tmp_path, _clean_watcher):
     assert get_files_changed(str(root)) == []  # seed
     (root / "platforms" / "cisco_ios" / "commands" / "show.yaml").unlink()
     assert get_files_changed(str(root)) == [platform_dir]
+
+
+def test_get_files_changed_empty_root_first_file_detected(tmp_path, _clean_watcher):
+    """A file added to an initially-empty root is detected, not swallowed by re-seed.
+
+    The seed condition keys on the watch root only: an empty snapshot is a
+    legitimate baseline (a root with no watched files yet). Keying on snapshot
+    emptiness would re-seed on the next poll and swallow the first file ever
+    added (1st code review codex #2, taken in at final-refactor).
+    """
+    root = tmp_path / "nos"
+    (root / "platforms_py").mkdir(parents=True)
+    assert get_files_changed(str(root)) == []  # seed: empty but valid baseline
+    newplugin = root / "platforms_py" / "newplugin.py"
+    newplugin.write_text("NAME = 'x'\n", encoding="utf-8")
+    assert get_files_changed(str(root)) == [str(newplugin)]

--- a/tests/plugins/test_shell_utils.py
+++ b/tests/plugins/test_shell_utils.py
@@ -10,12 +10,12 @@ from unittest.mock import patch
 
 from simnos.plugins.shell import utils as shell_utils
 from simnos.plugins.shell.utils import (
-    change_jinja_to_corresponding_py,
     get_files_changed,
     get_files_lasttime_changed,
     get_files_recently_modified,
     get_files_under_directory,
     get_new_files,
+    resolve_reload_targets,
 )
 
 RANDOM_FILE: str = random.choice(
@@ -64,9 +64,12 @@ class ShellUtilsTest(TestCase):
         with the absolute `nos.__path__[0]`) may have primed the
         module-level `_files_lasttime_changed_old` snapshot; without a
         reset, the relative-path calls below would treat every file as
-        "new" and the first-call-returns-empty contract breaks.
+        "new" and the first-call-returns-empty contract breaks. `_watch_root`
+        is reset too so the next call re-seeds rather than diffing against a
+        prior root's snapshot (#274 / D7).
         """
         shell_utils._files_lasttime_changed_old.clear()
+        shell_utils._watch_root = None
 
     def tearDown(self):
         """Avoid leaking the stateful cache to other tests.
@@ -77,6 +80,7 @@ class ShellUtilsTest(TestCase):
         `_files_lasttime_changed_old` (ty adoption, M-9).
         """
         shell_utils._files_lasttime_changed_old.clear()
+        shell_utils._watch_root = None
 
     def test_get_files_under_directory(self):
         """
@@ -85,7 +89,10 @@ class ShellUtilsTest(TestCase):
         files = get_files_under_directory("simnos/plugins/nos")
         self.assertTrue(files)
         self.assertTrue(all(not file.endswith("__init__.py") for file in files))
-        self.assertTrue(all(file for file in files if file.endswith((".py", ".j2", ".yaml"))))
+        # Every returned file is a watched extension; `.txt` is now watched so an
+        # A3 literal-capture edit triggers a reload (#274 / D2).
+        self.assertTrue(all(file.endswith((".py", ".j2", ".yaml", ".txt")) for file in files))
+        self.assertTrue(any(file.endswith(".txt") for file in files))
 
     def test_get_files_lasttime_changed(self):
         """
@@ -106,32 +113,6 @@ class ShellUtilsTest(TestCase):
         old_files = ["file1", "file2"]
         new_files = ["file2", "file3"]
         self.assertEqual(get_new_files(old_files, new_files), ["file3"])
-
-    def test_change_jinja_to_corresponding_py(self):
-        """
-        Test to check if we change j2 files to corresponding py files
-        """
-        files = get_files_under_directory("simnos/plugins/nos")
-        files = [file for file in files if "cisco_ios" in file]
-        files = [file for file in files if file.endswith(".j2")]
-        files = change_jinja_to_corresponding_py(files)
-        self.assertTrue(files)
-        self.assertTrue(all(not file.endswith(".j2") for file in files))
-        self.assertTrue(all(file for file in files if file.endswith(".py")))
-        self.assertTrue(all("cisco_ios" in file for file in files))
-
-    def test_change_jinja_to_corresponding_py_null(self):
-        """
-        Test to check if we don't change any j2 files to corresponding py files
-        """
-        files = get_files_under_directory("simnos/plugins/nos")
-        files = [file for file in files if "cisco_ios" in file]
-        files = [file for file in files if file.endswith(".py")]
-        files = change_jinja_to_corresponding_py(files)
-        self.assertTrue(files)
-        self.assertTrue(all(not file.endswith(".j2") for file in files))
-        self.assertTrue(all(file for file in files if file.endswith(".py")))
-        self.assertTrue(all("cisco_ios" in file for file in files))
 
     def test_get_files_recently_modified(self):
         """
@@ -173,15 +154,20 @@ class ShellUtilsTest(TestCase):
 
     def test_get_files_changed(self):
         """
-        Test to check if we get the files that have been changed
+        Test to check if we get the reload targets for files that changed.
+
+        `get_files_changed` now returns reload targets, not raw changed files
+        (#274 / D1): a changed A3 command file is rolled up to its platform dir,
+        a `.py` module stays itself. The first call only seeds the snapshot.
         """
-        files = get_files_changed("simnos/plugins/nos")
-        self.assertFalse(files)
+        targets = get_files_changed("simnos/plugins/nos")
+        self.assertFalse(targets)  # first call: seed only, no diff
         with patch("os.stat", side_effect=mock_os_stat):
-            files = get_files_changed("simnos/plugins/nos")
-        self.assertTrue(files)
-        self.assertIn(RANDOM_FILE, files)
-        files = get_files_changed("simnos/plugins/nos")
+            targets = get_files_changed("simnos/plugins/nos")
+        self.assertTrue(targets)
+        # The single changed RANDOM_FILE maps to exactly its rollup target.
+        expected = resolve_reload_targets([RANDOM_FILE], "simnos/plugins/nos")
+        self.assertTrue(set(expected).issubset(set(targets)))
 
     def test_get_files_changed_null(self):
         """
@@ -191,3 +177,108 @@ class ShellUtilsTest(TestCase):
         self.assertFalse(files)
         files = get_files_changed("simnos/plugins/nos")
         self.assertFalse(files)
+
+
+# --- resolve_reload_targets (#274 / D1) --------------------------------------
+#
+# `resolve_reload_targets` maps changed files to the reload units `from_file`
+# accepts: an A3 file rolls up to its platform dir (`from_file` reloads a dir,
+# not a single command file), a `.py` module stays itself, a legacy py-plugin
+# `.j2` maps to its `.py`, everything else is dropped. These replace the old
+# `change_jinja_to_corresponding_py` tests, using a tmp tree for precision.
+
+
+def _make_nos_tree(base):
+    """Build a minimal ``plugins/nos``-shaped tree under ``base``; return its root."""
+    root = base / "nos"
+    cisco = root / "platforms" / "cisco_ios" / "commands"
+    cisco.mkdir(parents=True)
+    (root / "platforms" / "cisco_ios" / "platform.yaml").write_text("modes: {}\n", encoding="utf-8")
+    (cisco / "show.yaml").write_text("command: show\n", encoding="utf-8")
+    (cisco / "show.txt").write_text("out\n", encoding="utf-8")
+    (cisco / "show.j2").write_text("{{ base_prompt }}\n", encoding="utf-8")
+    (root / "platforms_py").mkdir(parents=True)
+    (root / "platforms_py" / "cisco_ios.py").write_text("NAME = 'cisco_ios'\n", encoding="utf-8")
+    return root
+
+
+def test_resolve_targets_a3_files_roll_up_to_platform_dir(tmp_path):
+    """Every A3 file (yaml/txt/j2/platform.yaml) rolls up to its platform dir."""
+    root = _make_nos_tree(tmp_path)
+    platform_dir = str(root / "platforms" / "cisco_ios")
+    for rel in ("platform.yaml", "commands/show.yaml", "commands/show.txt", "commands/show.j2"):
+        changed = str(root / "platforms" / "cisco_ios" / rel)
+        assert resolve_reload_targets([changed], str(root)) == [platform_dir]
+
+
+def test_resolve_targets_dedup_same_platform(tmp_path):
+    """Multiple edits in one platform collapse to a single dir target."""
+    root = _make_nos_tree(tmp_path)
+    platform_dir = str(root / "platforms" / "cisco_ios")
+    changed = [
+        str(root / "platforms" / "cisco_ios" / "commands" / "show.yaml"),
+        str(root / "platforms" / "cisco_ios" / "commands" / "show.txt"),
+        str(root / "platforms" / "cisco_ios" / "platform.yaml"),
+    ]
+    assert resolve_reload_targets(changed, str(root)) == [platform_dir]
+
+
+def test_resolve_targets_py_module_passthrough(tmp_path):
+    """A `platforms_py/<p>.py` edit stays itself (not mistaken for an A3 dir)."""
+    root = _make_nos_tree(tmp_path)
+    pyfile = str(root / "platforms_py" / "cisco_ios.py")
+    assert resolve_reload_targets([pyfile], str(root)) == [pyfile]
+
+
+def test_resolve_targets_legacy_jinja_configurations(tmp_path):
+    """A legacy `configurations/<p>.yaml.j2` maps to its `.py` module."""
+    root = _make_nos_tree(tmp_path)
+    j2 = str(root / "platforms_py" / "configurations" / "huawei_smartax.yaml.j2")
+    assert resolve_reload_targets([j2], str(root)) == [str(root / "platforms_py" / "huawei_smartax.py")]
+
+
+def test_resolve_targets_legacy_jinja_templates(tmp_path):
+    """A legacy `templates/<p>/<cmd>.j2` maps to its `.py` module."""
+    root = _make_nos_tree(tmp_path)
+    j2 = str(root / "platforms_py" / "templates" / "cisco_ios" / "show_run.j2")
+    assert resolve_reload_targets([j2], str(root)) == [str(root / "platforms_py" / "cisco_ios.py")]
+
+
+def test_resolve_targets_drops_non_plugin_and_stray(tmp_path):
+    """Non-plugin files and a stray file directly under `platforms/` are dropped."""
+    root = _make_nos_tree(tmp_path)
+    assert resolve_reload_targets([str(root / "README.txt")], str(root)) == []
+    # `platforms/foo.yaml` has no `<p>/` level (min-segment guard) -> dropped.
+    assert resolve_reload_targets([str(root / "platforms" / "foo.yaml")], str(root)) == []
+
+
+def test_resolve_targets_drops_deleted_platform_dir(tmp_path):
+    """An old-only path whose whole platform dir is gone is dropped (not reloaded)."""
+    root = _make_nos_tree(tmp_path)
+    ghost = str(root / "platforms" / "ghost" / "commands" / "show.yaml")
+    assert resolve_reload_targets([ghost], str(root)) == []
+
+
+def test_get_files_changed_root_change_reseeds(tmp_path):
+    """A changed watch root re-seeds instead of reporting all prior paths (#274 / D7)."""
+    shell_utils._files_lasttime_changed_old.clear()
+    shell_utils._watch_root = None
+    root_a = _make_nos_tree(tmp_path / "a")
+    root_b = _make_nos_tree(tmp_path / "b")
+    assert get_files_changed(str(root_a)) == []  # seed A
+    assert get_files_changed(str(root_b)) == []  # root change -> re-seed, no phantom diff
+    shell_utils._files_lasttime_changed_old.clear()
+    shell_utils._watch_root = None
+
+
+def test_get_files_changed_detects_deletion(tmp_path):
+    """Deleting a command file rolls up to the (healthy) platform dir (#274 / D7)."""
+    shell_utils._files_lasttime_changed_old.clear()
+    shell_utils._watch_root = None
+    root = _make_nos_tree(tmp_path)
+    platform_dir = str(root / "platforms" / "cisco_ios")
+    assert get_files_changed(str(root)) == []  # seed
+    (root / "platforms" / "cisco_ios" / "commands" / "show.yaml").unlink()
+    assert get_files_changed(str(root)) == [platform_dir]
+    shell_utils._files_lasttime_changed_old.clear()
+    shell_utils._watch_root = None

--- a/tests/plugins/test_shell_utils.py
+++ b/tests/plugins/test_shell_utils.py
@@ -277,7 +277,10 @@ def test_resolve_targets_drops_unrecognized_jinja(tmp_path):
     root = _make_nos_tree(tmp_path)
     stray = str(root / "README.j2")
     unknown_shape = str(root / "platforms_py" / "notes" / "foo.j2")
-    assert resolve_reload_targets([stray, unknown_shape], str(root)) == []
+    # In the configurations dir but not a `<platform>.yaml.j2` — without the
+    # suffix check this would fabricate `README.j2.py` (2nd round codex #1).
+    non_config = str(root / "platforms_py" / "configurations" / "README.j2")
+    assert resolve_reload_targets([stray, unknown_shape, non_config], str(root)) == []
 
 
 def test_resolve_targets_drops_deleted_platform_dir(tmp_path):

--- a/tests/plugins/test_shell_utils.py
+++ b/tests/plugins/test_shell_utils.py
@@ -8,6 +8,8 @@ import time
 from unittest import TestCase
 from unittest.mock import patch
 
+import pytest
+
 from simnos.plugins.shell import utils as shell_utils
 from simnos.plugins.shell.utils import (
     get_files_changed,
@@ -164,19 +166,17 @@ class ShellUtilsTest(TestCase):
         self.assertFalse(targets)  # first call: seed only, no diff
         with patch("os.stat", side_effect=mock_os_stat):
             targets = get_files_changed("simnos/plugins/nos")
-        self.assertTrue(targets)
-        # The single changed RANDOM_FILE maps to exactly its rollup target.
-        expected = resolve_reload_targets([RANDOM_FILE], "simnos/plugins/nos")
-        self.assertTrue(set(expected).issubset(set(targets)))
+        # RANDOM_FILE is the only change, so the result is exactly its rollup target.
+        self.assertEqual(targets, resolve_reload_targets([RANDOM_FILE], "simnos/plugins/nos"))
 
     def test_get_files_changed_null(self):
         """
         Test to check if we don't get the files that have been changed
         """
-        files = get_files_changed("simnos/plugins/nos")
-        self.assertFalse(files)
-        files = get_files_changed("simnos/plugins/nos")
-        self.assertFalse(files)
+        targets = get_files_changed("simnos/plugins/nos")
+        self.assertFalse(targets)
+        targets = get_files_changed("simnos/plugins/nos")
+        self.assertFalse(targets)
 
 
 # --- resolve_reload_targets (#274 / D1) --------------------------------------
@@ -253,32 +253,44 @@ def test_resolve_targets_drops_non_plugin_and_stray(tmp_path):
 
 
 def test_resolve_targets_drops_deleted_platform_dir(tmp_path):
-    """An old-only path whose whole platform dir is gone is dropped (not reloaded)."""
+    """An old-only path whose whole platform dir is gone is dropped (not reloaded).
+
+    The `.j2` case pins that a deleted platform's A3 path never falls through to
+    the legacy `.j2`->py mapping (which would fabricate a bogus py target).
+    """
     root = _make_nos_tree(tmp_path)
-    ghost = str(root / "platforms" / "ghost" / "commands" / "show.yaml")
-    assert resolve_reload_targets([ghost], str(root)) == []
+    ghost_yaml = str(root / "platforms" / "ghost" / "commands" / "show.yaml")
+    ghost_j2 = str(root / "platforms" / "ghost" / "commands" / "show.j2")
+    assert resolve_reload_targets([ghost_yaml, ghost_j2], str(root)) == []
 
 
-def test_get_files_changed_root_change_reseeds(tmp_path):
-    """A changed watch root re-seeds instead of reporting all prior paths (#274 / D7)."""
+@pytest.fixture
+def _clean_watcher():
+    """Reset the module-global watcher snapshot around a test (#274 / D7).
+
+    Same contract as `ShellUtilsTest.setUp/tearDown` and the autouse fixture in
+    `test_cmd_shell_a3.TestA3HotReload` — without it, another test's snapshot
+    (possibly for a different root) leaks phantom changes into this one.
+    """
     shell_utils._files_lasttime_changed_old.clear()
     shell_utils._watch_root = None
+    yield
+    shell_utils._files_lasttime_changed_old.clear()
+    shell_utils._watch_root = None
+
+
+def test_get_files_changed_root_change_reseeds(tmp_path, _clean_watcher):
+    """A changed watch root re-seeds instead of reporting all prior paths (#274 / D7)."""
     root_a = _make_nos_tree(tmp_path / "a")
     root_b = _make_nos_tree(tmp_path / "b")
     assert get_files_changed(str(root_a)) == []  # seed A
     assert get_files_changed(str(root_b)) == []  # root change -> re-seed, no phantom diff
-    shell_utils._files_lasttime_changed_old.clear()
-    shell_utils._watch_root = None
 
 
-def test_get_files_changed_detects_deletion(tmp_path):
+def test_get_files_changed_detects_deletion(tmp_path, _clean_watcher):
     """Deleting a command file rolls up to the (healthy) platform dir (#274 / D7)."""
-    shell_utils._files_lasttime_changed_old.clear()
-    shell_utils._watch_root = None
     root = _make_nos_tree(tmp_path)
     platform_dir = str(root / "platforms" / "cisco_ios")
     assert get_files_changed(str(root)) == []  # seed
     (root / "platforms" / "cisco_ios" / "commands" / "show.yaml").unlink()
     assert get_files_changed(str(root)) == [platform_dir]
-    shell_utils._files_lasttime_changed_old.clear()
-    shell_utils._watch_root = None


### PR DESCRIPTION
🐙claude:

Closes #274

## 概要

#264 の A3 移行 (platform データが `platforms/<p>/platform.yaml + commands/*` の dir 形式化) で実質機能しなくなっていた dev hot-reload (`SIMNOS_RELOAD_COMMANDS`) を、A3 形式で機能させる。

設計: `design/20260612_190034_claude_issue-274-a3-hot-reload.md` (D1-D8、design cross-review 2 round 反映済・確定)。

## 壊れていたもの (A3 移行後)

- 個別 `commands/*.yaml` が `from_file` に渡り「Unsupported file extension」ValueError → 編集のたび error log + 旧データ据え置き
- `.txt` (A3 literal capture) が watch 対象外
- `.j2` が旧 py-plugin 前提の変換で実在しない py パスへ誤マップ
- rollback に `resolved_platform` が無く A3 reload 失敗時に復元不能

## 変更内容

### watcher 層 (`simnos/plugins/shell/utils.py`)
| 変更 | 設計 |
|---|---|
| `resolve_reload_targets` 新設 — changed file を reload 単位へ丸める。判定順 **A3-dir rollup (最優先) → legacy `.j2`→py → `.py` → drop+debug log**。`platforms_py` は segment 完全一致で除外、ghost platform (dir 消滅) も drop | D1 |
| `_legacy_jinja_to_py` — 既知 2 形状 (`configurations/<p>.yaml.j2` / `templates/<p>/<cmd>.j2`) のみ map、他は None → drop (bogus py target の捏造防止) | D1 |
| `.txt` を watch 対象に追加 | D2 |
| `get_files_changed` — **root-aware snapshot** (root 変更で再 seed、seed キーは root のみ = 空 root も正当 baseline) + **削除検知** (old-only path も changed 扱い → dir rollup で伝播) | D7 |

### shell 層 (`simnos/plugins/shell/cmd_shell.py`)
| 変更 | 設計 |
|---|---|
| **ownership filter** — `reload_commands` が foreign A3 platform dir を skip。anchor は構築時 capture の `_platform_name` (foreign py reload による live `nos.name` 上書きに免疫)。`git checkout` で session が別機種に乗っ取られるのを防止 | D6 |
| `_NOS_RELOAD_ATTRS` に `resolved_platform` 追加 — post-commit `_rebuild` 失敗の rollback を A3 対応 | D3 |
| `precmd` の語彙を `reload_targets` へ | D1 |

### テスト
- `test_shell_utils.py`: rollup/dedup/drop (非プラグイン・unrecognized `.j2`・ghost platform)/削除検知/root 再 seed/空 root 初 file/拡張子排除性 (tmp tree 直接 pin、`.bak` 非 watch は #232 `_atomic_write` が依存する load-bearing 契約)
- `test_cmd_shell_a3.py` `TestA3HotReload`: precmd E2E (編集反映 + 新規 yaml 出現)、D3 post-commit rollback、D6 foreign skip + anchor 生存、mode degrade — すべて tmp platform (実ツリー非 mutate)
- 既存 `HotReloadTest` は**無改変で green** (per-file lenient/rollback 契約 #232/#264 維持)

## レビュー

- design cross-review 2 round (1st MUST FIX: 他 platform 乗っ取り → D6 / 2nd SHOULD FIX: anchor 自壊 + root 非保持 → capture 化 + root-aware)
- code cross-review 2 round (1st SHOULD FIX: 排除性テストが空虚に真 → tmp tree pin / 2nd SHOULD FIX: configurations 形状の suffix 未検証 → `.yaml.j2` guard)。2nd round で claude「収束している」/ gemini LGTM 相当
- defer (理由付き): `.py` target の platforms_py 絞り込み (reload 対象 py の SSoT は registry の glob、watcher への契約複製は drift の種。誤爆は per-file guard が dev ログ 1 行で握る)

## Follow-up 候補 (起票は別途判断)
- `lint-platform-data` に「py NAME == filename stem == A3 dir basename」規約 lint (D6 anchor 前提の保護)
- watcher snapshot の per-shell 化 (consume-once の multi-session/multi-host 制約解消)

## 検証
- full CI green: ruff / format / yamllint / ty / lint-platform-data / **full suite 1061 passed** (integration 込み)
- **実 SSH 自己検証** (reload server + tmux ssh client): `.txt` 編集が live session に反映 ✅ / juniper 編集でも cisco session 非乗っ取り ✅ / `git checkout` 復元も反映 ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)