### PR TITLE
refactor: TCPServerBase teardown の DRY 共通化 + wakeup-send OSError observability (#294)

### DIFF
--- a/simnos/core/servers.py
+++ b/simnos/core/servers.py
@@ -100,10 +100,11 @@ class TCPServerBase(ABC):
         except BaseException:
             # BaseException, not Exception: a KeyboardInterrupt mid-start (the
             # operator aborts startup) must still roll the partial start back.
-            # Mirror stop()'s teardown ORDER — clear the flag, wake select(),
-            # join the listen thread, THEN close sockets — so a listen thread
-            # that already spawned does not race `_cleanup_resources()` closing
-            # the selector/socket out from under its `select()` loop. Clearing
+            # Mirror stop()'s teardown ORDER — signal the listen loop to stop
+            # (clear the flag + wake select()), join the listen thread, THEN
+            # close sockets — so a listen thread that already spawned does not
+            # race `_cleanup_resources()` closing the selector/socket out from
+            # under its `select()` loop. `_signal_listen_stop()` clearing
             # `_is_running` first also guarantees a later stop() early-returns
             # instead of tripping its `_listen_thread is not None` assertion.
             #
@@ -114,15 +115,35 @@ class TCPServerBase(ABC):
             # unstarted thread raises RuntimeError — which would mask the
             # original error and skip cleanup (#291). We re-raise immediately.
             try:
-                self._is_running.clear()
-                if self._wakeup_w is not None:
-                    with contextlib.suppress(OSError):
-                        self._wakeup_w.send(b"\x00")
+                self._signal_listen_stop()
                 if self._listen_thread is not None and self._listen_thread.is_alive():
                     self._listen_thread.join(timeout=SHUTDOWN_IO_TIMEOUT)
             finally:
                 self._cleanup_resources()
             raise
+
+    def _signal_listen_stop(self):
+        """Signal the listen loop to stop: clear the running flag and wake select().
+
+        Shared by stop() and start()'s rollback — the one byte sent over the
+        wakeup socketpair unblocks the listen thread's select() instantly
+        instead of waiting out the safety-net timeout. The caller is responsible
+        for joining the listen thread afterwards (the join differs between the
+        two paths: stop() asserts the thread exists, the rollback guards on
+        is_alive() because start() may have raised before the thread started).
+
+        The wakeup send is best-effort: a broken wakeup socket must not stop
+        shutdown — the caller still falls back to the SHUTDOWN_IO_TIMEOUT-bounded
+        join. The OSError is logged at debug rather than suppressed silently so a
+        slow shutdown (select() exiting via timeout instead of the wakeup) leaves
+        a diagnostic breadcrumb (#294).
+        """
+        self._is_running.clear()
+        if self._wakeup_w is not None:
+            try:
+                self._wakeup_w.send(b"\x00")
+            except OSError:
+                log.debug("wakeup send failed; listen thread will exit via select() timeout", exc_info=True)
 
     def _bind_sockets(self):
         """
@@ -155,17 +176,14 @@ class TCPServerBase(ABC):
         if not self._is_running.is_set():
             return
 
-        # `_is_running.clear()` + the wakeup + the thread joins all run under the
-        # cleanup try/finally so `_cleanup_resources()` still frees the sockets
-        # if an interrupt lands anywhere in the teardown. Clearing inside the try
-        # also means a retry stop() (which only proceeds while `_is_running` is
-        # set) can still clean up after an interrupted attempt (#291, symmetric
-        # with start()'s rollback).
+        # `_signal_listen_stop()` (clear + wakeup) + the thread joins all run
+        # under the cleanup try/finally so `_cleanup_resources()` still frees the
+        # sockets if an interrupt lands anywhere in the teardown. Clearing inside
+        # the try also means a retry stop() (which only proceeds while
+        # `_is_running` is set) can still clean up after an interrupted attempt
+        # (#291, symmetric with start()'s rollback).
         try:
-            self._is_running.clear()
-            if self._wakeup_w is not None:
-                with contextlib.suppress(OSError):
-                    self._wakeup_w.send(b"\x00")
+            self._signal_listen_stop()
 
             # fail-safe join — wakeup socket may have failed; bound by SHUTDOWN_IO_TIMEOUT.
             # _is_running.is_set() guard at the top of stop() returns early if start()

--- a/tests/core/test_servers.py
+++ b/tests/core/test_servers.py
@@ -626,3 +626,53 @@ class StartFailureRollbackTest(unittest.TestCase):
 
         assert events == ["send", "join", "cleanup"]
         assert not servers._is_running.is_set()
+
+
+class SignalListenStopTest(unittest.TestCase):
+    """`TCPServerBase._signal_listen_stop` — the teardown step shared by stop()
+    and start()'s rollback (#294): clear the running flag + best-effort wakeup.
+    """
+
+    def test_clears_running_and_sends_wakeup(self):
+        """The helper clears `_is_running` and sends one wakeup byte."""
+        servers = StubServer()
+        servers._is_running.set()
+        mock_wakeup_w = MagicMock()
+        servers._wakeup_w = mock_wakeup_w
+
+        servers._signal_listen_stop()
+
+        assert not servers._is_running.is_set()
+        mock_wakeup_w.send.assert_called_once_with(b"\x00")
+
+    def test_no_wakeup_socket_is_noop(self):
+        """With no wakeup socket the helper still clears the flag, no crash."""
+        servers = StubServer()
+        servers._is_running.set()
+        servers._wakeup_w = None
+
+        servers._signal_listen_stop()
+
+        assert not servers._is_running.is_set()
+
+    def test_wakeup_oserror_is_logged_not_raised(self):
+        """A failing wakeup send is logged at debug and does not propagate (#294).
+
+        The send is best-effort: a broken wakeup socket must not stop teardown
+        (the caller falls back to the timeout-bounded join). The OSError is
+        logged rather than suppressed silently so a slow shutdown leaves a
+        diagnostic breadcrumb. Without the `log.debug` the assertLogs block
+        fails (no records); without the `except OSError` the error propagates
+        out of the helper, so the assertions below are never reached.
+        """
+        servers = StubServer()
+        servers._is_running.set()
+        mock_wakeup_w = MagicMock()
+        mock_wakeup_w.send.side_effect = OSError("broken pipe")
+        servers._wakeup_w = mock_wakeup_w
+
+        with self.assertLogs("simnos.core.servers", level="DEBUG") as captured:
+            servers._signal_listen_stop()  # must not raise
+
+        assert any("wakeup send failed" in message for message in captured.output)
+        assert not servers._is_running.is_set()

--- a/tests/core/test_servers.py
+++ b/tests/core/test_servers.py
@@ -3,6 +3,7 @@ Test module for simnos.core.servers.
 The file can be found under simnos/core/servers.py
 """
 
+import logging
 import socket
 import sys
 import threading
@@ -634,16 +635,26 @@ class SignalListenStopTest(unittest.TestCase):
     """
 
     def test_clears_running_and_sends_wakeup(self):
-        """The helper clears `_is_running` and sends one wakeup byte."""
+        """The helper clears `_is_running` *before* sending the wakeup byte.
+
+        The clear-before-send order is the contract: the listen loop re-checks
+        `_is_running` after select() wakes, so the flag must already be clear
+        when the wakeup arrives. Pinned directly via the send side_effect (which
+        records the flag state at send time), not just the end state — otherwise
+        a future send -> clear swap would slip past an end-state-only check.
+        """
         servers = StubServer()
         servers._is_running.set()
+        flag_clear_at_send: list[bool] = []
         mock_wakeup_w = MagicMock()
+        mock_wakeup_w.send.side_effect = lambda *a, **k: flag_clear_at_send.append(not servers._is_running.is_set())
         servers._wakeup_w = mock_wakeup_w
 
         servers._signal_listen_stop()
 
         assert not servers._is_running.is_set()
         mock_wakeup_w.send.assert_called_once_with(b"\x00")
+        assert flag_clear_at_send == [True]  # flag was already clear when send fired
 
     def test_no_wakeup_socket_is_noop(self):
         """With no wakeup socket the helper still clears the flag, no crash."""
@@ -664,6 +675,10 @@ class SignalListenStopTest(unittest.TestCase):
         diagnostic breadcrumb. Without the `log.debug` the assertLogs block
         fails (no records); without the `except OSError` the error propagates
         out of the helper, so the assertions below are never reached.
+
+        The record-level asserts pin B's contract directly: DEBUG level + the
+        captured OSError traceback (`exc_info=True`). A message-substring check
+        alone would silently pass if `exc_info=True` or the level were dropped.
         """
         servers = StubServer()
         servers._is_running.set()
@@ -674,5 +689,9 @@ class SignalListenStopTest(unittest.TestCase):
         with self.assertLogs("simnos.core.servers", level="DEBUG") as captured:
             servers._signal_listen_stop()  # must not raise
 
-        assert any("wakeup send failed" in message for message in captured.output)
         assert not servers._is_running.is_set()
+        record = captured.records[0]
+        assert record.levelno == logging.DEBUG
+        assert "wakeup send failed" in record.getMessage()
+        assert record.exc_info is not None  # exc_info=True captured the traceback
+        assert isinstance(record.exc_info[1], OSError)


### PR DESCRIPTION
🐙claude:

## 概要
#294(= #291 / PR #293 follow-up)。`TCPServerBase` の teardown 周辺 2 件を 1 本で消化。機能変更ではなく整理 + observability。

base=v3。#294 issue は #291 系の運用に揃え OPEN 維持(`Closes` 不使用、v3→main 時に判断)。

## A1. teardown ロジックの DRY 共通化 [refactor]
`start()` の rollback と `stop()` で**完全一致**していた「`_is_running.clear()` + wakeup-send」を private helper `_signal_listen_stop()` に共通化。

分岐する listen-thread join は**呼び出し側に残置**し、既存 tested path を不変に保った:
- `start()` rollback → 未起動 thread を join しない `is_alive()` ガード
- `stop()` → `assert self._listen_thread is not None`(start 成功後の post-condition)+ connection thread の deadline join

teardown ORDER(clear → send → join → cleanup(finally))は両経路とも不変。`test_start_rollback_teardown_order_on_interrupt` が `["send", "join", "cleanup"]` を引き続き pin。

## B. wakeup-send の OSError observability [enhancement]
`self._wakeup_w.send(b"\x00")` の `OSError` を `contextlib.suppress` の黙殺から `log.debug(..., exc_info=True)` に変更。送信失敗で shutdown を止めない fail-safe 挙動(timeout-bounded join への fallback)は不変だが、`select()` が wakeup でなく timeout 経由で抜ける slow-shutdown の診断 breadcrumb を残す。catch 対象は `OSError` のみで黙殺範囲は不変。

## テスト
新規 `SignalListenStopTest`(3 件):
- `test_clears_running_and_sends_wakeup` — send の side_effect で `clear→send` 順序を直接 pin
- `test_no_wakeup_socket_is_noop` — wakeup socket 不在でも clear のみ実行、crash なし
- `test_wakeup_oserror_is_logged_not_raised` — `records[0]` の `levelno==DEBUG` + `exc_info is not None` + `isinstance(exc, OSError)` で B の契約を pin、かつ非伝播を確認

mutation 検証: `exc_info=True` 削除で observability test fail / `clear↔send` 入替で順序 test fail / `log.debug` → `pass` で observability test fail。

## レビュー / 検証
- cross-review 1st round: codex / gemini / claude **全員 SUGGESTION で収束**(MUST/SHOULD FIX なし)。3/3 一致の「observability test の `exc_info`/level pin」+ codex の「clear→send 順序 pin」を取り込み済。docstring 重複整理(claude#4)は join site の局所 rationale で真の重複ではないため据え置き。
- final-refactor: Phase 1/2 ともにクリーン(変更なし)。
- full CI: `invoke ruff`(94 files clean)/ `ty`(All checks passed)/ full suite **1245 passed / 7 skipped / 1 xfailed**(integration 込み、test_docker.py は環境依存で deselect)。

🤖 Generated with [Claude Code](https://claude.com/claude-code)