### PR TITLE
feat: inventory platform → device_type rename + alias 解決 (#266 PR1 = D1+D2+D3)

### DIFF
--- a/docker/inventory.yaml
+++ b/docker/inventory.yaml
@@ -13,4 +13,4 @@ hosts:
     - 6001
     - 6002
     replicas: 2
-    platform: cisco_ios
+    device_type: cisco_ios

--- a/simnos/core/host.py
+++ b/simnos/core/host.py
@@ -9,7 +9,7 @@ from typing import TYPE_CHECKING
 
 from simnos.core.nos import Nos
 from simnos.core.pydantic_models import ModelHost
-from simnos.plugins.nos import assert_platform_supported
+from simnos.plugins.nos import assert_platform_supported, resolve_device_type
 
 if TYPE_CHECKING:
     from simnos.core.simnos import SimNOS
@@ -32,7 +32,7 @@ class Host:
         shell: dict,
         nos: dict,
         simnos: "SimNOS",
-        platform: str | None = None,
+        device_type: str | None = None,
         configuration_file: str | None = None,
     ) -> None:
         self.name: str = name
@@ -50,11 +50,11 @@ class Host:
         self.shell_plugin = None
         self.nos_plugin = None
         self.nos = None
-        self.platform: str | None = platform
+        self.device_type: str | None = device_type
         self.configuration_file: str | None = configuration_file
 
-        if self.platform:
-            self.nos_inventory["plugin"] = self.platform
+        if self.device_type:
+            self.nos_inventory["plugin"] = self.device_type
 
         self._validate()
 
@@ -73,7 +73,14 @@ class Host:
             return
         self.server_plugin = self.simnos.servers_plugins[self.server_inventory["plugin"]]
         self.shell_plugin = self.simnos.shell_plugins[self.shell_inventory["plugin"]]
