### PR TITLE
test: py-only platform の registry→shell→wire e2e pin を追加 (#277)

### DIFF
--- a/tests/assets/synthetic_py_only.py
+++ b/tests/assets/synthetic_py_only.py
@@ -25,6 +25,11 @@ CONFIG_PROMPT: str = "{base_prompt}(config)#"
 # proving registry → shell → callable-output dispatch works for a py-only NOS.
 PY_ONLY_MARKER: str = "SYNTHETIC-PY-ONLY-MARKER"
 
+# This module's own `_default_` output. Distinct from the shell's BASIC_COMMANDS
+# default ("Unknown command"); the test asserts an unknown command returns THIS,
+# pinning that a py-only module's `_default_` wins the legacy merge precedence.
+PY_ONLY_DEFAULT: str = "% Invalid input detected at '^' marker."
+
 
 class SyntheticPyOnly(BaseDevice):
     """Minimal device exposing one dynamic command for the e2e pin."""
@@ -47,7 +52,7 @@ commands = {
         "prompt": [INITIAL_PROMPT, ENABLE_PROMPT],
     },
     "_default_": {
-        "output": "% Invalid input detected at '^' marker.",
+        "output": PY_ONLY_DEFAULT,
         "help": "Output to print for unknown commands",
         "prompt": [INITIAL_PROMPT, ENABLE_PROMPT],
     },

--- a/tests/assets/synthetic_py_only.py
+++ b/tests/assets/synthetic_py_only.py
@@ -1,0 +1,64 @@
+"""Synthetic py-only platform for the #277 end-to-end pin.
+
+Deliberately has NO A3 dir (`platforms/synthetic_py_only/`) — it exists only as
+this module, so it exercises the registry's py-only branch
+(`simnos/plugins/nos/__init__.py`, the `not in nos_plugins` append) and the
+legacy `build_resolved_platform` path (`nos.resolved_platform is None` →
+`adapt_legacy_commands`). That path is otherwise unexercised end to end because
+every shipped platform ships an A3 dir; #266's inventory/adapter rework could
+silently break it.
+
+Prompts mirror cisco_ios so a netmiko `cisco_ios` driver can connect and drive
+it (`terminal length 0` / `terminal width 511` answer netmiko's session prep).
+This is NOT a shipped platform — a test injects it into the registry with
+monkeypatch and removes it on teardown.
+"""
+
+from simnos.plugins.nos.platforms_py._templates.base_template import BaseDevice
+
+NAME: str = "synthetic_py_only"
+INITIAL_PROMPT: str = "{base_prompt}>"
+ENABLE_PROMPT: str = "{base_prompt}#"
+CONFIG_PROMPT: str = "{base_prompt}(config)#"
+
+# The dynamic handler's return value — the test asserts this reaches the wire,
+# proving registry → shell → callable-output dispatch works for a py-only NOS.
+PY_ONLY_MARKER: str = "SYNTHETIC-PY-ONLY-MARKER"
+
+
+class SyntheticPyOnly(BaseDevice):
+    """Minimal device exposing one dynamic command for the e2e pin."""
+
+    def make_show_marker(self, base_prompt, current_mode, current_prompt, command):
+        """Return a unique marker proving the dynamic handler reached the wire."""
+        return PY_ONLY_MARKER
+
+
+commands = {
+    "enable": {
+        "output": None,
+        "new_prompt": ENABLE_PROMPT,
+        "help": "enter exec prompt",
+        "prompt": INITIAL_PROMPT,
+    },
+    "show py-only": {
+        "output": SyntheticPyOnly.make_show_marker,
+        "help": "dynamic py-only marker command",
+        "prompt": [INITIAL_PROMPT, ENABLE_PROMPT],
+    },
+    "_default_": {
+        "output": "% Invalid input detected at '^' marker.",
+        "help": "Output to print for unknown commands",
+        "prompt": [INITIAL_PROMPT, ENABLE_PROMPT],
+    },
+    "terminal width 511": {
+        "output": "",
+        "help": "Set terminal width to 511",
+        "prompt": [INITIAL_PROMPT, ENABLE_PROMPT],
+    },
+    "terminal length 0": {
+        "output": "",
+        "help": "Set terminal length to 0",
+        "prompt": [INITIAL_PROMPT, ENABLE_PROMPT],
+    },
+}

--- a/tests/plugins/test_py_only_platform_e2e.py
+++ b/tests/plugins/test_py_only_platform_e2e.py
@@ -1,0 +1,83 @@
+"""End-to-end pin for a py-only platform (#277).
+
+Every shipped platform ships an A3 dir (`platforms/<p>/`), so the
+registry → shell → wire path for a platform that is ONLY a
+`platforms_py/<p>.py` module — no A3 dir — is otherwise unexercised end to end.
+That path is the legacy `build_resolved_platform` branch
+(`nos.resolved_platform is None` → `adapt_legacy_commands`), which #266's
+inventory/adapter rework could silently break.
+
+A synthetic py-only platform (`tests/assets/synthetic_py_only.py`) is injected
+into the registry for the duration of one test, then driven over a real netmiko
+session. The registry mutation is undone on teardown (`monkeypatch`), so the
+registry-invariant tests in `tests/core/test_simnos.py` — which run without this
+fixture — are unaffected (pytest-xdist workers are separate processes too).
+"""
+
+import os
+
+from netmiko import ConnectHandler
+import pytest
+
+from simnos.core.nos import Nos
+import simnos.plugins.nos as nos_registry
+from simnos.plugins.nos import nos_plugins
+from tests.utils import creds_from_host
+
+PY_ONLY_NAME = "synthetic_py_only"
+PY_ONLY_MODULE = os.path.abspath(os.path.join(os.path.dirname(__file__), "..", "assets", "synthetic_py_only.py"))
+PY_ONLY_MARKER = "SYNTHETIC-PY-ONLY-MARKER"
+
+
+@pytest.fixture
+def register_py_only(monkeypatch):
+    """Register the synthetic py-only platform in the registry for one test.
+
+    Mirrors what the import-time registry does for a real py-only module:
+    `nos_plugins[name] = [<p>.py]` and the name joins `available_platforms`
+    (the tuple `assert_platform_supported` gates host platforms against).
+    `monkeypatch` restores both on teardown.
+    """
+    monkeypatch.setitem(nos_plugins, PY_ONLY_NAME, [PY_ONLY_MODULE])
+    monkeypatch.setattr(nos_registry, "available_platforms", (*nos_registry.available_platforms, PY_ONLY_NAME))
+    return PY_ONLY_NAME
+
+
+def test_py_only_platform_takes_legacy_resolved_platform_path(register_py_only):
+    """A py-only NOS builds via the legacy path, not the A3 ResolvedPlatform.
+
+    Pins the registry contract: the module's `NAME` matches the registry key
+    (the filename stem), the dynamic command is loaded, and `resolved_platform`
+    stays None so the shell routes it through `adapt_legacy_commands` (#277).
+    """
+    nos = Nos(filename=nos_plugins[PY_ONLY_NAME])
+    assert nos.name == PY_ONLY_NAME
+    assert nos.resolved_platform is None
+    assert "show py-only" in nos.commands
+    # The dynamic output is a callable handler, not a literal — the py-only
+    # value proposition (dynamic behavior with no A3 statics).
+    assert callable(nos.commands["show py-only"]["output"])
+
+
+@pytest.mark.timeout(60)
+def test_py_only_platform_serves_dynamic_command_over_wire(register_py_only, simnos_factory):
+    """The registered py-only platform answers a dynamic command over the wire.
+
+    registry → SimNOS server → netmiko session → callable-output dispatch, end
+    to end. Driven with the `cisco_ios` netmiko driver (the synthetic prompts
+    mirror cisco_ios); the unique marker proves the dynamic handler's return
+    value reached the client unmodified (#277).
+    """
+    net = simnos_factory(PY_ONLY_NAME)
+    host = next(iter(net.hosts.values()))
+    creds = creds_from_host(host)
+    device = {
+        "device_type": "cisco_ios",
+        "host": "localhost",
+        "username": creds["username"],
+        "password": creds["password"],
+        "port": creds["port"],
+    }
+    with ConnectHandler(**device) as conn:
+        output = conn.send_command("show py-only")
+    assert PY_ONLY_MARKER in output

--- a/tests/plugins/test_py_only_platform_e2e.py
+++ b/tests/plugins/test_py_only_platform_e2e.py
@@ -22,11 +22,15 @@ import pytest
 from simnos.core.nos import Nos
 import simnos.plugins.nos as nos_registry
 from simnos.plugins.nos import nos_plugins
+from tests.assets.synthetic_py_only import PY_ONLY_MARKER
 from tests.utils import creds_from_host
 
+# The registry key is the filename stem; hardcoded (not derived from the asset's
+# NAME) so the `nos.name == PY_ONLY_NAME` assertion stays a real NAME==stem pin
+# rather than a vacuous self-comparison. PY_ONLY_MARKER is imported from the
+# asset (single source — its wire-delivered value is still asserted independently).
 PY_ONLY_NAME = "synthetic_py_only"
 PY_ONLY_MODULE = os.path.abspath(os.path.join(os.path.dirname(__file__), "..", "assets", "synthetic_py_only.py"))
-PY_ONLY_MARKER = "SYNTHETIC-PY-ONLY-MARKER"
 
 
 @pytest.fixture
@@ -57,6 +61,11 @@ def test_py_only_platform_takes_legacy_resolved_platform_path(register_py_only):
     # The dynamic output is a callable handler, not a literal — the py-only
     # value proposition (dynamic behavior with no A3 statics).
     assert callable(nos.commands["show py-only"]["output"])
+    # The 3 scalar prompts the legacy adapter consumes (build_resolved_platform
+    # passes exactly these to adapt_legacy_commands) are wired from the module.
+    assert nos.initial_prompt == "{base_prompt}>"
+    assert nos.enable_prompt == "{base_prompt}#"
+    assert nos.config_prompt == "{base_prompt}(config)#"
 
 
 @pytest.mark.timeout(60)

--- a/tests/plugins/test_py_only_platform_e2e.py
+++ b/tests/plugins/test_py_only_platform_e2e.py
@@ -22,13 +22,12 @@ import pytest
 from simnos.core.nos import Nos
 import simnos.plugins.nos as nos_registry
 from simnos.plugins.nos import nos_plugins
-from tests.assets.synthetic_py_only import PY_ONLY_MARKER
-from tests.utils import creds_from_host
+from tests.assets.synthetic_py_only import PY_ONLY_DEFAULT, PY_ONLY_MARKER
+from tests.utils import creds_from_host, netmiko_device
 
-# The registry key is the filename stem; hardcoded (not derived from the asset's
-# NAME) so the `nos.name == PY_ONLY_NAME` assertion stays a real NAME==stem pin
-# rather than a vacuous self-comparison. PY_ONLY_MARKER is imported from the
-# asset (single source — its wire-delivered value is still asserted independently).
+# The injection key mirrors the real registry, which keys a py-only module on
+# its filename stem. The markers are imported from the asset (single source);
+# their wire-delivered values are still asserted independently over the channel.
 PY_ONLY_NAME = "synthetic_py_only"
 PY_ONLY_MODULE = os.path.abspath(os.path.join(os.path.dirname(__file__), "..", "assets", "synthetic_py_only.py"))
 
@@ -39,23 +38,30 @@ def register_py_only(monkeypatch):
 
     Mirrors what the import-time registry does for a real py-only module:
     `nos_plugins[name] = [<p>.py]` and the name joins `available_platforms`
-    (the tuple `assert_platform_supported` gates host platforms against).
-    `monkeypatch` restores both on teardown.
+    (the tuple `assert_platform_supported` gates host platforms against). The
+    tuple is re-sorted to preserve its `tuple(sorted(nos_plugins.keys()))`
+    invariant (1st round 🦊#2). `monkeypatch` restores both on teardown.
     """
     monkeypatch.setitem(nos_plugins, PY_ONLY_NAME, [PY_ONLY_MODULE])
-    monkeypatch.setattr(nos_registry, "available_platforms", (*nos_registry.available_platforms, PY_ONLY_NAME))
+    monkeypatch.setattr(
+        nos_registry, "available_platforms", tuple(sorted((*nos_registry.available_platforms, PY_ONLY_NAME)))
+    )
     return PY_ONLY_NAME
 
 
 def test_py_only_platform_takes_legacy_resolved_platform_path(register_py_only):
     """A py-only NOS builds via the legacy path, not the A3 ResolvedPlatform.
 
-    Pins the registry contract: the module's `NAME` matches the registry key
-    (the filename stem), the dynamic command is loaded, and `resolved_platform`
-    stays None so the shell routes it through `adapt_legacy_commands` (#277).
+    Pins the registry contract: the module's `NAME` matches the filename stem
+    (the real registry's key), the dynamic command is loaded, and
+    `resolved_platform` stays None so the shell routes it through
+    `adapt_legacy_commands` (#277).
     """
-    nos = Nos(filename=nos_plugins[PY_ONLY_NAME])
-    assert nos.name == PY_ONLY_NAME
+    nos = Nos(filename=nos_plugins[register_py_only])
+    # NAME==stem pin (1st round 🐙#6): the real registry keys on the filename
+    # stem, so the module's NAME must equal it — comparing against the stem
+    # derived from the path (not a hardcoded constant) catches a typo'd NAME.
+    assert nos.name == os.path.basename(PY_ONLY_MODULE).removesuffix(".py")
     assert nos.resolved_platform is None
     assert "show py-only" in nos.commands
     # The dynamic output is a callable handler, not a literal — the py-only
@@ -70,23 +76,22 @@ def test_py_only_platform_takes_legacy_resolved_platform_path(register_py_only):
 
 @pytest.mark.timeout(60)
 def test_py_only_platform_serves_dynamic_command_over_wire(register_py_only, simnos_factory):
-    """The registered py-only platform answers a dynamic command over the wire.
+    """The registered py-only platform answers commands over the wire.
 
     registry → SimNOS server → netmiko session → callable-output dispatch, end
     to end. Driven with the `cisco_ios` netmiko driver (the synthetic prompts
-    mirror cisco_ios); the unique marker proves the dynamic handler's return
-    value reached the client unmodified (#277).
+    mirror cisco_ios). The unique marker proves the dynamic handler's return
+    value reached the client unmodified; the unknown-command check proves the
+    module's own `_default_` wins the legacy merge over the shell's BASIC
+    default ("Unknown command"), not just that some default answered (#277,
+    1st round 🦊#3).
     """
-    net = simnos_factory(PY_ONLY_NAME)
+    net = simnos_factory(register_py_only)
     host = next(iter(net.hosts.values()))
-    creds = creds_from_host(host)
-    device = {
-        "device_type": "cisco_ios",
-        "host": "localhost",
-        "username": creds["username"],
-        "password": creds["password"],
-        "port": creds["port"],
-    }
+    device = netmiko_device("cisco_ios", creds_from_host(host))
     with ConnectHandler(**device) as conn:
-        output = conn.send_command("show py-only")
-    assert PY_ONLY_MARKER in output
+        marker_output = conn.send_command("show py-only")
+        default_output = conn.send_command("definitely not a real command")
+    assert PY_ONLY_MARKER in marker_output
+    assert PY_ONLY_DEFAULT in default_output
+    assert "Unknown command" not in default_output


### PR DESCRIPTION
🐙claude:

## 概要
Issue #277。「A3 dir を持たず `platforms_py/<p>.py` モジュールのみで構成される py-only platform」の **registry 登録 → shell build → 代表コマンドの wire 出力** を end-to-end で pin する integration test を追加する。

現状 shipped platform は全て A3 dir 併設のため、py-only の e2e 経路 — legacy `build_resolved_platform`(`nos.resolved_platform is None` → `adapt_legacy_commands`、`simnos/plugins/shell/cmd_shell.py:60-67`)— が直接実証されていない。#266(inventory/adapter 刷新)がこの経路を黙って壊し得るため、回帰検知用の pin を置く。

Closes #277(v3 → main マージ時に発火)

## 主な変更
- **`tests/assets/synthetic_py_only.py`**(新規): 合成 py-only platform。A3 dir を持たず、`SyntheticPyOnly` device + `show py-only` dynamic handler(ユニーク marker 返却)+ module 固有 `_default_` + paging コマンド。prompt を cisco_ios 風にして netmiko `cisco_ios` driver で駆動可能。shipped 非対象で、test が registry に注入。
- **`tests/plugins/test_py_only_platform_e2e.py`**(新規):
  - `register_py_only` fixture: `monkeypatch.setitem(nos_plugins, ...)` + `setattr(available_platforms, ...)`(`tuple(sorted(...))` で derived invariant 保持)で合成 platform を registry 注入、teardown で復元。
  - **registry/legacy-path pin**: py-only NOS は `nos.name == filename stem`、`resolved_platform is None`(legacy 経路選択)、dynamic command が callable、3 scalar prompt(initial/enable/config = `adapt_legacy_commands` の入力)が wiring されることを確認。
  - **wire pin**: registry → SimNOS server → netmiko session → callable dispatch を端から端まで。`show py-only` の dynamic marker が wire 到達、かつ未知コマンドで module 側 `_default_`(`% Invalid input...`)が legacy merge で BASIC default(`Unknown command`)に勝つことを確認。

## 安全性(registry 注入)
`SimNOS.__init__` が module-global `nos_plugins` dict をそのまま束縛し、`assert_platform_supported` が呼び出し毎に `available_platforms` を読むため、`monkeypatch` の setitem/setattr 双方が host gate に効く。teardown 復元 + pytest-xdist の worker 別プロセスにより、`tests/core/test_simnos.py` の registry-invariant test(`available_platforms == sorted(nos_plugins.keys())` 等)とは非干渉。

## cross-review(1st round)
3 reviewer(codex / gemini / claude)とも **SUGGESTION**(MUST/SHOULD FIX 0)。3 者一致で「py-only legacy 経路を非 vacuous に踏む妥当な regression pin」と確認。取り込み 5 件:
- wire test を `netmiko_device()` ヘルパに寄せて既存 wire test と pattern 統一(🐙#4 / 🦊#1)
- NAME==stem pin を filename stem との突合に変更し NAME typo を捕捉(🐙#6)
- module 側 `_default_` の precedence を wire で pin(🦊#3)
- `available_platforms` 注入で sorted invariant 保持(🦊#2)
- fixture 返り値の活用(🐳#4)

**defer(理由明記)**: pathlib 化 / import 二重引き(os.path 主体の既存統一・別名は `setattr` 都合で意図的) / fixture helper 切り出し(本 test 単独使用で過剰)。

## 検証
- 新規 2 test passed(wire 含む)/ full suite **1076 passed**(integration 込み)/ ruff・format・yamllint・ty 全 green
- `invoke lint-platform-data` OK(asset は `tests/assets/` 配下で lint 非対象)

## 関連
- epic #263 / #264(PR-3 #275)/ #266(inventory・adapter 刷新 — この pin が守る対象)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
