### PR TITLE
fix: Host.start() の partial-start resource leak を interrupt-safe に解消 (#291)

### DIFF
--- a/simnos/core/host.py
+++ b/simnos/core/host.py
@@ -154,18 +154,26 @@ class Host:
         # stops it, while `SimNOS._collect_server_threads()` still collects its
         # threads (it gates on `server is not None`), so a server left dangling
         # here makes the shutdown join block. Stop the just-built server and
-        # drop the reference before re-raising.
+        # drop the reference (and reset `running`) before re-raising.
         #
         # The catch is `BaseException`, not `Exception`: the most likely
         # partial-start trigger is a `KeyboardInterrupt` (the operator aborts
         # startup), which `except Exception` would miss — leaving the server set
-        # and hanging the join above. We re-raise immediately, so catching
-        # `BaseException` only adds a cleanup pass on the way out. The cleanup
-        # itself is a single best-effort attempt (not a guarantee): a failure is
-        # logged rather than raised so it cannot mask the original error (the
-        # real cause), and `self.server` is dropped regardless.
+        # and hanging the join above. `self.running = True` lives INSIDE the try
+        # so an interrupt in the gap between a successful `server.start()` and
+        # the flag set is still caught and rolled back (otherwise the host is
+        # left server-set / running-False — exactly the dangling state).
+        #
+        # We re-raise immediately, so catching `BaseException` only adds a
+        # cleanup pass on the way out. The cleanup itself is a single
+        # best-effort attempt (not a guarantee): a failure is logged rather than
+        # raised so it cannot mask the original error, and the reference/flag are
+        # reset regardless. A second `BaseException` *during* cleanup (a double
+        # Ctrl+C) can replace the original error, but `self.server` is still
+        # dropped so no leak/hang results.
         try:
             self.server.start()
+            self.running = True
         except BaseException:
             try:
                 self.server.stop()
@@ -173,8 +181,8 @@ class Host:
                 log.exception("Host %s: cleanup after a failed start() raised", self.name)
             finally:
                 self.server = None
+                self.running = False
             raise
-        self.running = True
 
     def _resolve_overlay_root(self, plugin_key: str) -> str | None:
         """Resolve this host's overlay dir, or None when overlay is not opted in (#286).

--- a/simnos/core/host.py
+++ b/simnos/core/host.py
@@ -146,31 +146,20 @@ class Host:
             render_config=render_config,
             **self.server_inventory["configuration"],
         )
-        # Defense-in-depth for a partial start (#291). The built-in
-        # `TCPServerBase.start()` self-cleans its sockets/threads on a mid-way
-        # failure, so `server.stop()` here is a no-op for them. But the
-        # orchestration layer skips a host whose `start()` raised — `running`
-        # stays False, so `SimNOS.stop()` (filters on `running == True`) never
-        # stops it, while `SimNOS._collect_server_threads()` still collects its
-        # threads (it gates on `server is not None`), so a server left dangling
-        # here makes the shutdown join block. Stop the just-built server and
-        # drop the reference (and reset `running`) before re-raising.
+        # Defense-in-depth for a partial start (#291). A host whose `start()`
+        # raised keeps `running == False`, so `SimNOS.stop()` (filters on
+        # `running == True`) never stops it, yet `SimNOS._collect_server_threads()`
+        # still collects its threads (it gates on `server is not None`) — a
+        # dangling server here makes the shutdown join block. Stop the just-built
+        # server and drop the reference + reset `running` before re-raising.
         #
         # The catch is `BaseException`, not `Exception`: the most likely
         # partial-start trigger is a `KeyboardInterrupt` (the operator aborts
-        # startup), which `except Exception` would miss — leaving the server set
-        # and hanging the join above. `self.running = True` lives INSIDE the try
-        # so an interrupt in the gap between a successful `server.start()` and
-        # the flag set is still caught and rolled back (otherwise the host is
-        # left server-set / running-False — exactly the dangling state).
-        #
-        # We re-raise immediately, so catching `BaseException` only adds a
-        # cleanup pass on the way out. The cleanup itself is a single
-        # best-effort attempt (not a guarantee): a failure is logged rather than
-        # raised so it cannot mask the original error, and the reference/flag are
-        # reset regardless. A second `BaseException` *during* cleanup (a double
-        # Ctrl+C) can replace the original error, but `self.server` is still
-        # dropped so no leak/hang results.
+        # startup), which `except Exception` would miss. `self.running = True`
+        # lives INSIDE the try so an interrupt in the gap after a successful
+        # `server.start()` is still rolled back rather than leaving the dangling
+        # state. Cleanup is best-effort: a failure is logged (not raised) so it
+        # cannot mask the original error, and the reference/flag reset regardless.
         try:
             self.server.start()
             self.running = True

--- a/simnos/core/host.py
+++ b/simnos/core/host.py
@@ -219,13 +219,21 @@ class Host:
 
         No-op if the server was never started or has already been stopped
         (``self.server is None``); this guards against double-stop calls.
+
+        The state reset runs in a ``finally`` so the host does not dangle if
+        ``server.stop()`` is cut short by an interrupt — the server self-cleans
+        in its own ``finally``, so dropping the reference + clearing ``running``
+        keeps the host out of ``SimNOS._collect_server_threads()`` (#291,
+        symmetric with the rollback in ``start()``).
         """
         if self.server is None:
             log.debug("Host %s has no running server; stop() is a no-op", self.name)
             return
-        self.server.stop()
-        self.server = None
-        self.running = False
+        try:
+            self.server.stop()
+        finally:
+            self.server = None
+            self.running = False
 
     def _warn_reserved_fields(self) -> None:
         """Warn loudly for reserved fields that are set but inert.

--- a/simnos/core/host.py
+++ b/simnos/core/host.py
@@ -146,7 +146,24 @@ class Host:
             render_config=render_config,
             **self.server_inventory["configuration"],
         )
-        self.server.start()
+        # Defense-in-depth for a partial start (#291). The built-in
+        # `TCPServerBase.start()` already self-cleans its sockets/threads on a
+        # mid-way failure, so `server.stop()` here is a no-op for them. But the
+        # orchestration layer (`SimNOS.stop()` filters on `running == True`)
+        # skips a host whose `start()` raised — `running` stays False — so a
+        # server plugin that does *not* self-clean would leak with no safety
+        # net. Stop the just-built server and drop the reference before
+        # re-raising; a cleanup failure must not mask the original start()
+        # error (the real cause), so it is logged rather than raised.
+        try:
+            self.server.start()
+        except Exception:
+            try:
+                self.server.stop()
+            except Exception:
+                log.exception("Host %s: cleanup after a failed start() raised", self.name)
+            self.server = None
+            raise
         self.running = True
 
     def _resolve_overlay_root(self, plugin_key: str) -> str | None:

--- a/simnos/core/host.py
+++ b/simnos/core/host.py
@@ -147,22 +147,32 @@ class Host:
             **self.server_inventory["configuration"],
         )
         # Defense-in-depth for a partial start (#291). The built-in
-        # `TCPServerBase.start()` already self-cleans its sockets/threads on a
-        # mid-way failure, so `server.stop()` here is a no-op for them. But the
-        # orchestration layer (`SimNOS.stop()` filters on `running == True`)
-        # skips a host whose `start()` raised — `running` stays False — so a
-        # server plugin that does *not* self-clean would leak with no safety
-        # net. Stop the just-built server and drop the reference before
-        # re-raising; a cleanup failure must not mask the original start()
-        # error (the real cause), so it is logged rather than raised.
+        # `TCPServerBase.start()` self-cleans its sockets/threads on a mid-way
+        # failure, so `server.stop()` here is a no-op for them. But the
+        # orchestration layer skips a host whose `start()` raised — `running`
+        # stays False, so `SimNOS.stop()` (filters on `running == True`) never
+        # stops it, while `SimNOS._collect_server_threads()` still collects its
+        # threads (it gates on `server is not None`), so a server left dangling
+        # here makes the shutdown join block. Stop the just-built server and
+        # drop the reference before re-raising.
+        #
+        # The catch is `BaseException`, not `Exception`: the most likely
+        # partial-start trigger is a `KeyboardInterrupt` (the operator aborts
+        # startup), which `except Exception` would miss — leaving the server set
+        # and hanging the join above. We re-raise immediately, so catching
+        # `BaseException` only adds a cleanup pass on the way out. The cleanup
+        # itself is a single best-effort attempt (not a guarantee): a failure is
+        # logged rather than raised so it cannot mask the original error (the
+        # real cause), and `self.server` is dropped regardless.
         try:
             self.server.start()
-        except Exception:
+        except BaseException:
             try:
                 self.server.stop()
             except Exception:
                 log.exception("Host %s: cleanup after a failed start() raised", self.name)
-            self.server = None
+            finally:
+                self.server = None
             raise
         self.running = True
 

--- a/simnos/core/servers.py
+++ b/simnos/core/servers.py
@@ -157,17 +157,20 @@ class TCPServerBase(ABC):
 
         self._is_running.clear()
 
-        if self._wakeup_w is not None:
-            with contextlib.suppress(OSError):
-                self._wakeup_w.send(b"\x00")
-
-        # fail-safe join — wakeup socket may have failed; bound by SHUTDOWN_IO_TIMEOUT.
-        # _is_running.is_set() guard at the top of stop() returns early if start()
-        # hasn't been called, so self._listen_thread is set here; narrow for ty.
-        assert self._listen_thread is not None  # noqa: S101 — post-condition of start()
-        self._listen_thread.join(timeout=SHUTDOWN_IO_TIMEOUT)
-
+        # The wakeup + thread joins run under the cleanup try/finally so
+        # `_cleanup_resources()` still frees the sockets if an interrupt lands
+        # during the wake or a join (#291, symmetric with start()'s rollback).
         try:
+            if self._wakeup_w is not None:
+                with contextlib.suppress(OSError):
+                    self._wakeup_w.send(b"\x00")
+
+            # fail-safe join — wakeup socket may have failed; bound by SHUTDOWN_IO_TIMEOUT.
+            # _is_running.is_set() guard at the top of stop() returns early if start()
+            # hasn't been called, so self._listen_thread is set here; narrow for ty.
+            assert self._listen_thread is not None  # noqa: S101 — post-condition of start()
+            self._listen_thread.join(timeout=SHUTDOWN_IO_TIMEOUT)
+
             alive = join_threads_with_deadline(
                 self._connection_threads,
                 SHUTDOWN_SERVER_STOP_DEADLINE,

--- a/simnos/core/servers.py
+++ b/simnos/core/servers.py
@@ -108,13 +108,13 @@ class TCPServerBase(ABC):
             # instead of tripping its `_listen_thread is not None` assertion.
             #
             # `_cleanup_resources()` runs in a `finally` so the sockets are freed
-            # even if the wake/join is cut short by a second interrupt. The
+            # even if the clear/wake/join is cut short by a second interrupt. The
             # `is_alive()` guard is required: if `start()` itself raised, the
             # thread object exists but was never started, and joining an
             # unstarted thread raises RuntimeError — which would mask the
             # original error and skip cleanup (#291). We re-raise immediately.
-            self._is_running.clear()
             try:
+                self._is_running.clear()
                 if self._wakeup_w is not None:
                     with contextlib.suppress(OSError):
                         self._wakeup_w.send(b"\x00")
@@ -155,12 +155,14 @@ class TCPServerBase(ABC):
         if not self._is_running.is_set():
             return
 
-        self._is_running.clear()
-
-        # The wakeup + thread joins run under the cleanup try/finally so
-        # `_cleanup_resources()` still frees the sockets if an interrupt lands
-        # during the wake or a join (#291, symmetric with start()'s rollback).
+        # `_is_running.clear()` + the wakeup + the thread joins all run under the
+        # cleanup try/finally so `_cleanup_resources()` still frees the sockets
+        # if an interrupt lands anywhere in the teardown. Clearing inside the try
+        # also means a retry stop() (which only proceeds while `_is_running` is
+        # set) can still clean up after an interrupted attempt (#291, symmetric
+        # with start()'s rollback).
         try:
+            self._is_running.clear()
             if self._wakeup_w is not None:
                 with contextlib.suppress(OSError):
                     self._wakeup_w.send(b"\x00")

--- a/simnos/core/servers.py
+++ b/simnos/core/servers.py
@@ -104,17 +104,24 @@ class TCPServerBase(ABC):
             # join the listen thread, THEN close sockets — so a listen thread
             # that already spawned does not race `_cleanup_resources()` closing
             # the selector/socket out from under its `select()` loop. Clearing
-            # `_is_running` first (before cleanup, which a second interrupt could
-            # abort) also guarantees a later stop() early-returns instead of
-            # tripping its `_listen_thread is not None` assertion (#291). We
-            # re-raise immediately.
+            # `_is_running` first also guarantees a later stop() early-returns
+            # instead of tripping its `_listen_thread is not None` assertion.
+            #
+            # `_cleanup_resources()` runs in a `finally` so the sockets are freed
+            # even if the wake/join is cut short by a second interrupt. The
+            # `is_alive()` guard is required: if `start()` itself raised, the
+            # thread object exists but was never started, and joining an
+            # unstarted thread raises RuntimeError — which would mask the
+            # original error and skip cleanup (#291). We re-raise immediately.
             self._is_running.clear()
-            if self._wakeup_w is not None:
-                with contextlib.suppress(OSError):
-                    self._wakeup_w.send(b"\x00")
-            if self._listen_thread is not None:
-                self._listen_thread.join(timeout=SHUTDOWN_IO_TIMEOUT)
-            self._cleanup_resources()
+            try:
+                if self._wakeup_w is not None:
+                    with contextlib.suppress(OSError):
+                        self._wakeup_w.send(b"\x00")
+                if self._listen_thread is not None and self._listen_thread.is_alive():
+                    self._listen_thread.join(timeout=SHUTDOWN_IO_TIMEOUT)
+            finally:
+                self._cleanup_resources()
             raise
 
     def _bind_sockets(self):

--- a/simnos/core/servers.py
+++ b/simnos/core/servers.py
@@ -97,7 +97,14 @@ class TCPServerBase(ABC):
 
             self._listen_thread = threading.Thread(target=self._listen)
             self._listen_thread.start()
-        except Exception:
+        except BaseException:
+            # BaseException, not Exception: a KeyboardInterrupt mid-start (the
+            # operator aborts startup) must still clear `_is_running` and free
+            # the partial sockets/threads. Otherwise a later stop() trips the
+            # `_listen_thread is not None` assertion — it passes the
+            # `_is_running` guard but the thread was never assigned — and the
+            # bound socket leaks before `_cleanup_resources()` runs (#291). We
+            # re-raise immediately.
             self._cleanup_resources()
             self._is_running.clear()
             raise

--- a/simnos/core/servers.py
+++ b/simnos/core/servers.py
@@ -99,14 +99,22 @@ class TCPServerBase(ABC):
             self._listen_thread.start()
         except BaseException:
             # BaseException, not Exception: a KeyboardInterrupt mid-start (the
-            # operator aborts startup) must still clear `_is_running` and free
-            # the partial sockets/threads. Otherwise a later stop() trips the
-            # `_listen_thread is not None` assertion — it passes the
-            # `_is_running` guard but the thread was never assigned — and the
-            # bound socket leaks before `_cleanup_resources()` runs (#291). We
+            # operator aborts startup) must still roll the partial start back.
+            # Mirror stop()'s teardown ORDER — clear the flag, wake select(),
+            # join the listen thread, THEN close sockets — so a listen thread
+            # that already spawned does not race `_cleanup_resources()` closing
+            # the selector/socket out from under its `select()` loop. Clearing
+            # `_is_running` first (before cleanup, which a second interrupt could
+            # abort) also guarantees a later stop() early-returns instead of
+            # tripping its `_listen_thread is not None` assertion (#291). We
             # re-raise immediately.
-            self._cleanup_resources()
             self._is_running.clear()
+            if self._wakeup_w is not None:
+                with contextlib.suppress(OSError):
+                    self._wakeup_w.send(b"\x00")
+            if self._listen_thread is not None:
+                self._listen_thread.join(timeout=SHUTDOWN_IO_TIMEOUT)
+            self._cleanup_resources()
             raise
 
     def _bind_sockets(self):

--- a/tests/core/test_host.py
+++ b/tests/core/test_host.py
@@ -111,18 +111,62 @@ class TestHost:
     def test_start_failure_cleanup_error_does_not_mask_original(self, host):
         """A cleanup stop() failure does not hide the original start() error.
 
-        The re-raised exception must be the real start() failure (the cause a
-        caller needs), not a secondary error from the best-effort cleanup
-        stop() (#291). The host state is still reset regardless.
+        The re-raised exception must be the *same* object as the real start()
+        failure (the cause a caller needs), not a secondary error from the
+        best-effort cleanup stop() (#291). Pinning that cleanup stop() was
+        actually called proves the suppression path ran (without it, dropping
+        the cleanup line would leave this test green). State is reset regardless.
         """
         server_factory = host.simnos.servers_plugins["server_plugin"]
         failed_server = server_factory.return_value
-        failed_server.start.side_effect = RuntimeError("bind failed")
+        start_error = RuntimeError("bind failed")
+        failed_server.start.side_effect = start_error
         failed_server.stop.side_effect = OSError("stop boom")
+        with pytest.raises(RuntimeError, match="bind failed") as exc_info:
+            host.start()
+        assert exc_info.value is start_error
+        failed_server.stop.assert_called_once()
+        assert host.server is None
+        assert not host.running
+
+    def test_start_baseexception_still_cleans_up(self, host):
+        """A BaseException (e.g. Ctrl+C) mid-start still triggers cleanup (#291).
+
+        KeyboardInterrupt is the most likely partial-start trigger (the operator
+        aborts startup). `except Exception` would miss it, leaving the server
+        set and running=False — which SimNOS.stop() skips but
+        _collect_server_threads() still picks up, hanging the shutdown join. The
+        catch is `except BaseException`, so the server is stopped and dropped
+        before the interrupt re-raises.
+        """
+        server_factory = host.simnos.servers_plugins["server_plugin"]
+        failed_server = server_factory.return_value
+        failed_server.start.side_effect = KeyboardInterrupt
+        with pytest.raises(KeyboardInterrupt):
+            host.start()
+        failed_server.stop.assert_called_once()
+        assert host.server is None
+        assert not host.running
+
+    def test_restart_after_failed_start_builds_fresh_server(self, host):
+        """A retry after a failed start() builds a new server (#291).
+
+        Dropping `self.server` on the failure path keeps the double-start guard
+        (gates on `running`, still False) open, so a retry is a real restart
+        that constructs a fresh server rather than re-using the failed one.
+        """
+        server_factory = host.simnos.servers_plugins["server_plugin"]
+        failed_server = Mock()
+        failed_server.start.side_effect = RuntimeError("bind failed")
+        good_server = Mock()
+        server_factory.side_effect = [failed_server, good_server]
         with pytest.raises(RuntimeError, match="bind failed"):
             host.start()
         assert host.server is None
-        assert not host.running
+        host.start()
+        assert host.server is good_server
+        assert host.running
+        good_server.start.assert_called_once()
 
     def test_stop(self, host):
         """

--- a/tests/core/test_host.py
+++ b/tests/core/test_host.py
@@ -182,6 +182,20 @@ class TestHost:
         mock_server.stop.assert_called_once()
         assert host.server is None
 
+    def test_stop_resets_state_even_if_server_stop_raises(self, host):
+        """Host.stop() resets state even if server.stop() is interrupted (#291).
+
+        The server self-cleans in its own finally, so the host must drop the
+        reference + clear running regardless, keeping the host out of
+        SimNOS._collect_server_threads(). Symmetric with start()'s rollback.
+        """
+        host.start()
+        host.server.stop.side_effect = KeyboardInterrupt
+        with pytest.raises(KeyboardInterrupt):
+            host.stop()
+        assert host.server is None
+        assert not host.running
+
     def test_platform_is_wrong(self, host):
         """
         The test passes if the ValueError is raised when the platform is not supported.

--- a/tests/core/test_host.py
+++ b/tests/core/test_host.py
@@ -90,6 +90,40 @@ class TestHost:
         assert host.server_plugin.call_count == 2
         assert host.server.start.call_count == 2
 
+    def test_start_failure_stops_server_and_resets(self, host):
+        """A mid-start server.start() failure cleans up and does not dangle.
+
+        Pins the partial-start defense-in-depth (#291): SimNOS.stop() filters
+        on running=True, so a host whose server.start() raised (running stays
+        False) is excluded from cluster shutdown. Host.start() therefore stops
+        the just-built server and drops the reference before re-raising, so no
+        server is left started-but-unreachable on the failed host.
+        """
+        server_factory = host.simnos.servers_plugins["server_plugin"]
+        failed_server = server_factory.return_value
+        failed_server.start.side_effect = RuntimeError("bind failed")
+        with pytest.raises(RuntimeError, match="bind failed"):
+            host.start()
+        failed_server.stop.assert_called_once()
+        assert host.server is None
+        assert not host.running
+
+    def test_start_failure_cleanup_error_does_not_mask_original(self, host):
+        """A cleanup stop() failure does not hide the original start() error.
+
+        The re-raised exception must be the real start() failure (the cause a
+        caller needs), not a secondary error from the best-effort cleanup
+        stop() (#291). The host state is still reset regardless.
+        """
+        server_factory = host.simnos.servers_plugins["server_plugin"]
+        failed_server = server_factory.return_value
+        failed_server.start.side_effect = RuntimeError("bind failed")
+        failed_server.stop.side_effect = OSError("stop boom")
+        with pytest.raises(RuntimeError, match="bind failed"):
+            host.start()
+        assert host.server is None
+        assert not host.running
+
     def test_stop(self, host):
         """
         It test that when the host is called the stop,

--- a/tests/core/test_servers.py
+++ b/tests/core/test_servers.py
@@ -233,11 +233,16 @@ class ServersTest(unittest.TestCase):
         with pytest.raises(KeyboardInterrupt):
             servers.stop()
 
-        # _cleanup_resources() ran despite the interrupted join.
+        # _cleanup_resources() ran despite the interrupted join: OS handles
+        # closed AND the internal references reset (so a retry/start is clean).
         mock_selector.close.assert_called_once()
         mock_sock.close.assert_called_once()
         mock_wakeup_w.close.assert_called_once()
         mock_wakeup_r.close.assert_called_once()
+        assert servers._selector is None
+        assert servers._socket is None
+        assert servers._wakeup_r is None
+        assert servers._wakeup_w is None
 
     @patch("threading.Event")
     @patch("threading.Thread")

--- a/tests/core/test_servers.py
+++ b/tests/core/test_servers.py
@@ -491,3 +491,25 @@ class StartFailureRollbackTest(unittest.TestCase):
         assert not servers._is_running.is_set()
         mock_wakeup_r.close.assert_called()
         mock_wakeup_w.close.assert_called()
+
+    @patch("simnos.core.servers.socket.socketpair")
+    @patch("simnos.core.servers.TCPServerBase._bind_sockets")
+    def test_start_rollback_on_keyboard_interrupt(self, mock_bind_sockets, mock_socketpair):
+        """A KeyboardInterrupt mid-start still rolls back (#291).
+
+        The rollback catches BaseException, not just Exception: an operator
+        aborting startup (Ctrl+C) must still clear `_is_running` and close the
+        partial sockets, otherwise a later stop() trips the `_listen_thread`
+        assertion and leaks the bound socket.
+        """
+        mock_socketpair.side_effect = KeyboardInterrupt
+        servers = StubServer()
+        servers._socket = MagicMock()  # simulate _bind_sockets success
+
+        with pytest.raises(KeyboardInterrupt):
+            servers.start()
+
+        assert not servers._is_running.is_set()
+        assert servers._socket is None
+        assert servers._wakeup_r is None
+        assert servers._wakeup_w is None

--- a/tests/core/test_servers.py
+++ b/tests/core/test_servers.py
@@ -513,3 +513,35 @@ class StartFailureRollbackTest(unittest.TestCase):
         assert servers._socket is None
         assert servers._wakeup_r is None
         assert servers._wakeup_w is None
+
+    @patch("simnos.core.servers.selectors.DefaultSelector")
+    @patch("simnos.core.servers.socket.socketpair")
+    @patch("simnos.core.servers.threading.Thread")
+    @patch("simnos.core.servers.TCPServerBase._bind_sockets")
+    def test_start_rollback_joins_listen_thread_on_interrupt(
+        self, mock_bind_sockets, mock_thread_cls, mock_socketpair, mock_selector_cls
+    ):
+        """A KeyboardInterrupt after the listen thread spawns joins it before cleanup (#291).
+
+        Once the listen thread is running, rollback must clear `_is_running`,
+        wake select(), and join the thread *before* `_cleanup_resources()`
+        closes the selector/socket — otherwise the live `_listen` loop races a
+        half-closed selector. Pins the teardown order, not just the end state.
+        """
+        mock_wakeup_r, mock_wakeup_w = MagicMock(), MagicMock()
+        mock_socketpair.return_value = (mock_wakeup_r, mock_wakeup_w)
+        mock_thread = MagicMock()
+        mock_thread.start.side_effect = KeyboardInterrupt  # interrupt just as the thread spawns
+        mock_thread_cls.return_value = mock_thread
+
+        servers = StubServer()
+        servers._socket = MagicMock()  # simulate _bind_sockets success
+
+        with pytest.raises(KeyboardInterrupt):
+            servers.start()
+
+        assert not servers._is_running.is_set()
+        mock_wakeup_w.send.assert_called_once()  # select() woken...
+        mock_thread.join.assert_called_once()  # ...thread joined before resources close
+        assert servers._selector is None
+        assert servers._socket is None

--- a/tests/core/test_servers.py
+++ b/tests/core/test_servers.py
@@ -518,30 +518,71 @@ class StartFailureRollbackTest(unittest.TestCase):
     @patch("simnos.core.servers.socket.socketpair")
     @patch("simnos.core.servers.threading.Thread")
     @patch("simnos.core.servers.TCPServerBase._bind_sockets")
-    def test_start_rollback_joins_listen_thread_on_interrupt(
+    def test_start_rollback_skips_join_for_unstarted_thread(
         self, mock_bind_sockets, mock_thread_cls, mock_socketpair, mock_selector_cls
     ):
-        """A KeyboardInterrupt after the listen thread spawns joins it before cleanup (#291).
+        """Rollback never joins an unstarted listen thread, and still cleans up (#291).
 
-        Once the listen thread is running, rollback must clear `_is_running`,
-        wake select(), and join the thread *before* `_cleanup_resources()`
-        closes the selector/socket — otherwise the live `_listen` loop races a
-        half-closed selector. Pins the teardown order, not just the end state.
+        If `_listen_thread.start()` itself raises (Ctrl+C or an OS thread limit),
+        the thread object exists but was never started — joining it raises
+        RuntimeError (emulated here via join's side_effect), which would mask the
+        original error and skip cleanup. The `is_alive()` guard skips the join,
+        so the original interrupt propagates and `_cleanup_resources()` still
+        frees the sockets. Removing the guard makes join() fire the RuntimeError
+        and this test fail.
         """
         mock_wakeup_r, mock_wakeup_w = MagicMock(), MagicMock()
         mock_socketpair.return_value = (mock_wakeup_r, mock_wakeup_w)
         mock_thread = MagicMock()
-        mock_thread.start.side_effect = KeyboardInterrupt  # interrupt just as the thread spawns
+        mock_thread.start.side_effect = KeyboardInterrupt  # interrupt as the thread spawns
+        mock_thread.is_alive.return_value = False  # never started
+        mock_thread.join.side_effect = RuntimeError("cannot join thread before it is started")
         mock_thread_cls.return_value = mock_thread
 
         servers = StubServer()
         servers._socket = MagicMock()  # simulate _bind_sockets success
 
-        with pytest.raises(KeyboardInterrupt):
+        with pytest.raises(KeyboardInterrupt):  # original error, not the join RuntimeError
             servers.start()
 
+        mock_thread.join.assert_not_called()  # guard skipped the unstarted join
         assert not servers._is_running.is_set()
-        mock_wakeup_w.send.assert_called_once()  # select() woken...
-        mock_thread.join.assert_called_once()  # ...thread joined before resources close
         assert servers._selector is None
         assert servers._socket is None
+        assert servers._wakeup_r is None
+        assert servers._wakeup_w is None
+
+    @patch("simnos.core.servers.selectors.DefaultSelector")
+    @patch("simnos.core.servers.socket.socketpair")
+    @patch("simnos.core.servers.threading.Thread")
+    @patch("simnos.core.servers.TCPServerBase._bind_sockets")
+    def test_start_rollback_teardown_order_on_interrupt(
+        self, mock_bind_sockets, mock_thread_cls, mock_socketpair, mock_selector_cls
+    ):
+        """Rollback runs wake -> join -> cleanup in that order on a live thread (#291).
+
+        With the listen thread alive, the selector must be woken and the thread
+        joined *before* `_cleanup_resources()` closes the selector/socket, else
+        the running `_listen` loop races a half-closed selector. Pins the
+        relative order via a shared event list (not just that each step ran).
+        """
+        events: list[str] = []
+        mock_wakeup_r, mock_wakeup_w = MagicMock(), MagicMock()
+        mock_wakeup_w.send.side_effect = lambda *a: events.append("send")
+        mock_socketpair.return_value = (mock_wakeup_r, mock_wakeup_w)
+        mock_thread = MagicMock()
+        mock_thread.is_alive.return_value = True  # simulate an interrupt with a live thread
+        mock_thread.start.side_effect = KeyboardInterrupt
+        mock_thread.join.side_effect = lambda *a, **k: events.append("join")
+        mock_thread_cls.return_value = mock_thread
+
+        servers = StubServer()
+        servers._socket = MagicMock()  # simulate _bind_sockets success
+
+        with patch.object(StubServer, "_cleanup_resources", autospec=True) as mock_cleanup:
+            mock_cleanup.side_effect = lambda self: events.append("cleanup")
+            with pytest.raises(KeyboardInterrupt):
+                servers.start()
+
+        assert events == ["send", "join", "cleanup"]
+        assert not servers._is_running.is_set()

--- a/tests/core/test_servers.py
+++ b/tests/core/test_servers.py
@@ -210,6 +210,38 @@ class ServersTest(unittest.TestCase):
     @patch("threading.Event")
     @patch("threading.Thread")
     @patch("socket.socket")
+    def test_stop_cleans_up_when_join_interrupted(self, mock_socket, mock_thread, mock_thread_event):
+        """stop() frees resources even if a thread join is interrupted (#291).
+
+        The wakeup + joins run under the cleanup try/finally, so a (second) Ctrl+C
+        during the listen-thread join still reaches _cleanup_resources() instead
+        of leaking the listen socket/selector. Symmetric with start()'s rollback.
+        """
+        mock_thread_event().is_set.return_value = True
+        servers = StubServer()
+        listen_thread = mock_thread()
+        listen_thread.join.side_effect = KeyboardInterrupt  # interrupt mid-join
+        servers._listen_thread = listen_thread
+        mock_sock = mock_socket()
+        servers._socket = mock_sock
+        mock_wakeup_w, mock_wakeup_r = MagicMock(), MagicMock()
+        servers._wakeup_w = mock_wakeup_w
+        servers._wakeup_r = mock_wakeup_r
+        mock_selector = MagicMock()
+        servers._selector = mock_selector
+
+        with pytest.raises(KeyboardInterrupt):
+            servers.stop()
+
+        # _cleanup_resources() ran despite the interrupted join.
+        mock_selector.close.assert_called_once()
+        mock_sock.close.assert_called_once()
+        mock_wakeup_w.close.assert_called_once()
+        mock_wakeup_r.close.assert_called_once()
+
+    @patch("threading.Event")
+    @patch("threading.Thread")
+    @patch("socket.socket")
     def test_stop_sends_wakeup(self, mock_socket, mock_thread, mock_thread_event):
         """Stop should send a wakeup byte to unblock select()."""
         mock_thread_event().is_set.return_value = True
@@ -565,14 +597,17 @@ class StartFailureRollbackTest(unittest.TestCase):
         joined *before* `_cleanup_resources()` closes the selector/socket, else
         the running `_listen` loop races a half-closed selector. Pins the
         relative order via a shared event list (not just that each step ran).
+        The mock simulates the native thread having started but the interrupt
+        arriving before `start()` returns (is_alive True + start() raises), so
+        the live-thread join path is exercised.
         """
         events: list[str] = []
         mock_wakeup_r, mock_wakeup_w = MagicMock(), MagicMock()
-        mock_wakeup_w.send.side_effect = lambda *a: events.append("send")
+        mock_wakeup_w.send.side_effect = lambda *a, **k: events.append("send")
         mock_socketpair.return_value = (mock_wakeup_r, mock_wakeup_w)
         mock_thread = MagicMock()
-        mock_thread.is_alive.return_value = True  # simulate an interrupt with a live thread
-        mock_thread.start.side_effect = KeyboardInterrupt
+        mock_thread.is_alive.return_value = True  # native thread started...
+        mock_thread.start.side_effect = KeyboardInterrupt  # ...but interrupted before start() returns
         mock_thread.join.side_effect = lambda *a, **k: events.append("join")
         mock_thread_cls.return_value = mock_thread
 
@@ -580,7 +615,7 @@ class StartFailureRollbackTest(unittest.TestCase):
         servers._socket = MagicMock()  # simulate _bind_sockets success
 
         with patch.object(StubServer, "_cleanup_resources", autospec=True) as mock_cleanup:
-            mock_cleanup.side_effect = lambda self: events.append("cleanup")
+            mock_cleanup.side_effect = lambda *a, **k: events.append("cleanup")
             with pytest.raises(KeyboardInterrupt):
                 servers.start()
 


### PR DESCRIPTION
🐙claude:

## 概要
`Host.start()` の `server.start()` が途中で失敗した host が `running=False` のまま残り、`SimNOS.stop()` の `running==True` filter から除外される一方で `SimNOS._collect_server_threads()`(`server is not None` で判定)が thread だけ収集するため、shutdown の join がハングしうる問題 (#291) を解消する。

## 調査の結論
当初の issue 想定(socket/thread leak)とは異なり、**通常の `Exception` 経路は既に潰れていた**:
- `Host.__init__`/server 構築は OS resource を確保しない(socket bind / thread spawn は `start()` 内)。
- `TCPServerBase.start()` は自前の try/except で partial 失敗時に `_cleanup_resources()` する。

cross-review で判明した**真の穴** = `KeyboardInterrupt`(`simnos up` 中の Ctrl+C = partial-start の最有力トリガ)が `except Exception` を素通りし、dangling server が `_collect_server_threads()` の join をハングさせる。さらに未起動 thread の `join()` (`RuntimeError`)・二重割り込みでの cleanup 未到達など、interrupt まわりの穴を 5 round で全て塞いだ。

## 変更
- **`simnos/core/host.py`**:
  - `Host.start()` を `except BaseException` で rollback(`running = True` を try 内に置き、`server.start()` 成功直後 gap の割り込みも巻き戻す。finally で `server=None` + `running=False` を reset、cleanup は best-effort で原例外を mask しない)。
  - `Host.stop()` の状態 reset を try/finally 化(`server.stop()` が割り込まれても host が dangle しない)。
- **`simnos/core/servers.py`**:
  - `TCPServerBase.start()` rollback と `stop()` を「`_is_running.clear()` → wakeup → join(start 側は `is_alive()` ガードで未起動 thread を join しない)→ `_cleanup_resources()`(finally)」の interrupt-safe 構造に統一・対称化。
- **テスト 9 件追加**(`tests/core/test_host.py` / `test_servers.py`): BaseException 経路・未起動 thread join・二相 cleanup 順序・stop 中割り込み・Host 状態 reset 等。割り込み系は mutation で teeth を確認。

## 品質ゲート
- cross-review 5 round で収束(claude / codex / gemini、最終 round は 3 者とも mergeable 明言)。
- `invoke ruff` / `ty check` clean。
- full suite **1242 passed / 7 skipped / 1 xfailed / 10 subtests passed**(integration 含む、`tests/core/test_docker.py` は環境依存で deselect)。

## defer (future 候補)
- `start()` rollback と `stop()` の teardown ロジックの DRY helper 抽出(reviewer 間 split-opinion、重複維持を選択)。
- wakeup-send の `OSError` を `log.debug` に残す observability 改善(#291 scope 外)。

## 備考
- base=v3。#291 issue は v3→main merge 時に close する運用のため "Closes #291" は付けず OPEN 維持。

🤖 Generated with [Claude Code](https://claude.com/claude-code)