-        self.nos_plugin = self.simnos.nos_plugins.get(self.nos_inventory["plugin"], self.nos_inventory["plugin"])
+        # device_type -> platform (registry key) resolution chokepoint (#266 / D2,
+        # Decision 8): all three plugin-key paths converge here — an explicit
+        # `device_type` (assigned in __init__), the `nos.plugin` default, and a
+        # direct `nos: {plugin: ...}`. `resolve_device_type` maps netmiko/ntc
+        # aliases (and identity names) to the registry key; an unknown value
+        # (e.g. a runtime-registered custom plugin) falls through unchanged.
+        plugin_key = resolve_device_type(self.nos_inventory["plugin"]) or self.nos_inventory["plugin"]
+        self.nos_plugin = self.simnos.nos_plugins.get(plugin_key, plugin_key)
         self.nos = (
             Nos(filename=self.nos_plugin, configuration_file=self.configuration_file)
             if not isinstance(self.nos_plugin, Nos)
@@ -107,14 +114,16 @@ class Host:
 
     def _validate(self):
         """Validate that the host has the required attributes using pydantic"""
-        if self.platform:
-            self._check_if_platform_is_supported(self.platform)
+        if self.device_type:
+            self._check_if_platform_is_supported(self.device_type)
         ModelHost(**self.__dict__)
 
-    def _check_if_platform_is_supported(self, platform: str):
-        """Check if the platform is supported.
+    def _check_if_platform_is_supported(self, device_type: str):
+        """Check that `device_type` resolves to a supported platform.
 
         Thin wrapper around the registry-level helper; kept as a method
-        because tests patch / call it as the Host-level seam (#237).
+        because tests patch / call it as the Host-level seam (#237). The
+        argument is the inventory `device_type` (#266); `assert_platform_supported`
+        accepts both internal platform names and netmiko/ntc aliases.
         """
-        assert_platform_supported(platform)
+        assert_platform_supported(device_type)

--- a/simnos/core/pydantic_models.py
+++ b/simnos/core/pydantic_models.py
@@ -301,7 +301,7 @@ class ModelHost(BaseModel):
     username: StrictStr
     password: StrictStr
     port: Port
-    platform: StrictStr | None = None
+    device_type: StrictStr | None = None
 
 
 # ---------------------------------------------------------------------------------------
@@ -400,7 +400,7 @@ class InventoryDefaultSection(BaseModel):
     password: StrictStr | None = None
     port: Port | list[Port] | None = None
     configuration_file: StrictStr | None = None
-    platform: StrictStr | None = None
+    device_type: StrictStr | None = None
     server: ParamikoSshServerPlugin | TelnetServerPlugin | None = None
     shell: CMDShellPlugin | None = None
     nos: NosPlugin | None = None

--- a/simnos/core/simnos.py
+++ b/simnos/core/simnos.py
@@ -48,9 +48,9 @@ default_inventory = {
         "nos": {"plugin": "cisco_ios", "configuration": {}},
     },
     "hosts": {
-        "router_cisco_ios": {"port": DEFAULT_PORT_START, "platform": "cisco_ios"},
-        "router_huawei_smartax": {"port": DEFAULT_PORT_START + 1, "platform": "huawei_smartax"},
-        "router_arista_eos": {"port": DEFAULT_PORT_START + 2, "platform": "arista_eos"},
+        "router_cisco_ios": {"port": DEFAULT_PORT_START, "device_type": "cisco_ios"},
+        "router_huawei_smartax": {"port": DEFAULT_PORT_START + 1, "device_type": "huawei_smartax"},
+        "router_arista_eos": {"port": DEFAULT_PORT_START + 2, "device_type": "arista_eos"},
     },
 }
 
@@ -468,23 +468,23 @@ def _get_free_port() -> int:
         return s.getsockname()[1]
 
 
-def simnos(platform: str | None = None, inventory: dict | str | None = None, return_instance: bool = False):
+def simnos(device_type: str | None = None, inventory: dict | str | None = None, return_instance: bool = False):
     """
     Decorator to run a test with SimNOS server.
     """
-    if platform and inventory:
-        raise ValueError("platform and inventory cannot be used together")
-    if not platform and not inventory:
-        raise ValueError("platform or inventory must be set")
-    if platform:
-        assert_platform_supported(platform)
+    if device_type and inventory:
+        raise ValueError("device_type and inventory cannot be used together")
+    if not device_type and not inventory:
+        raise ValueError("device_type or inventory must be set")
+    if device_type:
+        assert_platform_supported(device_type)
         inventory = {
             "hosts": {
                 "SimNOS": {
                     "username": "test",
                     "password": "test",
                     "port": _get_free_port(),
-                    "platform": platform,
+                    "device_type": device_type,
                 }
             }
         }

--- a/simnos/plugins/nos/__init__.py
+++ b/simnos/plugins/nos/__init__.py
@@ -153,7 +153,10 @@ def assert_platform_supported(platform: str) -> None:
     """
     if resolve_device_type(platform) is None:
         # Join the names so the user-facing message does not leak the
-        # registry container type (tuple vs list repr).
+        # registry container type (tuple vs list repr). Spell out that
+        # netmiko/ntc aliases are accepted too, so a user who typed an alias
+        # is not misled by the canonical-only list (#266 1st round gemini #4).
         raise ValueError(
-            f"Platform {platform} is not supported by SIMNOS. Supported platforms are: {', '.join(available_platforms)}"
+            f"Platform {platform} is not supported by SIMNOS. Supported platforms are: "
+            f"{', '.join(available_platforms)} (their netmiko_device_type / ntc_platform aliases are also accepted)."
         )

--- a/simnos/plugins/nos/__init__.py
+++ b/simnos/plugins/nos/__init__.py
@@ -14,10 +14,23 @@ static command data.
 ``available_platforms`` is the public derived view of this registry —
 ``simnos.core.nos.available_platforms`` re-exports it for backward
 compatibility with callers that still import from the core module.
+
+Inventory refers to a platform by its ``device_type`` (#266): besides the
+internal platform name (= directory basename, the registry key), a platform's
+``netmiko_device_type`` / ``ntc_platform`` aliases also resolve to it via the
+``device_type_to_platform`` reverse index built below.
 """
 
 import glob
+import logging
 import os
+
+from pydantic import ValidationError
+import yaml
+
+from simnos.core.platform_loader import PLATFORM_META_FILENAME, _load_platform_meta
+
+log = logging.getLogger(__name__)
 
 nos_plugins: dict = {}
 
@@ -27,12 +40,14 @@ current_directory = os.path.dirname(current_file_path)
 # Load A3 platform dirs (the command-data form, #264 / D6): each
 # `platforms/<name>/` holding a `platform.yaml` is one platform, discovered by
 # directory name (no parse needed for the registry).
+_a3_platform_dirs: dict[str, str] = {}
 platforms_directory_a3 = os.path.join(current_directory, "platforms")
 if os.path.isdir(platforms_directory_a3):
     for entry in sorted(os.listdir(platforms_directory_a3)):
         dirpath = os.path.join(platforms_directory_a3, entry)
-        if os.path.isfile(os.path.join(dirpath, "platform.yaml")):
+        if os.path.isfile(os.path.join(dirpath, PLATFORM_META_FILENAME)):
             nos_plugins[entry] = [dirpath]
+            _a3_platform_dirs[entry] = dirpath
 
 # load NOS from python modules updating the NOS.
 # The glob is non-recursive on purpose: authoring templates (BaseDevice in
@@ -55,14 +70,88 @@ for file in py_files:
 available_platforms: tuple[str, ...] = tuple(sorted(nos_plugins.keys()))
 
 
-def assert_platform_supported(platform: str) -> None:
-    """Raise ValueError if `platform` is not a registered NOS plugin.
+def _build_device_type_index() -> dict[str, str]:
+    """Build the ``device_type -> platform`` (registry key) reverse index (#266 / D2).
 
-    Shared by `Host._validate` and the `@simnos` test decorator so the
-    check and its error message live next to the registry they guard
-    (#237, G1 follow-up).
+    Each platform contributes up to three accepted ``device_type`` spellings:
+    its own name (*identity*), and the ``netmiko_device_type`` / ``ntc_platform``
+    aliases declared in ``platform.yaml``. Identity is registered first so a
+    platform name always wins over a colliding alias from another platform.
+
+    Collision rule (value comparison, not key presence): re-registering the same
+    ``(key -> platform)`` pair is a harmless no-op — the common case today, since
+    every platform currently has ``name == netmiko_device_type == ntc_platform``.
+    A key that would map to a *different* platform is a real collision and raises.
+    ``None`` / empty aliases are not registered.
+
+    Degradation (#266 / R2): a ``platform.yaml`` that fails to parse (YAML / I/O /
+    schema) is skipped with a warning rather than aborting the whole import. The
+    platform stays reachable by its identity name and fails loudly later at
+    ``Host.start()`` / ``load_platform_dir``.
     """
-    if platform not in available_platforms:
+    index: dict[str, str] = {}
+
+    def register(key: str | None, platform: str) -> None:
+        if not key:
+            return  # None / empty string is not a usable device_type
+        prev = index.get(key)
+        if prev is not None and prev != platform:
+            raise ValueError(f"device_type alias collision: {key!r} maps to both {prev!r} and {platform!r}")
+        index[key] = platform
+
+    # Identity first (every registered platform, A3 dir or .py module).
+    for platform in nos_plugins:
+        register(platform, platform)
+    # Aliases come from A3 platform.yaml only (.py modules carry no metadata).
+    for platform, dirpath in _a3_platform_dirs.items():
+        try:
+            meta = _load_platform_meta(os.path.join(dirpath, PLATFORM_META_FILENAME))
+        except (yaml.YAMLError, OSError, ValidationError, ValueError) as exc:
+            log.warning("device_type index: skipping %s metadata (%s) — identity name only", platform, exc)
+            continue
+        register(meta.netmiko_device_type, platform)
+        register(meta.ntc_platform, platform)
+    return index
+
+
+device_type_to_platform: dict[str, str] = _build_device_type_index()
+
+
+def resolve_device_type(device_type: str) -> str | None:
+    """Resolve an inventory ``device_type`` to its platform registry key (#266 / D2).
+
+    Returns the internal platform name for any accepted ``device_type``:
+    - a ``netmiko_device_type`` / ``ntc_platform`` alias, via the static index;
+    - any registered platform's own name (*identity*), checked dynamically
+      against ``nos_plugins`` so that platforms registered *after* import — a
+      custom plugin from ``SimNOS(plugins=[...])`` or a test-injected one —
+      still resolve by their own name even though the import-time index predates
+      them.
+
+    Returns ``None`` when the value is not a known device_type, which lets
+    callers fall back to the raw value (the chokepoint then hands it to the
+    registry ``.get(key, key)`` as-is).
+    """
+    mapped = device_type_to_platform.get(device_type)
+    if mapped is not None:
+        return mapped
+    if device_type in nos_plugins:
+        return device_type
+    return None
+
+
+def assert_platform_supported(platform: str) -> None:
+    """Raise ValueError if `platform` is not a registered/resolvable device_type.
+
+    Accepts either an internal platform name or a ``netmiko_device_type`` /
+    ``ntc_platform`` alias (anything `resolve_device_type` recognizes). Shared by
+    `Host._validate` and the `@simnos` test decorator so the check and its error
+    message live next to the registry they guard (#237, G1 follow-up; #266 D2
+    broadened it from a plain `available_platforms` membership test to alias
+    resolution). The message lists the canonical platform names; aliases resolve
+    to one of them.
+    """
+    if resolve_device_type(platform) is None:
         # Join the names so the user-facing message does not leak the
         # registry container type (tuple vs list repr).
         raise ValueError(

--- a/simnos/plugins/nos/platforms/edgecore/platform.yaml
+++ b/simnos/plugins/nos/platforms/edgecore/platform.yaml
@@ -4,5 +4,5 @@ modes:
   enable:
     prompt: "{{ base_prompt }}#"
 initial_mode: user
-netmiko_device_type: edgecore
+netmiko_device_type: edgecore_sonic
 ntc_platform: edgecore

--- a/simnos/plugins/nos/platforms/extreme_slxos/platform.yaml
+++ b/simnos/plugins/nos/platforms/extreme_slxos/platform.yaml
@@ -4,5 +4,5 @@ modes:
   config:
     prompt: "{{ base_prompt }}(config)#"
 initial_mode: user
-netmiko_device_type: extreme_slxos
+netmiko_device_type: extreme_slx
 ntc_platform: extreme_slxos

--- a/simnos/plugins/nos/platforms/watchguard_firebox/platform.yaml
+++ b/simnos/plugins/nos/platforms/watchguard_firebox/platform.yaml
@@ -4,5 +4,5 @@ modes:
   config:
     prompt: "{{ base_prompt }}(config)#"
 initial_mode: user
-netmiko_device_type: watchguard_firebox
+netmiko_device_type: watchguard_fireware
 ntc_platform: watchguard_firebox

--- a/tasks.py
+++ b/tasks.py
@@ -162,6 +162,47 @@ def check_platform_data_warnings(platforms_dir: str = PLATFORMS_A3_DIR) -> list[
     return warnings
 
 
+def check_platform_data_device_type_collisions(platforms_dir: str = PLATFORMS_A3_DIR) -> list[str]:
+    """Flag device_type alias collisions across A3 platforms (#266 / D2 defense-in-depth).
+
+    Mirrors the runtime reverse-index guard in :mod:`simnos.plugins.nos`: each
+    platform contributes its own name (*identity*) plus its ``netmiko_device_type``
+    / ``ntc_platform`` aliases as device_type keys. A key that resolves to more
+    than one platform is a collision — including an alias that lands on another
+    platform's identity name (2nd round gemini #3). The runtime guard already
+    raises on import; this surfaces the same conflict at authoring time with a
+    clear message instead of an import crash. Re-registering the same
+    ``(key -> platform)`` pair (the common ``name == netmiko == ntc`` case) is a
+    no-op, matching the runtime value-comparison rule.
+
+    Returns a list of human-readable violation strings (empty = clean).
+    """
+    index: dict[str, str] = {}
+    violations: list[str] = []
+
+    def register(key, platform: str, kind: str) -> None:
+        if not key or not isinstance(key, str):
+            return
+        prev = index.get(key)
+        if prev is not None and prev != platform:
+            violations.append(f"device_type collision: {key!r} ({kind} of {platform}) already maps to {prev}")
+            return
+        index[key] = platform
+
+    names = list_a3_platform_names(platforms_dir)
+    # Identity first (same order discipline as the runtime guard) so an alias
+    # colliding with another platform's name is reported against the alias.
+    for platform in names:
+        register(platform, platform, "identity")
+    for platform in names:
+        meta_path = os.path.join(platforms_dir, platform, "platform.yaml")
+        with open(meta_path, encoding="utf-8") as f:
+            meta = yaml.safe_load(f) or {}
+        register(meta.get("netmiko_device_type"), platform, "netmiko_device_type")
+        register(meta.get("ntc_platform"), platform, "ntc_platform")
+    return violations
+
+
 def _variant_output_refs(command_data: dict) -> list[str]:
     """The output file each variant references (str-typed entries only)."""
     return [
@@ -337,7 +378,9 @@ def lint_platform_data(context):
     shared output references, extension convention, stray ``.yml`` (see
     `check_platform_data`) + the authoring baseline ratchet (`_default_`
     presence / stub help / heritage wording, see
-    `check_platform_data_ratchet`). Warning-tier (printed, non-blocking):
+    `check_platform_data_ratchet`) + device_type alias collisions across
+    platforms (#266, see `check_platform_data_device_type_collisions`).
+    Warning-tier (printed, non-blocking):
     filename convention + ``type: ntc`` provenance (see
     `check_platform_data_warnings`).
     """
@@ -354,7 +397,7 @@ def lint_platform_data(context):
     if warnings:
         print(f"({len(warnings)} warning(s) — informational, not blocking)")
 
-    violations = check_platform_data() + check_platform_data_ratchet()
+    violations = check_platform_data() + check_platform_data_ratchet() + check_platform_data_device_type_collisions()
     for violation in violations:
         print(violation)
     if violations:
@@ -576,7 +619,7 @@ def netmiko_check(ctx, device_type: str):
             "host1": {
                 "username": "user",
                 "password": "user",
-                "platform": device_type,
+                "device_type": device_type,
                 "port": 6000,
             }
         }

--- a/tasks.py
+++ b/tasks.py
@@ -196,8 +196,18 @@ def check_platform_data_device_type_collisions(platforms_dir: str = PLATFORMS_A3
         register(platform, platform, "identity")
     for platform in names:
         meta_path = os.path.join(platforms_dir, platform, "platform.yaml")
-        with open(meta_path, encoding="utf-8") as f:
-            meta = yaml.safe_load(f) or {}
+        # A malformed platform.yaml becomes a violation string rather than a
+        # crashing traceback, so the lint stays symmetric with the runtime
+        # index guard's warn+skip degradation (#266 1st round gemini #6 / claude #4).
+        try:
+            with open(meta_path, encoding="utf-8") as f:
+                meta = yaml.safe_load(f)
+        except (yaml.YAMLError, OSError) as exc:
+            violations.append(f"{platform}/platform.yaml: unreadable for device_type collision check ({exc})")
+            continue
+        if not isinstance(meta, dict):
+            violations.append(f"{platform}/platform.yaml: not a mapping; cannot check device_type aliases")
+            continue
         register(meta.get("netmiko_device_type"), platform, "netmiko_device_type")
         register(meta.get("ntc_platform"), platform, "ntc_platform")
     return violations

--- a/tests/assets/inventory.yaml
+++ b/tests/assets/inventory.yaml
@@ -3,9 +3,9 @@ hosts:
     username: simnos
     password: simnos
     port: 5001
-    platform: huawei_smartax
+    device_type: huawei_smartax
   R2:
     username: simnos
     password: simnos
     port: 6000
-    platform: cisco_ios
+    device_type: cisco_ios

--- a/tests/assets/inventory_configuration.yaml
+++ b/tests/assets/inventory_configuration.yaml
@@ -3,5 +3,5 @@ hosts:
     username: simnos
     password: simnos
     port: 5001
-    platform: huawei_smartax
+    device_type: huawei_smartax
     configuration_file: "tests/assets/test_module.yaml.j2"

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -15,11 +15,11 @@ from tests.utils import build_inventory
 
 @pytest.fixture
 def simnos_factory():
-    """Factory fixture: start a SimNOS for a platform, auto-stop on teardown."""
+    """Factory fixture: start a SimNOS for a device_type, auto-stop on teardown."""
     started: list[SimNOS] = []
 
-    def _make(platform: str, **overrides) -> SimNOS:
-        net = SimNOS(inventory=build_inventory(platform, **overrides))
+    def _make(device_type: str, **overrides) -> SimNOS:
+        net = SimNOS(inventory=build_inventory(device_type, **overrides))
         # Register before start() so a mid-start failure (partly-started hosts)
         # is still torn down. SimNOS.stop() is a no-op for unstarted hosts.
         started.append(net)

--- a/tests/core/test_netmiko.py
+++ b/tests/core/test_netmiko.py
@@ -17,7 +17,7 @@ import pytest
 
 from simnos import SimNOS
 from simnos.core.nos import available_platforms
-from tests.utils import NETMIKO_DEVICE_TYPE_MAP, generate_random_string, get_free_port, get_platforms_from_md
+from tests.utils import generate_random_string, get_free_port, get_platforms_from_md, netmiko_device_type_of
 
 
 class TestNetmiko:
@@ -44,7 +44,7 @@ class TestNetmiko:
                         "username": "usertest",
                         "password": "passwordtest",
                         "port": free_port,
-                        "platform": device_type,
+                        "device_type": device_type,
                     }
                 }
             }
@@ -57,7 +57,7 @@ class TestNetmiko:
                 "username": "usertest",
                 "password": "passwordtest",
                 "port": free_port,
-                "device_type": NETMIKO_DEVICE_TYPE_MAP.get(device_type, device_type),
+                "device_type": netmiko_device_type_of(device_type),
             }
             print(f"Testing device_type: {device_type}")
             with ConnectHandler(**device_credentials):
@@ -87,25 +87,25 @@ class TestNetmiko:
                     "port": port_router0,
                     "username": generate_random_string(5),
                     "password": generate_random_string(8),
-                    "platform": random.choice(available_platforms),
+                    "device_type": random.choice(available_platforms),
                 },
                 "router1": {
                     "port": port_router1,
                     "username": generate_random_string(5),
                     "password": generate_random_string(8),
-                    "platform": random.choice(available_platforms),
+                    "device_type": random.choice(available_platforms),
                 },
             }
         }
         credentials = {}
         for router in inventory["hosts"]:
-            platform = inventory["hosts"][router]["platform"]
+            device_type = inventory["hosts"][router]["device_type"]
             credentials[router] = {
                 "host": "localhost",
                 "username": inventory["hosts"][router]["username"],
                 "password": inventory["hosts"][router]["password"],
                 "port": inventory["hosts"][router]["port"],
-                "device_type": NETMIKO_DEVICE_TYPE_MAP.get(platform, platform),
+                "device_type": netmiko_device_type_of(device_type),
             }
 
         net = SimNOS(inventory=inventory)

--- a/tests/core/test_simnos.py
+++ b/tests/core/test_simnos.py
@@ -20,7 +20,7 @@ from simnos.core.host import Host
 from simnos.core.nos import available_platforms
 from simnos.core.simnos import SimNOS, default_inventory, simnos
 from simnos.core.utils import _is_in_docker
-from simnos.plugins.nos import nos_plugins
+from simnos.plugins.nos import nos_plugins, resolve_device_type
 from tests.utils import get_platforms_from_md, get_running_hosts, set_attr
 
 
@@ -128,13 +128,13 @@ class TestSimNOS:
                     "port": 5001,
                     "username": "simnos_R1",
                     "password": "simnos_R1",
-                    "platform": available_platforms[0],
+                    "device_type": available_platforms[0],
                 },
                 "R2": {
                     "port": 6000,
                     "username": "simnos_R2",
                     "password": "simnos_R2",
-                    "platform": available_platforms[0],
+                    "device_type": available_platforms[0],
                 },
             }
         }
@@ -259,7 +259,7 @@ class TestSimNOS:
         """
         Test that the function _init creates the hosts.
         """
-        inventory = {"hosts": {"R1": {"port": 5001, "platform": "cisco_ios"}}}
+        inventory = {"hosts": {"R1": {"port": 5001, "device_type": "cisco_ios"}}}
         net = SimNOS(inventory)
         assert len(net.hosts) == 1
         assert "R1" in net.hosts
@@ -279,7 +279,7 @@ class TestSimNOS:
         """
         Test that the function _allocate_port allocates the port.
         """
-        inventory = {"hosts": {"R1": {"port": 5000, "platform": "cisco_ios"}}}
+        inventory = {"hosts": {"R1": {"port": 5000, "device_type": "cisco_ios"}}}
         net = SimNOS(inventory=inventory)
         assert 5000 in net.allocated_ports
         assert len(net.allocated_ports) == 1
@@ -288,7 +288,7 @@ class TestSimNOS:
         """
         Test that the function _allocate_port allocates the port.
         """
-        inventory = {"hosts": {"R1": {"port": [5000, 5001], "replicas": 2, "platform": "cisco_ios"}}}
+        inventory = {"hosts": {"R1": {"port": [5000, 5001], "replicas": 2, "device_type": "cisco_ios"}}}
         net = SimNOS(inventory=inventory)
         assert net.allocated_ports == {5000, 5001}
 
@@ -335,9 +335,37 @@ class TestSimNOS:
         Test that the function _check_platform raises an exception
         when the platform is wrong.
         """
-        inventory = {"hosts": {"R1": {"platform": "wrong_platform"}}}
+        inventory = {"hosts": {"R1": {"device_type": "wrong_platform"}}}
         with pytest.raises(ValueError, match=r"Platform wrong_platform is not supported by SIMNOS"):
             SimNOS(inventory=inventory)
+
+    def test_legacy_platform_key_rejected(self):
+        """The v2 `platform:` key is rejected in v3 (#266, 案3-A complete breaking).
+
+        v3 renamed the inventory field to `device_type` with no compat alias;
+        `extra="forbid"` on the inventory models makes a stale `platform:` a hard
+        load error (the migration path is a version pin / key rename, not an
+        in-place alias). This pins that the breaking change stays breaking.
+        """
+        inventory = {"hosts": {"R1": {"platform": "cisco_ios"}}}
+        with pytest.raises(ValueError, match=r"Extra inputs are not permitted"):
+            SimNOS(inventory=inventory)
+
+    def test_device_type_netmiko_alias_resolves(self):
+        """A netmiko-canonical `device_type` resolves to its internal platform (#266 / D2).
+
+        `edgecore_sonic` is edgecore's `netmiko_device_type` alias (not its
+        internal name); inventory may name a platform by that alias and the host
+        validates/builds without error, while `available_platforms` keeps the
+        internal name. This is the 2-key capability the alias index unlocks.
+        """
+        inventory = {"hosts": {"R1": {"device_type": "edgecore_sonic"}}}
+        net = SimNOS(inventory=inventory)
+        assert net.hosts["R1"].device_type == "edgecore_sonic"
+        assert "edgecore" in available_platforms
+        assert "edgecore_sonic" not in available_platforms
+        # The alias resolves to the internal platform key (the reverse-index core).
+        assert resolve_device_type("edgecore_sonic") == "edgecore"
 
     def test_inventory_validation_cmdshell_plugin(self):
         """
@@ -348,7 +376,7 @@ class TestSimNOS:
             "hosts": {
                 "R1": {
                     "port": 6000,
-                    "platform": available_platforms[0],
+                    "device_type": available_platforms[0],
                     "shell": {
                         "plugin": "CMDShell",
                         "configuration": {},
@@ -373,7 +401,7 @@ class TestSimNOS:
             "hosts": {
                 "R1": {
                     "port": 6000,
-                    "platform": "huawei_smartax",
+                    "device_type": "huawei_smartax",
                     "configuration_file": "tests/assets/test_module.yaml.j2",
                 }
             }
@@ -475,7 +503,7 @@ class TestSimNOS:
         Test cisco_ios NOS loaded correctly as it has two sources: the A3
         platform dir (#264 — replaced the legacy cisco_ios.yaml) and cisco_ios.py.
         """
-        inventory = {"hosts": {"R1": {"port": 5001, "platform": "cisco_ios"}}}
+        inventory = {"hosts": {"R1": {"port": 5001, "device_type": "cisco_ios"}}}
         net = SimNOS(inventory)
         assert len(net.nos_plugins["cisco_ios"]) == 2, "Not all files detected"
 
@@ -556,9 +584,9 @@ class TestPlatformsManifest:
             assert len(net.hosts) == 3
         assert threading.active_count() <= baseline
 
-    @simnos(platform="cisco_ios", return_instance=True)
-    def test_decorator_with_platform(self, net: SimNOS):
-        """Test that the decorator works with a platform."""
+    @simnos(device_type="cisco_ios", return_instance=True)
+    def test_decorator_with_device_type(self, net: SimNOS):
+        """Test that the decorator works with a device_type."""
         platforms_used = []
         for host in net.hosts.values():
             nos = host.nos
@@ -577,19 +605,19 @@ class TestPlatformsManifest:
         correctly the inventory, it will work.
         """
 
-    def test_decorator_raise_error_if_platform_and_inventory_provided(self):
-        """Test that the decorator raises an exception if both platform and inventory are set."""
-        with pytest.raises(ValueError, match=r"platform and inventory cannot be used together"):
+    def test_decorator_raise_error_if_device_type_and_inventory_provided(self):
+        """Test that the decorator raises an exception if both device_type and inventory are set."""
+        with pytest.raises(ValueError, match=r"device_type and inventory cannot be used together"):
 
-            @simnos(platform="cisco_ios", inventory="tests/assets/inventory.yaml")
+            @simnos(device_type="cisco_ios", inventory="tests/assets/inventory.yaml")
             def dummy_function():
                 pass
 
             dummy_function()
 
-    def test_decorator_raise_error_if_not_platform_or_inventory_provided(self):
-        """Test that the decorator raises an exception if neither platform nor inventory are set."""
-        with pytest.raises(ValueError, match=r"platform or inventory must be set"):
+    def test_decorator_raise_error_if_not_device_type_or_inventory_provided(self):
+        """Test that the decorator raises an exception if neither device_type nor inventory are set."""
+        with pytest.raises(ValueError, match=r"device_type or inventory must be set"):
 
             @simnos()
             def dummy_function():
@@ -639,16 +667,16 @@ class TestPlatformsManifest:
             )
 
     def test_simnos_decorator_rejects_unknown_platform(self):
-        """Pin that `simnos(platform=...)` raises at decorator-factory evaluation time.
+        """Pin that `simnos(device_type=...)` raises at decorator-factory evaluation time.
 
         The validation lives in the decorator factory body (before the
         inner `decorator(func)` is returned), so a typo like
-        `@simnos(platform="cisxo_ios")` raises at module load time rather
+        `@simnos(device_type="cisxo_ios")` raises at module load time rather
         than waiting until the wrapped function is called. Catching this
         early avoids paying test startup cost on a doomed run.
         """
         with pytest.raises(ValueError, match="not supported"):
-            simnos(platform="nonexistent_platform")
+            simnos(device_type="nonexistent_platform")
 
     def test_simnos_decorator_accepts_known_platform(self):
         """Pin that a known platform does not raise at decorator evaluation.
@@ -658,7 +686,7 @@ class TestPlatformsManifest:
         test ensures the validation discriminates correctly.
         """
         # Should not raise — known platform from registry.
-        decorator = simnos(platform="cisco_ios")
+        decorator = simnos(device_type="cisco_ios")
         assert callable(decorator)
 
 
@@ -752,9 +780,9 @@ class TestGlobalDeadline:
         """Sequential path: hosts past deadline are skipped with a warning."""
         inventory = {
             "hosts": {
-                "R1": {"port": 5001, "platform": "cisco_ios"},
-                "R2": {"port": 5002, "platform": "cisco_ios"},
-                "R3": {"port": 5003, "platform": "cisco_ios"},
+                "R1": {"port": 5001, "device_type": "cisco_ios"},
+                "R2": {"port": 5002, "device_type": "cisco_ios"},
+                "R3": {"port": 5003, "device_type": "cisco_ios"},
             }
         }
         net = SimNOS(inventory)
@@ -779,8 +807,8 @@ class TestGlobalDeadline:
         """Parallel path: executor uses shutdown(wait=False, cancel_futures=True)."""
         inventory = {
             "hosts": {
-                "R1": {"port": 5001, "platform": "cisco_ios"},
-                "R2": {"port": 5002, "platform": "cisco_ios"},
+                "R1": {"port": 5001, "device_type": "cisco_ios"},
+                "R2": {"port": 5002, "device_type": "cisco_ios"},
             }
         }
         net = SimNOS(inventory)
@@ -812,8 +840,8 @@ class TestGlobalDeadline:
         """Parallel path without timeout: executor uses shutdown(wait=True)."""
         inventory = {
             "hosts": {
-                "R1": {"port": 5001, "platform": "cisco_ios"},
-                "R2": {"port": 5002, "platform": "cisco_ios"},
+                "R1": {"port": 5001, "device_type": "cisco_ios"},
+                "R2": {"port": 5002, "device_type": "cisco_ios"},
             }
         }
         net = SimNOS(inventory)
@@ -843,8 +871,8 @@ class TestGlobalDeadline:
         """Parallel path with exception (not timeout): executor still uses shutdown(wait=True)."""
         inventory = {
             "hosts": {
-                "R1": {"port": 5001, "platform": "cisco_ios"},
-                "R2": {"port": 5002, "platform": "cisco_ios"},
+                "R1": {"port": 5001, "device_type": "cisco_ios"},
+                "R2": {"port": 5002, "device_type": "cisco_ios"},
             }
         }
         net = SimNOS(inventory)

--- a/tests/core/test_simnos.py
+++ b/tests/core/test_simnos.py
@@ -367,6 +367,22 @@ class TestSimNOS:
         # The alias resolves to the internal platform key (the reverse-index core).
         assert resolve_device_type("edgecore_sonic") == "edgecore"
 
+    def test_resolve_device_type_runtime_registered_and_unknown(self, monkeypatch):
+        """resolve_device_type serves a runtime-registered platform and None-passes the unknown (#266 / D2).
+
+        This is the mechanism the `nos.plugin` direct-write path relies on
+        (a custom plugin from `SimNOS(plugins=[...])`, or a `nos: {plugin: X}`
+        absent from the import-time index, 1st round codex #3): an unknown value
+        must return None so the `start()` chokepoint falls back to the raw key,
+        and a name added to `nos_plugins` after import must resolve by identity
+        via the dynamic fallback (not just the static reverse index).
+        """
+        import simnos.plugins.nos as nos_registry
+
+        assert resolve_device_type("runtime_only_nos") is None  # unknown → None (chokepoint passes raw through)
+        monkeypatch.setitem(nos_registry.nos_plugins, "runtime_only_nos", ["<runtime-registered>"])
+        assert resolve_device_type("runtime_only_nos") == "runtime_only_nos"  # identity via dynamic fallback
+
     def test_inventory_validation_cmdshell_plugin(self):
         """
         Test that the inventory is validated when

--- a/tests/plugins/test_cmd_shell.py
+++ b/tests/plugins/test_cmd_shell.py
@@ -864,7 +864,7 @@ class HotReloadTest(TestCase):
 
     @pytest.mark.skipif(sys.platform == "win32", reason="Windows does not allow file movement on Github runners")
     @pytest.mark.xdist_group("hot-reload-fs")
-    @simnos(platform="cisco_ios", return_instance=True)
+    @simnos(device_type="cisco_ios", return_instance=True)
     def test_hot_reload_integration_py_jinja(self, net: SimNOS):
         """
         Test that the hot reload feature works correctly for a py-template edit.

--- a/tests/plugins/test_telnet_server.py
+++ b/tests/plugins/test_telnet_server.py
@@ -337,7 +337,7 @@ class InventoryValidationTest(unittest.TestCase):
                     "username": "admin",
                     "password": "admin",
                     "port": 6023,
-                    "platform": "cisco_ios",
+                    "device_type": "cisco_ios",
                     "server": {
                         "plugin": "TelnetServer",
                         "configuration": {
@@ -361,7 +361,7 @@ class InventoryValidationTest(unittest.TestCase):
                     "username": "admin",
                     "password": "admin",
                     "port": 6022,
-                    "platform": "cisco_ios",
+                    "device_type": "cisco_ios",
                     "server": {
                         "plugin": "ParamikoSshServer",
                         "configuration": {

--- a/tests/test_lint_platform_data.py
+++ b/tests/test_lint_platform_data.py
@@ -338,3 +338,22 @@ class TestDeviceTypeCollisions:
         self._meta(tmp_path, "p_b", netmiko="p_a")
         violations = check_platform_data_device_type_collisions(str(tmp_path))
         assert any("p_a" in v for v in violations)
+
+    def test_malformed_platform_yaml_is_violation_not_crash(self, tmp_path):
+        # A malformed platform.yaml yields a violation string, not a traceback —
+        # symmetric with the runtime index guard's warn+skip (1st round PR1
+        # cross-review gemini #6 / claude #4).
+        d = tmp_path / "broken"
+        d.mkdir(parents=True)
+        (d / "platform.yaml").write_text("netmiko_device_type: [unclosed\n", encoding="utf-8")
+        violations = check_platform_data_device_type_collisions(str(tmp_path))
+        assert any("broken/platform.yaml" in v for v in violations)
+
+    def test_non_mapping_platform_yaml_is_violation(self, tmp_path):
+        # A platform.yaml that parses to a non-mapping (e.g. a bare list) is a
+        # violation, not an AttributeError on `.get`.
+        d = tmp_path / "listy"
+        d.mkdir(parents=True)
+        (d / "platform.yaml").write_text("- just\n- a\n- list\n", encoding="utf-8")
+        violations = check_platform_data_device_type_collisions(str(tmp_path))
+        assert any("listy/platform.yaml" in v and "not a mapping" in v for v in violations)

--- a/tests/test_lint_platform_data.py
+++ b/tests/test_lint_platform_data.py
@@ -11,6 +11,7 @@ actually fails — without these a bug in the lint logic would read as
 
 from tasks import (
     check_platform_data,
+    check_platform_data_device_type_collisions,
     check_platform_data_ratchet,
     check_platform_data_warnings,
     is_stub_help,
@@ -293,3 +294,47 @@ class TestRatchet:
         violations = check_platform_data_ratchet(str(tmp_path / "nonexistent"), baseline)
         assert any("alcatel_aos" in v and "not an A3 platform" in v for v in violations)
         assert any("cisco_ios" in v and "not an A3 platform" in v for v in violations)
+
+
+class TestDeviceTypeCollisions:
+    """#266 / D2: device_type alias collisions across platforms are gated.
+
+    Mirrors the runtime reverse-index guard in `simnos.plugins.nos`; these
+    pin that the authoring-time lint catches the same conflicts (and does NOT
+    false-positive on the `name == netmiko == ntc` shape every platform ships
+    today, which a naive "key already seen" check would).
+    """
+
+    @staticmethod
+    def _meta(tmp_path, name, *, netmiko=None, ntc=None):
+        d = tmp_path / name
+        d.mkdir(parents=True, exist_ok=True)
+        lines = []
+        if netmiko is not None:
+            lines.append(f"netmiko_device_type: {netmiko}")
+        if ntc is not None:
+            lines.append(f"ntc_platform: {ntc}")
+        (d / "platform.yaml").write_text(("\n".join(lines) + "\n") if lines else "{}\n", encoding="utf-8")
+
+    def test_distinct_platforms_pass(self, tmp_path):
+        self._meta(tmp_path, "edgecore", netmiko="edgecore_sonic", ntc="edgecore")
+        self._meta(tmp_path, "cisco_ios", netmiko="cisco_ios", ntc="cisco_ios")
+        assert check_platform_data_device_type_collisions(str(tmp_path)) == []
+
+    def test_identity_equals_aliases_is_noop(self, tmp_path):
+        # name == netmiko == ntc (today's common case) must NOT false-positive.
+        self._meta(tmp_path, "cisco_ios", netmiko="cisco_ios", ntc="cisco_ios")
+        assert check_platform_data_device_type_collisions(str(tmp_path)) == []
+
+    def test_two_platforms_share_netmiko_alias_flagged(self, tmp_path):
+        self._meta(tmp_path, "p_a", netmiko="shared_dt")
+        self._meta(tmp_path, "p_b", netmiko="shared_dt")
+        violations = check_platform_data_device_type_collisions(str(tmp_path))
+        assert any("shared_dt" in v for v in violations)
+
+    def test_alias_colliding_with_other_identity_flagged(self, tmp_path):
+        # p_b's netmiko alias lands on p_a's identity name (2nd round gemini #3).
+        self._meta(tmp_path, "p_a")
+        self._meta(tmp_path, "p_b", netmiko="p_a")
+        violations = check_platform_data_device_type_collisions(str(tmp_path))
+        assert any("p_a" in v for v in violations)

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -2,30 +2,38 @@
 This module contains utility functions for the tests.
 """
 
+import os
 import random
 import socket
 import string
 
 from simnos.core.host import Host
+from simnos.core.platform_loader import PLATFORM_META_FILENAME, _load_platform_meta
 from simnos.plugins.nos import nos_plugins
-
-# Platforms where the simnos platform name differs from netmiko's device_type.
-# netmiko expects its own canonical device_type string, so these must be mapped
-# before building ConnectHandler kwargs (see netmiko_device()).
-# netmiko canonical names: https://github.com/ktbyers/netmiko/blob/master/PLATFORMS.md
-NETMIKO_DEVICE_TYPE_MAP: dict[str, str] = {
-    "edgecore": "edgecore_sonic",
-    "extreme_slxos": "extreme_slx",
-    "watchguard_firebox": "watchguard_fireware",
-}
 
 # Default credentials used to build single-host test inventories.
 TEST_USERNAME = "test_user"
 TEST_PASSWORD = "test_password"
 
 
+def netmiko_device_type_of(device_type: str) -> str:
+    """Return the netmiko canonical device_type for a simnos ``device_type``.
+
+    Replaces the old hardcoded NETMIKO_DEVICE_TYPE_MAP (#266 / D3): the
+    simnos→netmiko mapping now lives in each platform's ``platform.yaml``
+    (``netmiko_device_type``), the data SSoT. Falls back to ``device_type``
+    itself when the platform has no A3 metadata or no explicit
+    ``netmiko_device_type`` (the identity case, which is most platforms).
+    """
+    for path in nos_plugins.get(device_type, []):
+        meta_path = os.path.join(path, PLATFORM_META_FILENAME)
+        if os.path.isfile(meta_path):
+            return _load_platform_meta(meta_path).netmiko_device_type or device_type
+    return device_type
+
+
 def build_inventory(
-    platform: str,
+    device_type: str,
     *,
     host_key: str = "device",
     username: str = TEST_USERNAME,
@@ -39,7 +47,7 @@ def build_inventory(
     A free port is allocated when ``port`` is not given.
     """
     port = port if port is not None else get_free_port()
-    host = {"username": username, "password": password, "port": port, "platform": platform, **extra}
+    host = {"username": username, "password": password, "port": port, "device_type": device_type, **extra}
     return {"hosts": {host_key: host}}
 
 
@@ -48,8 +56,9 @@ def creds_from_host(host: Host) -> dict:
     return {"username": host.username, "password": host.password, "port": host.port}
 
 
-def netmiko_device(platform: str, creds: dict, **extra) -> dict:
-    """Build netmiko ``ConnectHandler`` kwargs (applies NETMIKO_DEVICE_TYPE_MAP).
+def netmiko_device(device_type: str, creds: dict, **extra) -> dict:
+    """Build netmiko ``ConnectHandler`` kwargs (maps the simnos ``device_type``
+    to netmiko's canonical device_type via platform.yaml, #266 / D3).
 
     ``**extra`` merges additional kwargs such as ``session_log``.
     """
@@ -58,7 +67,7 @@ def netmiko_device(platform: str, creds: dict, **extra) -> dict:
         "username": creds["username"],
         "password": creds["password"],
         "port": creds["port"],
-        "device_type": NETMIKO_DEVICE_TYPE_MAP.get(platform, platform),
+        "device_type": netmiko_device_type_of(device_type),
         **extra,
     }
 


### PR DESCRIPTION
🐙claude:

## 概要
v3.0 epic #263 P1-3 (#266) の **PR1 = D1+D2+D3 (device_type rename core)**。inventory の呼称を `platform` → `device_type` に rename し、netmiko/ntc 名でも内部 platform 名でも解決できる alias 機構をデータ駆動で本番経路に載せる。`#266` は v3→main マージ時に close する運用のため、本 PR では auto-close しない。

base = `v3`。設計書: `design/20260613_153454_claude_issue-266-p1-3-inventory-device-type.md`(cross-review 2 round + final-refactor 確定)。

## 変更内容 (D1+D2+D3)
- **D1 rename**: `ModelHost` / `InventoryDefaultSection` の `platform` → `device_type`、`Host(device_type=)` + `self.device_type`、`simnos()` デコレータ param/key/エラーメッセージ、production `default_inventory`。**案3-A 完全 breaking** — 旧 `platform:` は `extra="forbid"` で reject(deprecation alias なし、移行は v2 pin / key 書き換え)。
- **D2 alias 解決**: registry 構築時に `device_type → platform` 逆引き index + `resolve_device_type()` を追加(`netmiko_device_type` / `ntc_platform` alias を解決、identity は `nos_plugins` を動的フォールバックして runtime 登録 plugin も救済、未知値は None passthrough)。解決 chokepoint = `host.py` `start()` の registry lookup 直前(device_type 由来 / `nos.plugin` 既定 / 直書きの全 3 経路が通る単一点)。collision guard は**値比較**(identity 優先、`name==netmiko==ntc` の現データで誤検知しない)。import 時 meta-parse 失敗は warn+skip で degrade(import 全滅回避)。`lint-platform-data` に authoring 時の collision 検出を追加(defense-in-depth)。
- **D3 NETMIKO_DEVICE_TYPE_MAP 廃止**: `edgecore` / `extreme_slxos` / `watchguard_firebox` の `netmiko_device_type` を netmiko canonical 名(`edgecore_sonic` / `extreme_slx` / `watchguard_fireware`)に修正し、test helper を `platform.yaml` データ参照(`netmiko_device_type_of`)に置換。hardcode map を削除。

## 回帰 pin
- `test_legacy_platform_key_rejected`: 旧 `platform:` が `extra="forbid"` で reject される(breaking 契約の固定)
- `test_device_type_netmiko_alias_resolves`: `edgecore_sonic` → `edgecore` 解決 + `available_platforms` は内部名のみ
- `test_resolve_device_type_runtime_registered_and_unknown`: runtime 登録 identity fallback + 未知値 None passthrough
- collision lint 6 件(distinct pass / `name==alias` no-op / 共有 alias flag / alias→他 identity flag / malformed・non-mapping yaml violation)

## scope (本 PR に含まないもの)
- **#265 予約 field + `ModelSysConfig` + sys_config + precedence (D4) + docs/migration (D5) は PR2** に分割。理由 = #265 予約 field / ModelSysConfig は消費者が PR2 まで存在せず PR1 では dead code になるため。**breaking(rename)は全て本 PR に集約**しているので epic「breaking を P1 で 1 回」原則は維持。
- **docs の inventory 例 (`platform:`) は PR2/D5 で一括更新**。本 PR が先に merge される期間は公開 docs snippet が v3 runtime では reject される点に注意(意図した分割、cross-review codex#5 で明示）。

## cross-review
1st round (codex/gemini/claude) 総合 **SUGGESTION**(MUST/SHOULD FIX 0)。取り込み 3 件(alias 受理ヒント / lint malformed 耐性 / runtime fallback test)、非取り込み 4 件(理由は worklog 記録)。

## 検証
ruff check + format / yamllint / ty / `lint-platform-data` / full suite **1085 passed, 7 skipped, 1 xfailed**(integration 含む)— 全 green。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
