### PR TITLE
feat: SSH を asyncssh + shared loop へ — W3 push を async session 化 (#297 Stage 2)

### DIFF
--- a/docker/inventory.yaml
+++ b/docker/inventory.yaml
@@ -1,6 +1,6 @@
 default:
   server:
-    plugin: "ParamikoSshServer"
+    plugin: "AsyncSshServer"
     configuration:
       address: "0.0.0.0"
       timeout: 1

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,6 +36,7 @@ classifiers = [
 requires-python = ">=3.13,<3.15"
 dependencies = [
     "paramiko>=4.0,<6.0",
+    "asyncssh>=2.23,<3.0",
     "pyyaml<7.0",
     "pydantic<3.0",
     "jinja2>=3.1.6",
@@ -177,6 +178,9 @@ dev = [
 ]
 compatibility = [
     # netmiko is already in `dev` (default group), so not repeated here
-    "scrapli",        # scrapli interop test
-    "ansible-core",   # ansible interop test (cli_command / ios_facts)
+    "scrapli",          # scrapli interop test
+    "ansible-core",     # ansible interop test (cli_command / ios_facts)
+    "ansible-pylibssh", # ansible libssh backend — required against the asyncssh
+                        # transport (paramiko backend trips the auth-retry
+                        # disconnect, #297 Stage 2 テーマE / E2)
 ]

--- a/simnos/core/host.py
+++ b/simnos/core/host.py
@@ -144,6 +144,10 @@ class Host:
             username=self.username,
             password=self.password,
             render_config=render_config,
+            # AsyncSshServer (#297 Stage 2) reaches the SimNOS-owned shared loop
+            # through this back reference; the sync paramiko/telnet plugins accept
+            # and ignore it for a uniform construction call.
+            simnos=self.simnos,
             **self.server_inventory["configuration"],
         )
         # Defense-in-depth for a partial start (#291). A host whose `start()`

--- a/simnos/core/pydantic_models.py
+++ b/simnos/core/pydantic_models.py
@@ -349,6 +349,31 @@ class ParamikoSshServerPlugin(BaseModel):
     configuration: ParamikoSshServerConfig | None = None
 
 
+class AsyncSshServerConfig(BaseModel):
+    """Pydantic model for the asyncssh SSH server configuration (#297 Stage 2).
+
+    Same fields as ``ParamikoSshServerConfig`` so an inventory can switch the SSH
+    transport by name alone. ``timeout`` / ``watchdog_interval`` are accepted for
+    signature parity (the async path drives shutdown via loop close, not a recv
+    poll), so they are inert here but kept for drop-in inventory compatibility.
+    """
+
+    ssh_key_file: StrictStr | None = None
+    ssh_key_file_password: StrictStr | None = None
+    ssh_banner: StrictStr | None = "SIMNOS AsyncSSH Server"
+    timeout: StrictInt | None = 1
+    address: Literal["localhost"] | IPvAnyAddress | None = None
+    watchdog_interval: StrictInt | None = 1
+    authorized_keys: StrictStr | None = None
+
+
+class AsyncSshServerPlugin(BaseModel):
+    """Pydantic model for the asyncssh SSH server plugin (#297 Stage 2)."""
+
+    plugin: Literal["AsyncSshServer"]
+    configuration: AsyncSshServerConfig | None = None
+
+
 class TelnetServerConfig(BaseModel):
     """
     Pydantic model for Telnet server configuration.
@@ -464,7 +489,7 @@ class InventoryDefaultSection(BaseModel):
     port: Port | list[Port] | None = None
     configuration_file: StrictStr | None = None
     device_type: StrictStr | None = None
-    server: ParamikoSshServerPlugin | TelnetServerPlugin | None = None
+    server: AsyncSshServerPlugin | ParamikoSshServerPlugin | TelnetServerPlugin | None = None
     shell: CMDShellPlugin | None = None
     nos: NosPlugin | None = None
     # Inventory render fields. `overlay` is consumed by #286 (Host.start resolves

--- a/simnos/core/shared_loop.py
+++ b/simnos/core/shared_loop.py
@@ -223,7 +223,7 @@ class SharedLoop:
         loop = self._loop
         if loop is None or loop.is_closed():
             return
-        budget = self._remaining(deadline, SHUTDOWN_SERVER_STOP_DEADLINE)
+        budget = self._remaining(deadline)
         try:
             self.submit_coro(listener.aclose()).result(timeout=budget)
         except Exception:
@@ -270,7 +270,7 @@ class SharedLoop:
             if loop is not None and not loop.is_closed():
                 loop.call_soon_threadsafe(loop.stop)
             if thread is not None:
-                thread.join(timeout=self._remaining(deadline, SHUTDOWN_SERVER_STOP_DEADLINE))
+                thread.join(timeout=self._remaining(deadline))
                 alive = thread.is_alive()
             with self._lock:
                 self._loop = None
@@ -282,8 +282,8 @@ class SharedLoop:
                 log.warning("shared loop thread did not exit within timeout; loop left in FAILED state")
 
     @staticmethod
-    def _remaining(deadline: float | None, fallback: float) -> float:
-        """Seconds left until *deadline* (monotonic), or *fallback* when unset."""
+    def _remaining(deadline: float | None) -> float:
+        """Seconds left until *deadline* (monotonic), or the per-server budget when unset."""
         if deadline is None:
-            return min(fallback, SHUTDOWN_SERVER_STOP_DEADLINE)
+            return SHUTDOWN_SERVER_STOP_DEADLINE
         return max(SHUTDOWN_IO_TIMEOUT, deadline - time.monotonic())

--- a/simnos/core/shared_loop.py
+++ b/simnos/core/shared_loop.py
@@ -235,12 +235,14 @@ class SharedLoop:
         Called by ``SimNOS.stop()`` after stopping the requested hosts. Tears the
         loop down only when the registry is empty (refcount == 0); otherwise other
         async hosts are still running and the loop must stay up (partial stop).
-        Returns True when a teardown ran.
+        A ``FAILED`` loop (a prior teardown could not join the thread) is retried
+        here so ``stop()`` stays idempotently recoverable (gemini 1st#2). Returns
+        True when a teardown ran.
         """
         with self._lock:
-            if self._state is not LoopState.RUNNING:
+            if self._state not in (LoopState.RUNNING, LoopState.FAILED):
                 return False
-            if self._listeners:
+            if self._state is LoopState.RUNNING and self._listeners:
                 return False  # other async hosts still running
             self._state = LoopState.STOPPING
         self._global_teardown(deadline)
@@ -254,7 +256,10 @@ class SharedLoop:
         ``finally`` (see ``_start_locked``), so this only has to stop the loop and
         join the thread. Emergency cleanup runs in ``finally`` so the bounded
         executor + loop refs are released even if something above raises. If the
-        loop thread cannot be joined within budget the state goes ``FAILED``.
+        loop thread cannot be joined within budget the state goes ``FAILED`` and
+        the refs are **kept** so a later ``teardown_if_idle`` can retry the join
+        (gemini 1st#2) — detaching them would orphan a still-running thread with no
+        handle to re-join.
         """
         loop = self._loop
         executor = self._executor
@@ -273,11 +278,14 @@ class SharedLoop:
                 thread.join(timeout=self._remaining(deadline))
                 alive = thread.is_alive()
             with self._lock:
-                self._loop = None
-                self._thread = None
-                self._executor = None
                 self._listeners.clear()
-                self._state = LoopState.FAILED if alive else LoopState.STOPPED
+                if alive:
+                    self._state = LoopState.FAILED  # keep refs for a retry join
+                else:
+                    self._loop = None
+                    self._thread = None
+                    self._executor = None
+                    self._state = LoopState.STOPPED
             if alive:
                 log.warning("shared loop thread did not exit within timeout; loop left in FAILED state")
 

--- a/simnos/core/shared_loop.py
+++ b/simnos/core/shared_loop.py
@@ -23,6 +23,7 @@ Lifecycle (§1a):
 import asyncio
 from collections.abc import Awaitable
 import concurrent.futures
+import contextlib
 import enum
 import logging
 import os
@@ -273,7 +274,14 @@ class SharedLoop:
         finally:
             alive = False
             if loop is not None and not loop.is_closed():
-                loop.call_soon_threadsafe(loop.stop)
+                # The is_closed() check and call_soon_threadsafe are not atomic: the
+                # loop thread may close the loop (its run_forever finally) in between,
+                # so a concurrent close races to "Event loop is closed". Suppress it
+                # — a closed loop is already stopping, and an unsuppressed RuntimeError
+                # here would skip the join + state update and strand the machine in
+                # STOPPING, breaking FAILED recovery / idempotent stop (gemini 2nd#1).
+                with contextlib.suppress(RuntimeError):
+                    loop.call_soon_threadsafe(loop.stop)
             if thread is not None:
                 thread.join(timeout=self._remaining(deadline))
                 alive = thread.is_alive()

--- a/simnos/core/shared_loop.py
+++ b/simnos/core/shared_loop.py
@@ -1,0 +1,289 @@
+"""SimNOS-owned shared asyncio event loop (#297 Stage 2, §1 / §1a / §2a).
+
+The spike (#296) proved that one event loop multiplexing every async listener and
+session — not one loop per host — is the architecture v3 should build. This module
+owns that single loop as a **SimNOS-scoped resource** (Decision 2): one dedicated
+thread runs the loop, one bounded ``ThreadPoolExecutor`` runs the blocking
+dispatch off the loop thread (§2a), and a single-lock registry tracks the active
+async listeners so partial stop / restart / double stop stay coherent (§1a).
+
+The public ``SimNOS`` API stays fully synchronous (``start()`` / ``stop()``); the
+sync↔async boundary lives here behind ``run_coro`` / ``submit_coro``.
+
+Lifecycle (§1a):
+
+- ``RUNNING``  — loop thread alive, accepting registrations.
+- ``STOPPING`` — global teardown in progress.
+- ``STOPPED``  — loop thread joined + loop closed; a later ``ensure_running`` lazily
+  recreates everything (restart).
+- ``FAILED``   — teardown could not fully release the loop thread; ``ensure_running``
+  refuses to restart (no silent restart), ``teardown`` may be retried.
+"""
+
+import asyncio
+from collections.abc import Awaitable
+import concurrent.futures
+import enum
+import logging
+import os
+import threading
+import time
+from typing import Protocol, TypeVar
+
+from simnos.core.timeouts import (
+    SHUTDOWN_IO_TIMEOUT,
+    SHUTDOWN_SERVER_STOP_DEADLINE,
+)
+
+log = logging.getLogger(__name__)
+
+_T = TypeVar("_T")
+
+#: Loop-thread startup budget (seconds). The thread only has to create the loop
+#: and signal readiness, so this is generous.
+_LOOP_START_TIMEOUT = 10
+
+
+def _default_max_workers() -> int:
+    """Default bounded-executor size (§2a). Overridable via init arg / env.
+
+    CPU-based so CI (2 vCPU) and a real host (8+ vCPU) get a sensible default;
+    the 100-host stress (Stage 2) tunes the recommended value documented for
+    ``SIMNOS_DISPATCH_WORKERS``. Bounded (not unbounded) is the whole point — an
+    unbounded executor would reintroduce the W3 thread-per-session explosion.
+    """
+    return min(64, max(8, (os.cpu_count() or 4) * 4))
+
+
+class LoopState(enum.Enum):
+    """Lifecycle state of the shared loop (§1a)."""
+
+    STOPPED = "stopped"
+    RUNNING = "running"
+    STOPPING = "stopping"
+    FAILED = "failed"
+
+
+class AsyncListener(Protocol):
+    """An async host listener the shared loop can drain on stop (§1a).
+
+    ``AsyncSshServer`` implements it: ``aclose`` stops accepting, closes the
+    listener socket, and drains the host's active sessions — the host-scope (5a)
+    cleanup that must run even on a partial stop.
+    """
+
+    async def aclose(self) -> None:
+        """Close the listener + drain this host's active sessions."""
+        ...
+
+
+class SharedLoop:
+    """One asyncio loop + bounded executor + listener registry, owned by SimNOS."""
+
+    def __init__(self, max_workers: int | None = None) -> None:
+        env_workers = os.environ.get("SIMNOS_DISPATCH_WORKERS")
+        if max_workers is None and env_workers:
+            max_workers = int(env_workers)
+        if max_workers is not None and max_workers < 1:
+            raise ValueError(f"max_workers must be >= 1, got {max_workers}")
+        self._max_workers = max_workers or _default_max_workers()
+
+        self._lock = threading.Lock()
+        self._state = LoopState.STOPPED
+        self._loop: asyncio.AbstractEventLoop | None = None
+        self._thread: threading.Thread | None = None
+        self._executor: concurrent.futures.ThreadPoolExecutor | None = None
+        # Active async listeners keyed by object identity (one per host). refcount
+        # = len(registry); "all async hosts stopped" is registry-empty, not a scan
+        # of configured-host running flags (§1, codex#3).
+        self._listeners: dict[int, AsyncListener] = {}
+
+    # ------------------------------------------------------------------ state
+    @property
+    def state(self) -> LoopState:
+        with self._lock:
+            return self._state
+
+    @property
+    def refcount(self) -> int:
+        """Number of registered async listeners (active hosts on this loop)."""
+        with self._lock:
+            return len(self._listeners)
+
+    @property
+    def loop(self) -> asyncio.AbstractEventLoop:
+        """The running loop. Raises if not started (call ``ensure_running`` first)."""
+        if self._loop is None:
+            raise RuntimeError("shared loop is not running")
+        return self._loop
+
+    @property
+    def executor(self) -> concurrent.futures.ThreadPoolExecutor:
+        """The bounded dispatch executor (§2a)."""
+        if self._executor is None:
+            raise RuntimeError("shared loop executor is not running")
+        return self._executor
+
+    # ------------------------------------------------------------------ startup
+    def ensure_running(self) -> asyncio.AbstractEventLoop:
+        """Lazily start the loop thread + executor; return the running loop.
+
+        Idempotent while ``RUNNING``. Recreates everything after ``STOPPED``
+        (restart). Refuses to restart from ``FAILED`` (no silent restart, §1a).
+        """
+        with self._lock:
+            if self._state is LoopState.RUNNING:
+                assert self._loop is not None  # noqa: S101 — RUNNING invariant
+                return self._loop
+            if self._state is LoopState.STOPPING:
+                raise RuntimeError("shared loop is stopping; cannot start")
+            if self._state is LoopState.FAILED:
+                raise RuntimeError(
+                    "shared loop is in FAILED state (a previous teardown could not release it); "
+                    "retry stop() before starting again"
+                )
+            self._start_locked()
+            return self._loop  # type: ignore[return-value]  # set by _start_locked
+
+    def _start_locked(self) -> None:
+        """Start the loop thread + executor (caller holds the lock)."""
+        ready = threading.Event()
+        start_error: list[BaseException] = []
+
+        def _run() -> None:
+            try:
+                loop = asyncio.new_event_loop()
+                asyncio.set_event_loop(loop)
+                self._loop = loop
+            except BaseException as exc:
+                start_error.append(exc)
+                ready.set()
+                return
+            ready.set()
+            try:
+                loop.run_forever()
+            finally:
+                # Own the loop's full lifecycle on this thread so teardown is a
+                # deterministic join. shutdown_default_executor joins the loop's
+                # internal executor threads (asyncssh's getaddrinfo etc.) that a
+                # bare loop.close() would leave lingering; without it a stopped
+                # SimNOS keeps an `asyncio_N` worker alive (thread-count leak).
+                try:
+                    loop.run_until_complete(loop.shutdown_asyncgens())
+                    # `timeout` is a real 3.12+ parameter; ty's stdlib stub lags.
+                    loop.run_until_complete(
+                        loop.shutdown_default_executor(timeout=SHUTDOWN_IO_TIMEOUT)  # type: ignore[unknown-argument]
+                    )
+                except Exception:
+                    log.debug("shared loop cleanup error", exc_info=True)
+                finally:
+                    loop.close()
+
+        self._executor = concurrent.futures.ThreadPoolExecutor(
+            max_workers=self._max_workers, thread_name_prefix="simnos-dispatch"
+        )
+        self._thread = threading.Thread(target=_run, daemon=True, name="simnos-shared-loop")
+        self._thread.start()
+        if not ready.wait(timeout=_LOOP_START_TIMEOUT):
+            raise RuntimeError(f"shared loop failed to start within {_LOOP_START_TIMEOUT}s")
+        if start_error:
+            raise start_error[0]
+        self._state = LoopState.RUNNING
+
+    # ------------------------------------------------------------------ submit
+    def submit_coro(self, coro: Awaitable[_T]) -> "concurrent.futures.Future[_T]":
+        """Schedule *coro* on the loop from a sync caller (run_coroutine_threadsafe)."""
+        return asyncio.run_coroutine_threadsafe(coro, self.loop)  # type: ignore[arg-type]
+
+    def run_coro(self, coro: Awaitable[_T], timeout: float | None = None) -> _T:
+        """Run *coro* on the loop and block for its result (sync facade)."""
+        return self.submit_coro(coro).result(timeout=timeout)
+
+    # ------------------------------------------------------------------ registry
+    def register(self, listener: AsyncListener) -> None:
+        """Register an active async listener (refcount += 1)."""
+        with self._lock:
+            if self._state is not LoopState.RUNNING:
+                raise RuntimeError(f"cannot register a listener while loop is {self._state.value}")
+            self._listeners[id(listener)] = listener
+
+    def drain_host(self, listener: AsyncListener, deadline: float | None = None) -> None:
+        """Host-scope stop (§1a 5a): close + drain one listener; idempotent.
+
+        Pops the listener (so a double stop is a no-op) and runs its ``aclose`` on
+        the loop, bounded by *deadline*. This MUST run even on a partial stop so
+        the host's listener socket is released (else restart hits EADDRINUSE,
+        gemini#1). A drain error is logged, not raised — the host reference is
+        already removed, and a stuck close must not block stopping other hosts.
+        """
+        with self._lock:
+            listener = self._listeners.pop(id(listener), None)  # type: ignore[assignment]
+        if listener is None:
+            return  # already drained
+        loop = self._loop
+        if loop is None or loop.is_closed():
+            return
+        budget = self._remaining(deadline, SHUTDOWN_SERVER_STOP_DEADLINE)
+        try:
+            self.submit_coro(listener.aclose()).result(timeout=budget)
+        except Exception:
+            log.exception("shared loop: draining host listener failed")
+
+    def teardown_if_idle(self, deadline: float | None = None) -> bool:
+        """Global teardown (§1a 5b) when no async listeners remain.
+
+        Called by ``SimNOS.stop()`` after stopping the requested hosts. Tears the
+        loop down only when the registry is empty (refcount == 0); otherwise other
+        async hosts are still running and the loop must stay up (partial stop).
+        Returns True when a teardown ran.
+        """
+        with self._lock:
+            if self._state is not LoopState.RUNNING:
+                return False
+            if self._listeners:
+                return False  # other async hosts still running
+            self._state = LoopState.STOPPING
+        self._global_teardown(deadline)
+        return True
+
+    # ------------------------------------------------------------------ teardown
+    def _global_teardown(self, deadline: float | None) -> None:
+        """Stop the loop, join the thread, detach (§1a 5b).
+
+        The loop thread closes the loop + joins its internal executor in its own
+        ``finally`` (see ``_start_locked``), so this only has to stop the loop and
+        join the thread. Emergency cleanup runs in ``finally`` so the bounded
+        executor + loop refs are released even if something above raises. If the
+        loop thread cannot be joined within budget the state goes ``FAILED``.
+        """
+        loop = self._loop
+        executor = self._executor
+        thread = self._thread
+        try:
+            # Bounded executor shutdown: cancel queued dispatch, do not wait for an
+            # in-flight (possibly non-cooperative) handler — same policy as the
+            # legacy parallel-stop path (cancel_futures, no block).
+            if executor is not None:
+                executor.shutdown(wait=False, cancel_futures=True)
+        finally:
+            alive = False
+            if loop is not None and not loop.is_closed():
+                loop.call_soon_threadsafe(loop.stop)
+            if thread is not None:
+                thread.join(timeout=self._remaining(deadline, SHUTDOWN_SERVER_STOP_DEADLINE))
+                alive = thread.is_alive()
+            with self._lock:
+                self._loop = None
+                self._thread = None
+                self._executor = None
+                self._listeners.clear()
+                self._state = LoopState.FAILED if alive else LoopState.STOPPED
+            if alive:
+                log.warning("shared loop thread did not exit within timeout; loop left in FAILED state")
+
+    @staticmethod
+    def _remaining(deadline: float | None, fallback: float) -> float:
+        """Seconds left until *deadline* (monotonic), or *fallback* when unset."""
+        if deadline is None:
+            return min(fallback, SHUTDOWN_SERVER_STOP_DEADLINE)
+        return max(SHUTDOWN_IO_TIMEOUT, deadline - time.monotonic())

--- a/simnos/core/simnos.py
+++ b/simnos/core/simnos.py
@@ -20,6 +20,7 @@ from simnos.core.host import Host
 from simnos.core.nos import Nos
 from simnos.core.pydantic_models import ModelSimnosInventory, ModelSysConfig
 from simnos.core.servers import join_threads_with_deadline
+from simnos.core.shared_loop import SharedLoop
 from simnos.core.timeouts import (
     SHUTDOWN_GLOBAL_DEADLINE,
     SHUTDOWN_SAFETY_NET_DEADLINE,
@@ -40,7 +41,7 @@ default_inventory = {
         "password": "user",
         "port": DEFAULT_PORT_START,
         "server": {
-            "plugin": "ParamikoSshServer",
+            "plugin": "AsyncSshServer",
             "configuration": {
                 "address": "127.0.0.1",
                 "timeout": 1,
@@ -108,6 +109,13 @@ class SimNOS:
         self.shell_plugins = shell_plugins
         self.nos_plugins = nos_plugins
         self.servers_plugins = servers_plugins
+
+        # The shared asyncio loop async server plugins (AsyncSshServer) run on
+        # (#297 Stage 2, §1). Owned here as a SimNOS-scoped resource; the loop
+        # thread + bounded executor start lazily on the first async host start
+        # (``ensure_shared_loop``) and are torn down once in ``stop()`` when no
+        # async host remains. Sync paramiko/telnet servers do not touch it.
+        self._shared_loop = SharedLoop()
 
         self._load_sys_config(sys_config)
         self._load_inventory()
@@ -382,6 +390,16 @@ class SimNOS:
             raise ValueError(f"Port {port} already in use")
         self.allocated_ports.add(port)
 
+    def ensure_shared_loop(self) -> SharedLoop:
+        """Start (lazily) and return the SimNOS-owned shared asyncio loop (§1).
+
+        Called by async server plugins (``AsyncSshServer.start``) so the loop
+        thread + bounded executor exist before a listener is registered. Idempotent
+        while running; recreates the loop after a full stop (restart).
+        """
+        self._shared_loop.ensure_running()
+        return self._shared_loop
+
     def _get_hosts_as_list(self, hosts: str | list[str] | None = None) -> list[Host]:
         """
         Helper method to get hosts as list
@@ -456,6 +474,11 @@ class SimNOS:
         if managed_threads:
             remaining = max(0, deadline - time.monotonic())
             self._join_threads(managed_threads, timeout=min(SHUTDOWN_SAFETY_NET_DEADLINE, remaining))
+        # Tear the shared loop down once no async host remains registered (§1a 5b):
+        # global teardown is SimNOS's job (the loop thread is joined here once, not
+        # per host). A partial stop that leaves async hosts running is a no-op here
+        # (refcount > 0), so the loop keeps serving them.
+        self._shared_loop.teardown_if_idle(deadline)
 
     def _collect_server_threads(self, hosts: list[Host]) -> list[threading.Thread]:
         """Collect all managed threads from host servers before stopping."""

--- a/simnos/plugins/servers/__init__.py
+++ b/simnos/plugins/servers/__init__.py
@@ -3,10 +3,12 @@ This module is the point of entry for server plugins in SIMNOS.
 
 """
 
+from .ssh_server_asyncssh import AsyncSshServer
 from .ssh_server_paramiko import ParamikoSshServer
 from .telnet_server import TelnetServer
 
 servers_plugins = {
+    "AsyncSshServer": AsyncSshServer,
     "ParamikoSshServer": ParamikoSshServer,
     "TelnetServer": TelnetServer,
 }

--- a/simnos/plugins/servers/async_session.py
+++ b/simnos/plugins/servers/async_session.py
@@ -91,6 +91,15 @@ async def run_async_push_session(
       ``io_errors`` raise) rather than a polled ``is_running`` flag — the shared
       loop closes the session on stop (§1a).
 
+    **Write-failure policy (§3a, codex/claude 1st):** the sync path's asymmetry
+    (immediate-echo ``TimeoutError`` = disconnect vs response-batch ``TimeoutError``
+    = retry) does *not* apply here. asyncssh has no per-write timeout — it applies
+    backpressure through ``drain`` flow-control, so the retry case never arises;
+    a real write failure surfaces as an ``io_errors`` raise and is treated as a
+    disconnect for both echo and response. The byte *content* is unchanged; only
+    the (timeout-specific) failure handling differs, which is inherent to swapping
+    a poll-timeout transport for a flow-controlled one.
+
     ``initial_skip_lf`` consumes a trailing LF/NUL left by a preceding channel
     login (auth_none), matching ``run_push_session``.
     """

--- a/simnos/plugins/servers/async_session.py
+++ b/simnos/plugins/servers/async_session.py
@@ -1,0 +1,219 @@
+"""Async push-dispatch session driver (#297 Stage 2, §3 / §3a).
+
+The async counterpart to ``tap_bridge.run_push_session``: it drives one client
+session over an event-driven transport (asyncssh process in Stage 2) using the
+**same** wire-assembly helpers (``_render_intro`` / ``_render_response``), so the
+byte stream is identical to the paramiko push path — pinned by the byte-parity
+goldens in ``tests/plugins/test_ssh_byte_parity.py``.
+
+The spike (#296) proved that bridging a *blocking* shell loop per session is the
+100-host failure source, so here the read loop is event-driven on the event-loop
+thread and **only the blocking ``shell.dispatch``** is off-loaded to the bounded
+executor (§2a). There is no per-session thread.
+
+Two collaborators are injected so the driver stays transport- and
+executor-agnostic (and unit-testable with fakes):
+
+- ``transport``: an :class:`AsyncPushTransport` wrapping the real async I/O.
+- ``dispatch``: an async callable that runs ``shell.dispatch(line)`` on the
+  bounded executor and returns the :class:`DispatchResult`.
+"""
+
+from collections.abc import Awaitable, Callable
+import logging
+from typing import TYPE_CHECKING, Protocol
+
+from simnos.plugins.servers.tap_bridge import _render_intro, _render_response
+
+if TYPE_CHECKING:
+    from simnos.plugins.servers.tap_bridge import PushShell
+    from simnos.plugins.shell.cmd_shell import DispatchResult
+
+log = logging.getLogger(__name__)
+
+# asyncssh stdin reads arrive in chunks; one read may carry several bytes/lines.
+# The §3a byte state machine iterates the chunk byte-by-byte so per-character echo
+# stays byte-identical to the synchronous paramiko path.
+_READ_CHUNK = 4096
+
+
+class AsyncPushTransport(Protocol):
+    """Minimal async transport surface the session driver needs (§3a, claude#3).
+
+    Mirrors ``tap_bridge.TransportAdapter`` but with an async ``recv`` (the read
+    is event-driven, not a blocking pull). ``send`` buffers a write; ``drain``
+    applies flow-control backpressure at response boundaries so a slow client
+    cannot make the server buffer without bound under the 100-host load.
+    """
+
+    #: Exceptions that mean "I/O failed / peer gone" for this transport.
+    io_errors: tuple[type[BaseException], ...]
+
+    #: RFC 854 CR NUL quirk switch (False for SSH, True for Telnet) — same
+    #: contract as ``TransportAdapter.nul_resets_skip_lf``.
+    nul_resets_skip_lf: bool
+
+    #: Short name for log messages ("ssh").
+    name: str
+
+    async def recv(self, n: int) -> bytes:
+        """Read up to *n* bytes. Returns ``b""`` on EOF (peer closed)."""
+        ...
+
+    def send(self, data: bytes) -> None:
+        """Queue *data* for the client (flushed by the transport / ``drain``)."""
+        ...
+
+    async def drain(self) -> None:
+        """Wait until queued writes have drained below the transport's limit."""
+        ...
+
+
+async def run_async_push_session(
+    transport: AsyncPushTransport,
+    shell: "PushShell",
+    dispatch: Callable[[str], Awaitable["DispatchResult"]],
+    *,
+    initial_skip_lf: bool = False,
+) -> None:
+    """Drive one client session with async push dispatch (#297 Stage 2, §3a).
+
+    The state machine is identical to ``run_push_session`` (regular char =
+    immediate echo; line terminator = held ``\\r\\n`` echo + body + prompt in one
+    write), so the wire bytes match the paramiko push path. The differences are
+    structural, not behavioural on the wire:
+
+    - the read is ``await transport.recv(...)`` (event-driven) instead of a
+      blocking per-byte pull, so the event-loop thread is free between bytes;
+    - ``shell.dispatch`` runs via the injected ``dispatch`` coroutine (bounded
+      executor), so a slow handler does not block the loop (§2a);
+    - shutdown is propagated by the transport closing (``recv`` -> ``b""`` / an
+      ``io_errors`` raise) rather than a polled ``is_running`` flag — the shared
+      loop closes the session on stop (§1a).
+
+    ``initial_skip_lf`` consumes a trailing LF/NUL left by a preceding channel
+    login (auth_none), matching ``run_push_session``.
+    """
+    try:
+        transport.send(_render_intro(shell))
+        await transport.drain()
+    except transport.io_errors:
+        log.debug("async_session [%s] intro write closed", transport.name)
+        return
+
+    buffer = bytearray()
+    skip_lf = initial_skip_lf
+    while True:
+        try:
+            data = await transport.recv(_READ_CHUNK)
+        except transport.io_errors:
+            log.debug("async_session [%s] read closed", transport.name)
+            return
+        if not data:
+            return  # EOF / peer gone
+
+        for i in range(len(data)):
+            byte = data[i : i + 1]
+
+            # Drop NUL completely (no echo, no buffer). Telnet (RFC 854): CR NUL
+            # is a complete sequence, so reset skip_lf; SSH preserves it.
+            if byte == b"\x00":
+                if transport.nul_resets_skip_lf:
+                    skip_lf = False
+                continue
+
+            # Consume the LF half of a CR LF pair.
+            if skip_lf:
+                skip_lf = False
+                if byte == b"\n":
+                    continue
+
+            if byte in (b"\r", b"\n"):
+                skip_lf = byte == b"\r"
+                # errors="replace" keeps malformed UTF-8 from crashing the
+                # session (parity with run_push_session, gemini#2).
+                line = bytes(buffer).decode("utf-8", errors="replace")
+                buffer.clear()
+                result = await dispatch(line)
+                try:
+                    transport.send(_render_response(shell, result))
+                    await transport.drain()
+                except transport.io_errors as e:
+                    log.error("async_session [%s] client write error: %s", transport.name, e)
+                    return
+                if result.close:
+                    return
+            else:
+                # Regular character: immediate echo (interactive latency
+                # unchanged). The raw byte is echoed, matching run_push_session.
+                try:
+                    transport.send(byte)
+                except transport.io_errors as e:
+                    log.error("async_session [%s] client write error: %s", transport.name, e)
+                    return
+                buffer += byte
+
+
+async def _async_read_line(transport: AsyncPushTransport, *, echo: bool, skip_lf: bool) -> tuple[str, bool]:
+    """Read one line byte-by-byte (async mirror of ``tap_bridge.read_line``).
+
+    Returns ``(line without trailing CR/LF, next_skip_lf)``; a CR sets
+    ``next_skip_lf=True`` so the next read consumes the LF half of a CR LF pair.
+    Reads one byte per ``recv`` (login is short and not perf-critical, so this
+    avoids a leftover-buffer between the two reads). EOF returns the partial line
+    (same contract as the sync ``read_line``).
+    """
+    buf = b""
+    while True:
+        byte = await transport.recv(1)
+        if not byte:  # EOF
+            return buf.decode("utf-8", errors="replace"), False
+        if skip_lf:
+            skip_lf = False
+            if byte == b"\n":
+                continue
+            if byte == b"\x00" and transport.nul_resets_skip_lf:
+                continue
+        if byte == b"\r":
+            if echo:
+                transport.send(b"\r\n")
+            return buf.decode("utf-8", errors="replace"), True
+        if byte == b"\n":
+            if echo:
+                transport.send(b"\r\n")
+            return buf.decode("utf-8", errors="replace"), False
+        if echo:
+            transport.send(byte)
+        buf += byte
+
+
+async def async_interactive_login(
+    transport: AsyncPushTransport,
+    username: str,
+    password: str,
+    *,
+    user_prompt: bytes,
+    pass_prompt: bytes,
+) -> tuple[bool, bool]:
+    """Async channel-level login (mirror of ``tap_bridge.interactive_login``).
+
+    Used for auth_none platforms (e.g. Dell PowerConnect) before the shell.
+    Returns ``(authenticated, skip_lf)``; ``skip_lf`` is forwarded to
+    ``run_async_push_session`` as ``initial_skip_lf`` so it consumes the trailing
+    LF/NUL left by the final CR of the password line. The wire interaction is
+    byte-identical to the sync path.
+    """
+    transport.send(user_prompt)
+    entered_user, skip_lf = await _async_read_line(transport, echo=True, skip_lf=False)
+    transport.send(pass_prompt)
+    entered_pass, skip_lf = await _async_read_line(transport, echo=False, skip_lf=skip_lf)
+    transport.send(b"\r\n")
+    await transport.drain()
+    authenticated = entered_user == username and entered_pass == password
+    log.debug(
+        "async_session.async_interactive_login [%s] %s for user %s",
+        transport.name,
+        "succeeded" if authenticated else "failed",
+        entered_user,
+    )
+    return authenticated, skip_lf

--- a/simnos/plugins/servers/ssh_server_asyncssh.py
+++ b/simnos/plugins/servers/ssh_server_asyncssh.py
@@ -102,13 +102,26 @@ class _SimnosSSHServer(asyncssh.SSHServer):
         password: str,
         allow_auth_none: bool,
         authorized_keys: "set[bytes]",
+        ssh_banner: str,
     ) -> None:
         self._username = username
         self._password = password
         self._allow_auth_none = allow_auth_none
         self._authorized_keys = authorized_keys
+        self._ssh_banner = ssh_banner
+        self._conn: asyncssh.SSHServerConnection | None = None
+        self._banner_sent = False
+
+    def connection_made(self, conn: "asyncssh.SSHServerConnection") -> None:
+        self._conn = conn
 
     def begin_auth(self, username: str) -> bool:
+        # Pre-auth banner (parity with ParamikoSshServerInterface.get_banner):
+        # sent once at the start of auth, consumed by the client's auth handler
+        # (so it never appears on the post-auth shell channel / byte-parity golden).
+        if self._ssh_banner and not self._banner_sent and self._conn is not None:
+            self._conn.send_auth_banner(f"{self._ssh_banner}\r\n", lang="en-US")
+            self._banner_sent = True
         # False = no SSH-level auth required (auth_none platforms: the Dell-style
         # channel login then runs inside the session, see _handle_process).
         return not self._allow_auth_none
@@ -198,6 +211,9 @@ class AsyncSshServer:
         self.password: str = password
         self.address: str = address
         self.port: int = port
+        # timeout / watchdog_interval are inert on the async path (shutdown is
+        # driven by closing the listener/sessions on the shared loop, not a recv
+        # poll); kept for ParamikoSshServer signature + config parity.
         self.timeout: int = timeout
         self.watchdog_interval: float = watchdog_interval
         self._simnos = simnos
@@ -276,7 +292,9 @@ class AsyncSshServer:
 
     async def _create_server(self) -> "asyncssh.SSHAcceptor":
         return await asyncssh.create_server(
-            lambda: _SimnosSSHServer(self.username, self.password, self._allow_auth_none, self._authorized_keys),
+            lambda: _SimnosSSHServer(
+                self.username, self.password, self._allow_auth_none, self._authorized_keys, self.ssh_banner
+            ),
             self.address,
             self.port,
             server_host_keys=[self._host_key],

--- a/simnos/plugins/servers/ssh_server_asyncssh.py
+++ b/simnos/plugins/servers/ssh_server_asyncssh.py
@@ -228,9 +228,12 @@ class AsyncSshServer:
         # Per-server run flag the shells observe: cleared on stop so an in-flight
         # dispatch returns close (cooperative stop, §1a).
         self._is_running = threading.Event()
+        # Set once aclose starts so a session that begins handshaking *after* the
+        # drain snapshot bows out instead of leaking past teardown (claude 1st#1).
+        self._closing = False
         # Active sessions, drained on aclose (§1a host-scope 5a).
         self._processes: set[asyncssh.SSHServerProcess] = set()
-        self._tasks: set = set()
+        self._tasks: set[asyncio.Task] = set()
 
     @property
     def managed_threads(self) -> list[threading.Thread]:
@@ -282,16 +285,54 @@ class AsyncSshServer:
 
     # ------------------------------------------------------------------ lifecycle
     def start(self) -> None:
-        """Register this host's listener on the shared loop (§1)."""
+        """Register this host's listener on the shared loop (§1).
+
+        On a failed/timed-out ``create_server`` the pending coroutine is cancelled
+        and any listener it managed to create is closed, so a failed start leaves
+        no orphan listener socket (codex 1st#1). The loop-idle cleanup — when this
+        failure leaves the loop with refcount 0 — is ``SimNOS.stop()``'s job
+        (``teardown_if_idle``), reached via the caller's ``stop()`` / context
+        manager ``__exit__``.
+        """
         if self._simnos is None:
             raise RuntimeError("AsyncSshServer requires a SimNOS reference (set by Host.start)")
         self._shared_loop = self._simnos.ensure_shared_loop()
         self._is_running.set()
-        self._acceptor = self._shared_loop.run_coro(self._create_server(), timeout=_CREATE_SERVER_TIMEOUT)
+        future = self._shared_loop.submit_coro(self._create_server())
+        try:
+            future.result(timeout=_CREATE_SERVER_TIMEOUT)
+        except BaseException:
+            future.cancel()
+            self._abort_failed_start()
+            raise
         self._shared_loop.register(self)
 
+    def _abort_failed_start(self) -> None:
+        """Close a listener left by a failed/timed-out start (codex 1st#1).
+
+        ``_create_server`` stores the acceptor on ``self`` as soon as it exists, so
+        even when ``result()`` gave up waiting (and the coroutine then completed)
+        the listener is reachable here and closed on the loop. Best-effort: a stuck
+        loop must not turn a start failure into a hang.
+        """
+        loop = self._shared_loop
+        if loop is None:
+            return
+        with contextlib.suppress(Exception):
+            loop.run_coro(self._aclose_acceptor(), timeout=SHUTDOWN_IO_TIMEOUT)
+
+    async def _aclose_acceptor(self) -> None:
+        """Close + await the listener socket (on the loop thread)."""
+        acceptor, self._acceptor = self._acceptor, None
+        if acceptor is not None:
+            acceptor.close()
+            with contextlib.suppress(Exception):
+                await acceptor.wait_closed()
+
     async def _create_server(self) -> "asyncssh.SSHAcceptor":
-        return await asyncssh.create_server(
+        # Store on self before returning so _abort_failed_start can close it even
+        # if start()'s result() already timed out (codex 1st#1).
+        self._acceptor = await asyncssh.create_server(
             lambda: _SimnosSSHServer(
                 self.username, self.password, self._allow_auth_none, self._authorized_keys, self.ssh_banner
             ),
@@ -306,6 +347,7 @@ class AsyncSshServer:
             reuse_address=True,
             reuse_port=(sys.platform == "linux"),
         )
+        return self._acceptor
 
     def stop(self) -> None:
         """Stop this host: drain its listener + sessions on the shared loop (§1a 5a).
@@ -317,16 +359,23 @@ class AsyncSshServer:
         self._is_running.clear()
         if self._shared_loop is not None:
             self._shared_loop.drain_host(self)
-        self._acceptor = None
+        # Do NOT null self._acceptor here: if drain_host timed out, the queued
+        # aclose runs later and still needs the reference to close the listener
+        # socket (clearing it would leak the socket → EADDRINUSE, gemini 1st#1).
+        # The instance is discarded by Host.start after stop(), so no leak.
 
     async def aclose(self) -> None:
         """Close the listener + drain active sessions (called by the shared loop).
 
-        Runs on the loop thread. Stops accepting, signals in-flight dispatch to
-        close (``_is_running`` cleared in ``stop``), closes each active session so
-        its read returns EOF, then awaits the session tasks with a bounded budget
-        (cancelling any stragglers) so teardown leaves no orphaned tasks.
+        Runs on the loop thread. Marks the server closing (so a session that
+        begins handshaking after the snapshot below bows out, claude 1st#1), stops
+        accepting, signals in-flight dispatch to close (``_is_running`` cleared in
+        ``stop``), closes each active session so its read returns EOF, then awaits
+        the session tasks with a bounded budget — cancelling any stragglers and
+        awaiting them so their ``finally`` runs (gemini 1st#3) — leaving no
+        orphaned task or listener.
         """
+        self._closing = True
         self._is_running.clear()
         if self._acceptor is not None:
             self._acceptor.close()
@@ -338,9 +387,21 @@ class AsyncSshServer:
             _, pending = await asyncio.wait(tasks, timeout=SHUTDOWN_IO_TIMEOUT)
             for t in pending:
                 t.cancel()
+            if pending:
+                # Give the cancelled tasks a brief, BOUNDED moment to run their
+                # finally (gemini 1st#3) — but do not block on a non-cooperative
+                # dispatch whose executor job cannot be cancelled. Such a handler is
+                # detached (§1a, codex 1st#3) so stop converges within the budget;
+                # its late result lands on the now-closed transport and is discarded
+                # (generation isolation via per-session shell + transport close).
+                await asyncio.wait(pending, timeout=SHUTDOWN_IO_TIMEOUT)
         if self._acceptor is not None:
+            # Bounded: wait_closed can otherwise block on a detached session's
+            # connection (a non-cooperative dispatch above), which would defeat the
+            # detach and stall stop to the drain budget. The listening socket is
+            # already closed by acceptor.close(); this just confirms shutdown.
             with contextlib.suppress(Exception):
-                await self._acceptor.wait_closed()
+                await asyncio.wait_for(self._acceptor.wait_closed(), timeout=SHUTDOWN_IO_TIMEOUT)
 
     # ------------------------------------------------------------------ per-session
     async def _handle_process(self, process: "asyncssh.SSHServerProcess") -> None:
@@ -350,8 +411,15 @@ class AsyncSshServer:
         auth_none channel login, then the push session driving ``shell.dispatch``
         via the bounded executor. asyncssh closes ``process`` when this returns.
         """
+        # A connection that finishes handshaking after aclose took its drain
+        # snapshot must not start a session on a stopping host (claude 1st#1).
+        if self._closing:
+            with contextlib.suppress(Exception):
+                process.close()
+            return
         task = asyncio.current_task()
-        self._tasks.add(task)
+        if task is not None:
+            self._tasks.add(task)
         self._processes.add(process)
         transport = AsyncSSHProcessTransport(process)
         try:
@@ -400,7 +468,8 @@ class AsyncSshServer:
             # this session only (§3a observability, #294-aligned).
             log.exception("AsyncSshServer session crashed")
         finally:
-            self._tasks.discard(task)
+            if task is not None:
+                self._tasks.discard(task)
             self._processes.discard(process)
             with contextlib.suppress(Exception):
                 process.close()

--- a/simnos/plugins/servers/ssh_server_asyncssh.py
+++ b/simnos/plugins/servers/ssh_server_asyncssh.py
@@ -326,7 +326,10 @@ class AsyncSshServer:
         """
         if future.cancelled():
             return
-        with contextlib.suppress(Exception):
+        # suppress BaseException, not Exception: this runs as a future done-callback
+        # on the loop thread, and a BaseException set on the future (or raised by
+        # close) must not escape into the loop (gemini 3rd#4).
+        with contextlib.suppress(BaseException):
             acceptor = future.result()
             if acceptor is not None:
                 acceptor.close()

--- a/simnos/plugins/servers/ssh_server_asyncssh.py
+++ b/simnos/plugins/servers/ssh_server_asyncssh.py
@@ -370,10 +370,10 @@ class AsyncSshServer:
         Runs on the loop thread. Marks the server closing (so a session that
         begins handshaking after the snapshot below bows out, claude 1st#1), stops
         accepting, signals in-flight dispatch to close (``_is_running`` cleared in
-        ``stop``), closes each active session so its read returns EOF, then awaits
-        the session tasks with a bounded budget — cancelling any stragglers and
-        awaiting them so their ``finally`` runs (gemini 1st#3) — leaving no
-        orphaned task or listener.
+        ``stop``), closes each active session so its read returns EOF, then waits
+        on the session tasks with a bounded budget — cancelling any stragglers and
+        giving them a bounded moment to run their ``finally`` (gemini 1st#3) —
+        leaving no orphaned task or listener.
         """
         self._closing = True
         self._is_running.clear()

--- a/simnos/plugins/servers/ssh_server_asyncssh.py
+++ b/simnos/plugins/servers/ssh_server_asyncssh.py
@@ -18,6 +18,7 @@ GEX: asyncssh handles moduli itself, so the paramiko GEX workaround
 """
 
 import asyncio
+import concurrent.futures
 import contextlib
 import io
 import logging
@@ -289,23 +290,46 @@ class AsyncSshServer:
 
         On a failed/timed-out ``create_server`` the pending coroutine is cancelled
         and any listener it managed to create is closed, so a failed start leaves
-        no orphan listener socket (codex 1st#1). The loop-idle cleanup — when this
-        failure leaves the loop with refcount 0 — is ``SimNOS.stop()``'s job
+        no orphan listener socket (codex 1st#1) — including the case where the
+        create completes *after* ``result()`` gave up: a done-callback closes that
+        late acceptor (codex 2nd#1). The loop-idle cleanup — when this failure
+        leaves the loop with refcount 0 — is ``SimNOS.stop()``'s job
         (``teardown_if_idle``), reached via the caller's ``stop()`` / context
         manager ``__exit__``.
         """
         if self._simnos is None:
             raise RuntimeError("AsyncSshServer requires a SimNOS reference (set by Host.start)")
         self._shared_loop = self._simnos.ensure_shared_loop()
+        self._closing = False  # fresh start (defensive if an instance is reused, codex 2nd#4)
         self._is_running.set()
         future = self._shared_loop.submit_coro(self._create_server())
         try:
             future.result(timeout=_CREATE_SERVER_TIMEOUT)
         except BaseException:
             future.cancel()
+            # If the create still completes after we gave up (cancellation lost the
+            # race, or it finished right at the timeout), close the acceptor it
+            # yields so no listener leaks (codex 2nd#1).
+            future.add_done_callback(self._discard_late_acceptor)
             self._abort_failed_start()
             raise
         self._shared_loop.register(self)
+
+    @staticmethod
+    def _discard_late_acceptor(future: "concurrent.futures.Future") -> None:
+        """Close a listener a cancelled/timed-out start produced after giving up.
+
+        Runs on the loop thread (run_coroutine_threadsafe completes the future
+        there), so ``acceptor.close()`` is loop-safe. A cancelled future has no
+        acceptor to reclaim; a completed one is closed (idempotent with
+        ``_abort_failed_start`` if both fire).
+        """
+        if future.cancelled():
+            return
+        with contextlib.suppress(Exception):
+            acceptor = future.result()
+            if acceptor is not None:
+                acceptor.close()
 
     def _abort_failed_start(self) -> None:
         """Close a listener left by a failed/timed-out start (codex 1st#1).
@@ -457,7 +481,13 @@ class AsyncSshServer:
 
             async def dispatch(line: str):
                 # Off-load the blocking dispatch (custom handlers / hot-reload) to
-                # the bounded executor so the loop thread stays free (§2a).
+                # the bounded executor so the loop thread stays free (§2a). A
+                # non-cooperative handler that outlives stop (its executor job
+                # cannot be cancelled) completes after the loop is torn down; the
+                # run_in_executor done-callback then logs a harmless "Event loop is
+                # closed" — the late result lands nowhere (the awaiting task was
+                # cancelled and the transport is closed = generation isolation,
+                # claude 2nd#2).
                 return await loop.run_in_executor(executor, client_shell.dispatch, line)
 
             await run_async_push_session(transport, client_shell, dispatch, initial_skip_lf=skip_lf)

--- a/simnos/plugins/servers/ssh_server_asyncssh.py
+++ b/simnos/plugins/servers/ssh_server_asyncssh.py
@@ -1,0 +1,388 @@
+"""asyncssh-backed SSH server plugin (#297 Stage 2, §2).
+
+Drop-in replacement for :class:`ParamikoSshServer`: the same ``__init__``
+signature so ``Host.start`` builds it identically, the same NOS data / CMDShell /
+render_config, the same wire bytes (pinned by the byte-parity goldens). Only the
+transport differs — asyncssh on the SimNOS-owned shared event loop
+(:mod:`simnos.core.shared_loop`) instead of a paramiko thread per connection.
+
+The spike (#296) proved the shape: asyncssh handles 100 concurrent connections at
+the transport layer; the failures came from bridging a *blocking* shell loop per
+session. So here each session is driven by :func:`run_async_push_session` (W3 push
+dispatch), with only the blocking ``shell.dispatch`` off-loaded to the bounded
+executor (§2a). No per-session thread.
+
+GEX: asyncssh handles moduli itself, so the paramiko GEX workaround
+(``_DISABLED_GEX_ALGORITHMS`` / bundled moduli) is not referenced on this path
+(removed wholesale in Stage 4).
+"""
+
+import asyncio
+import contextlib
+import io
+import logging
+import sys
+import threading
+from typing import TYPE_CHECKING
+
+import asyncssh
+
+from simnos.core.nos import Nos
+from simnos.core.timeouts import SHUTDOWN_IO_TIMEOUT
+from simnos.plugins.servers.async_session import (
+    async_interactive_login,
+    run_async_push_session,
+)
+
+if TYPE_CHECKING:
+    from simnos.core.host import HostRenderConfig
+    from simnos.core.shared_loop import SharedLoop
+    from simnos.core.simnos import SimNOS
+
+log = logging.getLogger(__name__)
+
+#: Per-host listener creation budget (seconds): create_server runs on the shared
+#: loop and is awaited synchronously by start() (parity with paramiko bind).
+_CREATE_SERVER_TIMEOUT = 30
+
+
+class AsyncSSHProcessTransport:
+    """AsyncPushTransport over an asyncssh ``SSHServerProcess`` (binary channel).
+
+    ``encoding=None`` makes the channel binary so the byte stream matches paramiko
+    exactly. The PTY signal events asyncssh surfaces from ``read`` (window resize,
+    Ctrl-C/Break, soft EOF) are *not* disconnects, so ``recv`` swallows them and
+    keeps reading — only a real EOF (``b""``) or an ``io_errors`` raise ends the
+    session.
+    """
+
+    io_errors = (OSError, EOFError, ConnectionError, asyncssh.Error)
+    nul_resets_skip_lf = False  # SSH has no CR NUL convention (parity with paramiko adapter)
+    name = "ssh"
+
+    def __init__(self, process: "asyncssh.SSHServerProcess") -> None:
+        self._process = process
+
+    async def recv(self, n: int) -> bytes:
+        while True:
+            try:
+                return await self._process.stdin.read(n)
+            except (asyncssh.TerminalSizeChanged, asyncssh.SignalReceived, asyncssh.BreakReceived):
+                continue  # PTY control event, not a disconnect — keep reading
+
+    def send(self, data: bytes) -> None:
+        self._process.stdout.write(data)
+
+    async def drain(self) -> None:
+        await self._process.stdout.drain()
+
+
+class _SimnosSSHServer(asyncssh.SSHServer):
+    """Connection-level auth (parity with ``ParamikoSshServerInterface``, §2).
+
+    password / publickey / keyboard-interactive / none, plus MikroTik-style ``+``
+    suffix username matching.
+
+    publickey is advertised **only when authorized_keys is configured** — the same
+    rule as paramiko's ``get_allowed_auths`` (which prepends ``publickey`` only
+    when keys are loaded). This matters for the asyncssh↔paramiko-client
+    interop (#297 テーマE / E2): a paramiko client that fails one auth method and
+    retries another resends ``SERVICE_REQUEST(ssh-userauth)``, which asyncssh
+    rejects (``Unexpected service in service request``) — a hardcoded protocol
+    check with no public-API override. So advertising publickey on a host with no
+    keys would only lure a key-offering client (e.g. ansible's default probe) into
+    that failing retry. Password-first clients (netmiko/scrapli) never retry and
+    are unaffected; a key-offering client against simnos must use a non-paramiko
+    backend (ansible → ansible-pylibssh).
+    """
+
+    def __init__(
+        self,
+        username: str,
+        password: str,
+        allow_auth_none: bool,
+        authorized_keys: "set[bytes]",
+    ) -> None:
+        self._username = username
+        self._password = password
+        self._allow_auth_none = allow_auth_none
+        self._authorized_keys = authorized_keys
+
+    def begin_auth(self, username: str) -> bool:
+        # False = no SSH-level auth required (auth_none platforms: the Dell-style
+        # channel login then runs inside the session, see _handle_process).
+        return not self._allow_auth_none
+
+    def password_auth_supported(self) -> bool:
+        return True
+
+    def validate_password(self, username: str, password: str) -> bool:
+        return self._match_username(username) and password == self._password
+
+    def kbdint_auth_supported(self) -> bool:
+        return True
+
+    def get_kbdint_challenge(self, username: str, lang: str, submethods: str):
+        # Single hidden Password prompt (parity with the paramiko
+        # keyboard-interactive InteractiveQuery). An unknown user gets no
+        # challenge (False) so the method fails cleanly.
+        if self._match_username(username):
+            return "", "", "", (("Password: ", False),)
+        return False
+
+    def validate_kbdint_response(self, username: str, responses) -> bool:
+        return len(responses) == 1 and responses[0] == self._password
+
+    def public_key_auth_supported(self) -> bool:
+        # Advertise publickey only when keys are configured (paramiko parity); see
+        # the class docstring for the auth-retry-disconnect rationale.
+        return bool(self._authorized_keys)
+
+    def validate_public_key(self, username: str, key) -> bool:
+        if not self._authorized_keys or not self._match_username(username):
+            return False
+        return key.export_public_key("openssh").split()[1] in self._authorized_keys
+
+    def _match_username(self, username: str) -> bool:
+        if username == self._username:
+            return True
+        base, sep, _ = username.partition("+")
+        return bool(sep) and base == self._username
+
+
+class AsyncSshServer:
+    """asyncssh SSH server plugin on the SimNOS-owned shared loop (§1 / §2).
+
+    Same constructor signature as ``ParamikoSshServer`` plus a ``simnos`` back
+    reference (added by ``Host.start``) so it can reach the shared loop. Not a
+    ``TCPServerBase`` — listening + sessions live on the shared asyncio loop, not
+    a thread per connection. ``managed_threads`` is empty: the loop thread is a
+    SimNOS-scoped resource joined once by ``SimNOS.stop()`` (Decision 2).
+    """
+
+    # One auto-generated RSA-2048 host key per process (parity with paramiko's
+    # shared _default_key: same alg + size, so KEX cost is comparable).
+    _default_key = None
+    _default_key_lock = threading.Lock()
+
+    def __init__(
+        self,
+        shell: type,
+        nos: Nos,
+        nos_inventory_config: dict,
+        port: int,
+        username: str,
+        password: str,
+        ssh_key_file: str | None = None,
+        ssh_key_file_password: str | None = None,
+        ssh_banner: str = "SIMNOS AsyncSSH Server",
+        shell_configuration: dict | None = None,
+        address: str = "127.0.0.1",
+        timeout: int = 1,
+        watchdog_interval: float = 1,
+        authorized_keys: str | None = None,
+        render_config: "HostRenderConfig | None" = None,
+        simnos: "SimNOS | None" = None,
+    ) -> None:
+        self.nos: Nos = nos
+        self.nos_inventory_config: dict = nos_inventory_config
+        self.shell: type = shell
+        self.shell_configuration: dict = shell_configuration or {}
+        self._render_config: HostRenderConfig | None = render_config
+        # Normalize the merged platform once at Host.start (per-host invariant,
+        # surfaces malformed data at startup) — parity with ParamikoSshServer.
+        build_shared = getattr(self.shell, "build_shared_platform", None)
+        self._shared_platform = build_shared(nos, self.nos_inventory_config, render_config) if build_shared else None
+        self.ssh_banner: str = ssh_banner
+        self.username: str = username
+        self.password: str = password
+        self.address: str = address
+        self.port: int = port
+        self.timeout: int = timeout
+        self.watchdog_interval: float = watchdog_interval
+        self._simnos = simnos
+        self._authorized_keys = self._load_authorized_keys(authorized_keys)
+        self._host_key = self._get_host_key(ssh_key_file, ssh_key_file_password)
+        # auth_none (Dell PowerConnect channel login): nos.auth == "none"
+        # (parity with ParamikoSshServer.connection_function).
+        self._allow_auth_none = getattr(nos, "auth", None) == "none"
+
+        self._shared_loop: SharedLoop | None = None
+        self._acceptor: asyncssh.SSHAcceptor | None = None
+        # Per-server run flag the shells observe: cleared on stop so an in-flight
+        # dispatch returns close (cooperative stop, §1a).
+        self._is_running = threading.Event()
+        # Active sessions, drained on aclose (§1a host-scope 5a).
+        self._processes: set[asyncssh.SSHServerProcess] = set()
+        self._tasks: set = set()
+
+    @property
+    def managed_threads(self) -> list[threading.Thread]:
+        """No SimNOS-managed threads: the loop is owned by SimNOS, not the plugin.
+
+        Returning [] keeps ``_collect_server_threads`` from joining the shared loop
+        thread once per async host (it is joined once by ``SimNOS.stop()``), and
+        lets it coexist with paramiko-era telnet servers that still return real
+        threads during the Stage 2-3 migration (Decision 2).
+        """
+        return []
+
+    @staticmethod
+    def _load_authorized_keys(path: str | None) -> "set[bytes]":
+        """Parse an OpenSSH authorized_keys file into a set of base64 key blobs.
+
+        Mirrors ``ParamikoSshServer._load_authorized_keys`` in intent (bare key
+        lines, skip comment/blank/marker lines). Stored value = the base64 middle
+        field of the OpenSSH line, matched in ``validate_public_key``.
+        """
+        keys: set[bytes] = set()
+        if not path:
+            return keys
+        with open(path) as fh:
+            for raw in fh:
+                line = raw.strip()
+                if not line or line.startswith(("#", "@")):
+                    continue
+                try:
+                    key = asyncssh.import_public_key(line)
+                    keys.add(key.export_public_key("openssh").split()[1])
+                except (asyncssh.KeyImportError, ValueError, IndexError) as exc:
+                    log.warning("Skipping unparseable authorized_keys line: %s", exc)
+        return keys
+
+    @classmethod
+    def _get_host_key(cls, key_file: str | None, key_pw: str | None):
+        if key_file:
+            return asyncssh.read_private_key(key_file, key_pw)
+        with cls._default_key_lock:
+            if cls._default_key is None:
+                cls._default_key = asyncssh.generate_private_key("ssh-rsa", key_size=2048)
+                log.warning(
+                    "Using auto-generated SSH host key. This key is not persisted and "
+                    "will change on restart. Provide a custom key via ssh_key_file "
+                    "for non-local use."
+                )
+        return cls._default_key
+
+    # ------------------------------------------------------------------ lifecycle
+    def start(self) -> None:
+        """Register this host's listener on the shared loop (§1)."""
+        if self._simnos is None:
+            raise RuntimeError("AsyncSshServer requires a SimNOS reference (set by Host.start)")
+        self._shared_loop = self._simnos.ensure_shared_loop()
+        self._is_running.set()
+        self._acceptor = self._shared_loop.run_coro(self._create_server(), timeout=_CREATE_SERVER_TIMEOUT)
+        self._shared_loop.register(self)
+
+    async def _create_server(self) -> "asyncssh.SSHAcceptor":
+        return await asyncssh.create_server(
+            lambda: _SimnosSSHServer(self.username, self.password, self._allow_auth_none, self._authorized_keys),
+            self.address,
+            self.port,
+            server_host_keys=[self._host_key],
+            encoding=None,  # binary channel → byte-exact parity with paramiko
+            process_factory=self._handle_process,
+            allow_pty=True,
+            # Restart-friendly bind (parity with TCPServerBase SO_REUSEADDR/PORT)
+            # so stop→start does not hit EADDRINUSE.
+            reuse_address=True,
+            reuse_port=(sys.platform == "linux"),
+        )
+
+    def stop(self) -> None:
+        """Stop this host: drain its listener + sessions on the shared loop (§1a 5a).
+
+        Per-host scope only — the global loop teardown is ``SimNOS.stop()``'s job
+        (``teardown_if_idle``) once no async hosts remain. Idempotent via
+        ``drain_host`` (double stop is a no-op).
+        """
+        self._is_running.clear()
+        if self._shared_loop is not None:
+            self._shared_loop.drain_host(self)
+        self._acceptor = None
+
+    async def aclose(self) -> None:
+        """Close the listener + drain active sessions (called by the shared loop).
+
+        Runs on the loop thread. Stops accepting, signals in-flight dispatch to
+        close (``_is_running`` cleared in ``stop``), closes each active session so
+        its read returns EOF, then awaits the session tasks with a bounded budget
+        (cancelling any stragglers) so teardown leaves no orphaned tasks.
+        """
+        self._is_running.clear()
+        if self._acceptor is not None:
+            self._acceptor.close()
+        for process in list(self._processes):
+            with contextlib.suppress(Exception):
+                process.close()
+        tasks = [t for t in self._tasks if not t.done()]
+        if tasks:
+            _, pending = await asyncio.wait(tasks, timeout=SHUTDOWN_IO_TIMEOUT)
+            for t in pending:
+                t.cancel()
+        if self._acceptor is not None:
+            with contextlib.suppress(Exception):
+                await self._acceptor.wait_closed()
+
+    # ------------------------------------------------------------------ per-session
+    async def _handle_process(self, process: "asyncssh.SSHServerProcess") -> None:
+        """asyncssh process handler: one interactive shell session (§3a).
+
+        Parity with ``ParamikoSshServer.connection_function`` but async: optional
+        auth_none channel login, then the push session driving ``shell.dispatch``
+        via the bounded executor. asyncssh closes ``process`` when this returns.
+        """
+        task = asyncio.current_task()
+        self._tasks.add(task)
+        self._processes.add(process)
+        transport = AsyncSSHProcessTransport(process)
+        try:
+            skip_lf = False
+            if self._allow_auth_none:
+                try:
+                    authenticated, skip_lf = await async_interactive_login(
+                        transport,
+                        self.username,
+                        self.password,
+                        user_prompt=b"\r\nUser Name:",
+                        pass_prompt=b"\r\nPassword:",
+                    )
+                except (OSError, asyncssh.Error) as exc:
+                    log.debug("auth_none channel login error: %s", exc)
+                    return
+                if not authenticated:
+                    log.warning("auth_none channel login failed, closing session")
+                    return
+
+            client_shell = self.shell(
+                stdin=io.StringIO(),
+                stdout=io.StringIO(),
+                nos=self.nos,
+                nos_inventory_config=self.nos_inventory_config,
+                is_running=self._is_running,
+                resolved_platform=self._shared_platform,
+                render_config=self._render_config,
+                **self.shell_configuration,
+            )
+            shared_loop = self._shared_loop
+            assert shared_loop is not None  # noqa: S101 — set in start() before any session
+            loop = shared_loop.loop
+            executor = shared_loop.executor
+
+            async def dispatch(line: str):
+                # Off-load the blocking dispatch (custom handlers / hot-reload) to
+                # the bounded executor so the loop thread stays free (§2a).
+                return await loop.run_in_executor(executor, client_shell.dispatch, line)
+
+            await run_async_push_session(transport, client_shell, dispatch, initial_skip_lf=skip_lf)
+        except asyncio.CancelledError:
+            raise
+        except Exception:
+            # A session-level crash must not take down the loop; log + tear down
+            # this session only (§3a observability, #294-aligned).
+            log.exception("AsyncSshServer session crashed")
+        finally:
+            self._tasks.discard(task)
+            self._processes.discard(process)
+            with contextlib.suppress(Exception):
+                process.close()

--- a/simnos/plugins/servers/ssh_server_paramiko.py
+++ b/simnos/plugins/servers/ssh_server_paramiko.py
@@ -227,7 +227,12 @@ class ParamikoSshServer(TCPServerBase):
         watchdog_interval: float = 1,
         authorized_keys: str | None = None,
         render_config: "HostRenderConfig | None" = None,
+        simnos: object = None,
     ):
+        # `simnos` is the SimNOS back reference Host.start passes uniformly to
+        # every server plugin (#297 Stage 2); only AsyncSshServer uses it (for the
+        # shared loop). Accepted and ignored here (paramiko is removed in Stage 4).
+        del simnos
         super().__init__(address=address, port=port, timeout=timeout)
 
         self.nos: Nos = nos

--- a/simnos/plugins/servers/telnet_server.py
+++ b/simnos/plugins/servers/telnet_server.py
@@ -116,7 +116,12 @@ class TelnetServer(TCPServerBase):
         timeout: int = 1,
         watchdog_interval: float = 1,
         render_config: "HostRenderConfig | None" = None,
+        simnos: object = None,
     ):
+        # `simnos` is the SimNOS back reference Host.start passes uniformly to
+        # every server plugin (#297 Stage 2); only AsyncSshServer uses it (for the
+        # shared loop). Accepted and ignored here.
+        del simnos
         super().__init__(address=address, port=port, timeout=timeout)
 
         self.nos: Nos = nos

--- a/tests/compatibility/test_ansible_cisco_ios.py
+++ b/tests/compatibility/test_ansible_cisco_ios.py
@@ -3,6 +3,16 @@
 Uses ansible-playbook via subprocess against simnos. Requires
 `cisco.ios` + `ansible.netcommon` collections (installed in the
 compatibility CI job before running these tests).
+
+SSH backend (#297 Stage 2, テーマE / E2): the inventory pins
+``ansible_network_cli_ssh_type: libssh`` (ansible-pylibssh) rather than the
+paramiko default. The v3 SSH transport is asyncssh, and ansible's *paramiko*
+backend offers a local key first, fails, then resends a SERVICE_REQUEST on retry
+— which asyncssh rejects (``Unexpected service in service request``). That
+strictness is hardcoded in asyncssh with no public-API override (E1 is not
+achievable), so the supported ansible backend against simnos is libssh. The
+"green" definition for this compat job is therefore pylibssh-backend; the
+paramiko backend is a known incompatibility, not a regression to chase.
 """
 
 import os
@@ -25,6 +35,7 @@ def _write_inventory(path: Path, creds: dict) -> None:
               ansible_user: {creds["username"]}
               ansible_password: {creds["password"]}
               ansible_connection: ansible.netcommon.network_cli
+              ansible_network_cli_ssh_type: libssh
               ansible_network_os: cisco.ios.ios
               ansible_become: true
               ansible_become_method: enable

--- a/tests/core/test_shared_loop.py
+++ b/tests/core/test_shared_loop.py
@@ -1,0 +1,167 @@
+"""Unit tests for the SimNOS-owned shared asyncio loop (#297 Stage 2, §1 / §1a).
+
+These pin the loop's lifecycle contract in isolation from asyncssh: lazy start,
+state machine, listener registry / refcount, partial-vs-global teardown,
+restart-after-stop, and the no-thread-leak guarantee that ``SimNOS.stop`` relies
+on. The async-server integration (real listeners, byte parity, 100-host stress)
+lives in the SSH tests; here a fake ``AsyncListener`` stands in.
+"""
+
+import asyncio
+import threading
+
+import pytest
+
+from simnos.core.shared_loop import LoopState, SharedLoop
+
+
+class _FakeListener:
+    """Minimal AsyncListener: records that aclose ran, optionally blocks on it."""
+
+    def __init__(self, block: threading.Event | None = None) -> None:
+        self.closed = threading.Event()
+        self._block = block
+
+    async def aclose(self) -> None:
+        if self._block is not None:
+            # Cooperatively wait (on the loop) until released, to model a slow drain.
+            while not self._block.is_set():
+                await asyncio.sleep(0.01)
+        self.closed.set()
+
+
+@pytest.fixture
+def loop():
+    """A SharedLoop torn down after the test even if an assertion fails."""
+    sl = SharedLoop(max_workers=4)
+    try:
+        yield sl
+    finally:
+        # Best-effort: drain any registered listeners then tear down the loop.
+        for listener in list(sl._listeners.values()):
+            sl.drain_host(listener)
+        sl.teardown_if_idle()
+
+
+def test_starts_stopped_and_lazy(loop):
+    """A fresh SharedLoop is STOPPED and spawns no thread until ensure_running."""
+    assert loop.state is LoopState.STOPPED
+    assert loop.refcount == 0
+    base = threading.active_count()
+    loop.ensure_running()
+    assert loop.state is LoopState.RUNNING
+    assert threading.active_count() == base + 1  # one loop thread
+
+
+def test_ensure_running_is_idempotent(loop):
+    """Repeated ensure_running returns the same loop without extra threads."""
+    first = loop.ensure_running()
+    base = threading.active_count()
+    second = loop.ensure_running()
+    assert first is second
+    assert threading.active_count() == base
+
+
+def test_run_coro_executes_on_loop(loop):
+    """run_coro runs a coroutine on the loop thread and returns its result."""
+    loop.ensure_running()
+
+    async def _work():
+        return threading.current_thread().name, 21 * 2
+
+    name, value = loop.run_coro(_work(), timeout=5)
+    assert value == 42
+    assert name == "simnos-shared-loop"
+
+
+def test_register_increments_refcount(loop):
+    """Registering listeners tracks refcount; draining decrements it."""
+    loop.ensure_running()
+    a, b = _FakeListener(), _FakeListener()
+    loop.register(a)
+    loop.register(b)
+    assert loop.refcount == 2
+    loop.drain_host(a)
+    assert loop.refcount == 1
+    assert a.closed.is_set()  # aclose ran on the loop
+
+
+def test_partial_stop_keeps_loop_running(loop):
+    """Draining one of two listeners must NOT tear the loop down (partial stop)."""
+    loop.ensure_running()
+    a, b = _FakeListener(), _FakeListener()
+    loop.register(a)
+    loop.register(b)
+    loop.drain_host(a)
+    assert loop.teardown_if_idle() is False  # b still registered -> no teardown
+    assert loop.state is LoopState.RUNNING
+    assert loop.refcount == 1
+
+
+def test_global_teardown_when_idle(loop):
+    """teardown_if_idle tears down once the last listener is drained (§1a 5b)."""
+    base = threading.active_count()
+    loop.ensure_running()
+    a = _FakeListener()
+    loop.register(a)
+    loop.drain_host(a)
+    assert loop.teardown_if_idle() is True
+    assert loop.state is LoopState.STOPPED
+    assert loop.refcount == 0
+    assert threading.active_count() == base  # loop thread joined, no leak
+
+
+def test_double_stop_is_idempotent(loop):
+    """A second drain of an already-drained listener is a no-op (double stop)."""
+    loop.ensure_running()
+    a = _FakeListener()
+    loop.register(a)
+    loop.drain_host(a)
+    loop.drain_host(a)  # must not raise
+    assert loop.refcount == 0
+    assert loop.teardown_if_idle() is True
+    assert loop.teardown_if_idle() is False  # already STOPPED
+
+
+def test_restart_after_stop(loop):
+    """ensure_running recreates the loop after a full stop (restart)."""
+    loop.ensure_running()
+    first = loop.loop
+    a = _FakeListener()
+    loop.register(a)
+    loop.drain_host(a)
+    loop.teardown_if_idle()
+    assert loop.state is LoopState.STOPPED
+
+    loop.ensure_running()  # restart
+    assert loop.state is LoopState.RUNNING
+    assert loop.loop is not first  # a fresh loop object
+    assert loop.run_coro(_one(), timeout=5) == 1
+
+
+async def _one() -> int:
+    return 1
+
+
+def test_failed_state_refuses_restart(loop):
+    """A FAILED loop refuses ensure_running (no silent restart, §1a)."""
+    loop.ensure_running()
+    # Force the FAILED state directly (a real un-joinable loop thread is hard to
+    # produce deterministically); the contract is what we pin.
+    with loop._lock:
+        loop._state = LoopState.FAILED
+    with pytest.raises(RuntimeError, match="FAILED"):
+        loop.ensure_running()
+
+
+def test_invalid_max_workers_rejected():
+    """max_workers < 1 is a loud error."""
+    with pytest.raises(ValueError, match="max_workers"):
+        SharedLoop(max_workers=0)
+
+
+def test_max_workers_env_override(monkeypatch):
+    """SIMNOS_DISPATCH_WORKERS overrides the default executor size."""
+    monkeypatch.setenv("SIMNOS_DISPATCH_WORKERS", "3")
+    sl = SharedLoop()
+    assert sl._max_workers == 3

--- a/tests/core/test_shared_loop.py
+++ b/tests/core/test_shared_loop.py
@@ -148,6 +148,23 @@ def test_failed_state_refuses_restart(loop):
         loop.ensure_running()
 
 
+def test_failed_state_recovers_via_teardown(loop):
+    """A FAILED loop is recoverable: teardown_if_idle retries the join (gemini 1st#2).
+
+    ensure_running's FAILED message tells the caller to retry stop(); that retry
+    (SimNOS.stop -> teardown_if_idle) must actually re-run the teardown. The refs
+    are kept on FAILED, so when the (here actually joinable) loop thread exits the
+    retry reaches STOPPED and the loop is restartable again.
+    """
+    loop.ensure_running()
+    with loop._lock:
+        loop._state = LoopState.FAILED  # simulate a prior teardown that could not join
+    assert loop.teardown_if_idle() is True
+    assert loop.state is LoopState.STOPPED
+    loop.ensure_running()
+    assert loop.state is LoopState.RUNNING
+
+
 def test_invalid_max_workers_rejected():
     """max_workers < 1 is a loud error."""
     with pytest.raises(ValueError, match="max_workers"):

--- a/tests/core/test_shared_loop.py
+++ b/tests/core/test_shared_loop.py
@@ -7,7 +7,6 @@ on. The async-server integration (real listeners, byte parity, 100-host stress)
 lives in the SSH tests; here a fake ``AsyncListener`` stands in.
 """
 
-import asyncio
 import threading
 
 import pytest
@@ -16,17 +15,12 @@ from simnos.core.shared_loop import LoopState, SharedLoop
 
 
 class _FakeListener:
-    """Minimal AsyncListener: records that aclose ran, optionally blocks on it."""
+    """Minimal AsyncListener: records that aclose ran on the loop."""
 
-    def __init__(self, block: threading.Event | None = None) -> None:
+    def __init__(self) -> None:
         self.closed = threading.Event()
-        self._block = block
 
     async def aclose(self) -> None:
-        if self._block is not None:
-            # Cooperatively wait (on the loop) until released, to model a slow drain.
-            while not self._block.is_set():
-                await asyncio.sleep(0.01)
         self.closed.set()
 
 

--- a/tests/core/test_simnos.py
+++ b/tests/core/test_simnos.py
@@ -105,7 +105,7 @@ class TestSimNOS:
             assert host.username == expected["username"]
             assert host.password == expected["password"]
             assert host.port == expected["port"]
-            assert host.server_inventory["plugin"] == "ParamikoSshServer"
+            assert host.server_inventory["plugin"] == "AsyncSshServer"
             if _is_in_docker() and "WSL2" in platform.release():
                 assert host.server_inventory["configuration"]["address"] == "0.0.0.0"
             else:

--- a/tests/plugins/test_async_session.py
+++ b/tests/plugins/test_async_session.py
@@ -1,0 +1,167 @@
+"""Unit tests for the async push session driver (#297 Stage 2, §3a).
+
+Pin the wire contract of ``run_async_push_session`` + ``async_interactive_login``
+in isolation (fake transport + fake shell), so a regression in the byte state
+machine is caught here without spinning a real asyncssh server. The byte-exact
+parity with the paramiko push path is pinned separately by the byte-parity
+goldens; these pin the driver's branch behaviour (echo / NUL / close / EOF /
+malformed UTF-8 / login skip_lf).
+"""
+
+import asyncio
+
+from simnos.plugins.servers.async_session import (
+    async_interactive_login,
+    run_async_push_session,
+)
+from simnos.plugins.shell.cmd_shell import DispatchResult
+
+
+class _FakeShell:
+    """PushShell stub: ``dispatch`` echoes the line, ``exit`` closes."""
+
+    intro = "Custom SSH Shell"
+    prompt = "device>"
+    newline = "\r\n"
+
+    def dispatch(self, line: str) -> DispatchResult:
+        if line == "exit":
+            return DispatchResult(body=None, prompt=self.prompt, close=True, mode="user")
+        if line == "":
+            return DispatchResult(body=None, prompt=self.prompt, close=False, mode="user")
+        return DispatchResult(body=f"out:{line}", prompt=self.prompt, close=False, mode="user")
+
+
+class _FakeTransport:
+    """AsyncPushTransport over a scripted byte stream; records writes.
+
+    ``recv(n)`` returns up to *n* bytes (respecting ``n`` like the real
+    ``AsyncSSHProcessTransport``), so the channel-login path that reads one byte
+    at a time behaves faithfully. The chunk list is flattened — the session
+    driver iterates byte-by-byte, so chunk boundaries do not affect its output.
+    """
+
+    io_errors = (OSError,)
+    nul_resets_skip_lf = False
+    name = "ssh"
+
+    def __init__(self, chunks: list[bytes], *, fail_on: bytes | None = None) -> None:
+        self._buf = b"".join(chunks)
+        self.out = bytearray()
+        self._fail_on = fail_on
+
+    async def recv(self, n: int) -> bytes:
+        if not self._buf:
+            return b""  # EOF
+        chunk, self._buf = self._buf[:n], self._buf[n:]
+        return chunk
+
+    def send(self, data: bytes) -> None:
+        if self._fail_on is not None and self._fail_on in data:
+            raise OSError("simulated write failure")
+        self.out += data
+
+    async def drain(self) -> None:
+        pass
+
+
+def _drive(transport: _FakeTransport, shell: _FakeShell, **kwargs) -> bytes:
+    async def _dispatch(line: str):
+        return shell.dispatch(line)
+
+    asyncio.run(run_async_push_session(transport, shell, _dispatch, **kwargs))
+    return bytes(transport.out)
+
+
+def test_intro_then_echo_and_response():
+    """Intro + prompt, per-char echo, then newline echo + body + next prompt."""
+    shell = _FakeShell()
+    out = _drive(_FakeTransport([b"show vlan\r"]), shell)
+    assert out == b"Custom SSH Shell\r\ndevice>show vlan\r\nout:show vlan\r\ndevice>"
+
+
+def test_empty_line_emits_newline_and_prompt_only():
+    """An empty line dispatches with no body: just the newline echo + prompt."""
+    out = _drive(_FakeTransport([b"\r"]), _FakeShell())
+    assert out == b"Custom SSH Shell\r\ndevice>\r\ndevice>"
+
+
+def test_nul_byte_is_dropped_midline():
+    """A NUL mid-line is dropped (no echo, not buffered); the command still runs."""
+    out = _drive(_FakeTransport([b"sh\x00ow vlan\r"]), _FakeShell())
+    # NUL absent from echo + the dispatched line is "show vlan".
+    assert b"\x00" not in out
+    assert b"out:show vlan" in out
+
+
+def test_crlf_pair_dispatches_once():
+    """CR LF is one terminator: a single dispatch, the LF consumed (skip_lf)."""
+    out = _drive(_FakeTransport([b"show vlan\r\n"]), _FakeShell())
+    assert out.count(b"out:show vlan") == 1
+
+
+def test_close_writes_only_newline_then_returns():
+    """A close result emits just the newline echo (no body/prompt) and stops."""
+    out = _drive(_FakeTransport([b"exit\r", b"ignored\r"]), _FakeShell())
+    # "exit" echoed + newline, then close — no body, no trailing prompt, and the
+    # second chunk is never read.
+    assert out.endswith(b"exit\r\n")
+    assert b"ignored" not in out
+
+
+def test_eof_drops_partial_line():
+    """An unterminated line at EOF is echoed but not dispatched (no spurious out)."""
+    out = _drive(_FakeTransport([b"show ver"]), _FakeShell())
+    assert out == b"Custom SSH Shell\r\ndevice>show ver"  # echo only, no response
+
+
+def test_malformed_utf8_does_not_crash():
+    """A malformed UTF-8 line is decoded with replacement, not a crash (gemini#2)."""
+    captured: list[str] = []
+    shell = _FakeShell()
+
+    async def _dispatch(line: str):
+        captured.append(line)
+        return shell.dispatch(line)
+
+    transport = _FakeTransport([b"a\xffb\r"])
+    asyncio.run(run_async_push_session(transport, shell, _dispatch))
+    assert captured == ["a�b"]  # U+FFFD replacement, session survived
+
+
+def test_write_failure_ends_session():
+    """An io_errors raise on a response write tears the session down cleanly."""
+    transport = _FakeTransport([b"show vlan\r"], fail_on=b"out:show vlan")
+    # Intro write succeeds, the response write raises -> driver returns (no crash).
+    out = _drive(transport, _FakeShell())
+    assert out.startswith(b"Custom SSH Shell\r\ndevice>show vlan")
+
+
+def test_async_interactive_login_success_and_skip_lf():
+    """Channel login authenticates and reports skip_lf after the password CR."""
+
+    async def _run():
+        transport = _FakeTransport([b"admin\r", b"secret\r"])
+        ok, skip_lf = await async_interactive_login(
+            transport, "admin", "secret", user_prompt=b"User: ", pass_prompt=b"Pass: "
+        )
+        return ok, skip_lf, bytes(transport.out)
+
+    ok, skip_lf, out = asyncio.run(_run())
+    assert ok is True
+    assert skip_lf is True  # password line ended on CR
+    # Username echoed, password NOT echoed, prompts sent.
+    assert b"User: admin\r\n" in out
+    assert b"Pass: " in out
+    assert b"secret" not in out
+
+
+def test_async_interactive_login_wrong_password_fails():
+    """A wrong password fails authentication."""
+
+    async def _run():
+        transport = _FakeTransport([b"admin\r", b"wrong\r"])
+        return await async_interactive_login(transport, "admin", "secret", user_prompt=b"User: ", pass_prompt=b"Pass: ")
+
+    ok, _ = asyncio.run(_run())
+    assert ok is False

--- a/tests/plugins/test_ssh_asyncssh.py
+++ b/tests/plugins/test_ssh_asyncssh.py
@@ -13,9 +13,10 @@ These drive raw paramiko channels (byte-exact, lighter than netmiko) against rea
 ``AsyncSshServer`` listeners on the SimNOS-owned shared loop.
 """
 
+import asyncio
 import concurrent.futures
 from concurrent.futures import ThreadPoolExecutor
-from contextlib import contextmanager
+from contextlib import contextmanager, suppress
 import os
 import socket
 import threading
@@ -207,6 +208,41 @@ def test_start_failure_converges_with_no_leak(monkeypatch):
     while threading.active_count() > baseline and time.monotonic() < deadline:
         time.sleep(0.05)
     assert threading.active_count() <= baseline
+
+
+def test_start_timeout_closes_late_acceptor(monkeypatch):
+    """A create that completes *after* start() timed out has its listener closed
+    via the done-callback — the real timeout→late-acceptor path (codex 3rd#2).
+
+    create_server is slowed past a shortened start timeout and made to complete
+    despite the cancel (swallowing CancelledError), modelling an asyncssh create
+    that wins the cancel race. The ``_discard_late_acceptor`` done-callback must
+    then close the orphaned acceptor.
+    """
+    closed = threading.Event()
+
+    class _FakeAcceptor:
+        def close(self):
+            closed.set()
+
+    async def _slow_create(*args, **kwargs):
+        # Swallow the cancel and complete anyway -> a "late" acceptor produced
+        # after start() gave up (models a create that wins the cancel race).
+        with suppress(asyncio.CancelledError):
+            await asyncio.sleep(1.0)
+        return _FakeAcceptor()
+
+    monkeypatch.setattr("simnos.plugins.servers.ssh_server_asyncssh._CREATE_SERVER_TIMEOUT", 0.3)
+    monkeypatch.setattr(asyncssh, "create_server", _slow_create)
+
+    (port,) = _free_ports(1)
+    net = SimNOS(inventory=_multi_host_inventory([port]))
+    try:
+        with pytest.raises(TimeoutError):
+            net.start()
+        assert closed.wait(timeout=5), "late acceptor was not closed by the done-callback"
+    finally:
+        net.stop()
 
 
 def test_discard_late_acceptor_closes_completed_future():

--- a/tests/plugins/test_ssh_asyncssh.py
+++ b/tests/plugins/test_ssh_asyncssh.py
@@ -13,6 +13,7 @@ These drive raw paramiko channels (byte-exact, lighter than netmiko) against rea
 ``AsyncSshServer`` listeners on the SimNOS-owned shared loop.
 """
 
+import concurrent.futures
 from concurrent.futures import ThreadPoolExecutor
 from contextlib import contextmanager
 import os
@@ -20,11 +21,13 @@ import socket
 import threading
 import time
 
+import asyncssh
 import paramiko
 import pytest
 
 from simnos import SimNOS
 from simnos.core.shared_loop import LoopState
+from simnos.plugins.servers.ssh_server_asyncssh import AsyncSshServer
 from simnos.plugins.shell.cmd_shell import CMDShell
 from tests.utils import TEST_PASSWORD, TEST_USERNAME
 
@@ -176,6 +179,55 @@ def test_double_stop_is_idempotent():
         net.stop()
         net.stop()  # second stop is a no-op
         assert net._shared_loop.state is LoopState.STOPPED
+
+
+def test_start_failure_converges_with_no_leak(monkeypatch):
+    """A failed create_server leaves the loop cleanable + no thread leak (codex 2nd#6).
+
+    create_server raises (e.g. bind failure): start() must re-raise, Host.start
+    rolls back, and the caller's stop() tears the now-idle loop down to STOPPED
+    with no orphaned thread.
+    """
+
+    async def _failing_create(*args, **kwargs):
+        raise OSError("simulated bind failure")
+
+    monkeypatch.setattr(asyncssh, "create_server", _failing_create)
+
+    (port,) = _free_ports(1)
+    baseline = threading.active_count()
+    net = SimNOS(inventory=_multi_host_inventory([port]))
+    try:
+        with pytest.raises(OSError, match="simulated bind failure"):
+            net.start()
+    finally:
+        net.stop()
+    assert net._shared_loop.state is LoopState.STOPPED
+    deadline = time.monotonic() + _THREAD_CONVERGE_DEADLINE
+    while threading.active_count() > baseline and time.monotonic() < deadline:
+        time.sleep(0.05)
+    assert threading.active_count() <= baseline
+
+
+def test_discard_late_acceptor_closes_completed_future():
+    """The late-acceptor done-callback closes a listener produced after start gave up (codex 2nd#1)."""
+    closed = threading.Event()
+
+    class _FakeAcceptor:
+        def close(self):
+            closed.set()
+
+    future: concurrent.futures.Future = concurrent.futures.Future()
+    future.set_result(_FakeAcceptor())
+    AsyncSshServer._discard_late_acceptor(future)
+    assert closed.is_set()
+
+
+def test_discard_late_acceptor_ignores_cancelled_future():
+    """A cancelled create future has no acceptor to reclaim — callback is a no-op."""
+    future: concurrent.futures.Future = concurrent.futures.Future()
+    future.cancel()
+    AsyncSshServer._discard_late_acceptor(future)  # must not raise
 
 
 def test_stop_converges_with_inflight_slow_dispatch(monkeypatch):

--- a/tests/plugins/test_ssh_asyncssh.py
+++ b/tests/plugins/test_ssh_asyncssh.py
@@ -1,0 +1,283 @@
+"""Integration tests for the asyncssh SSH transport + shared loop (#297 Stage 2).
+
+Covers the Stage 2 acceptance gates the byte-parity goldens don't:
+
+- **100-host concurrent, 0 failures** (§5) — the headline finding from the spike
+  (the W2-without-W3 hybrid dropped sessions under 100-host load; W3 push dispatch
+  on the shared loop must not).
+- **lifecycle** (§5) — partial stop keeps other hosts serving, restart, double
+  stop, and mixed SSH(async) + Telnet(paramiko-era) teardown — plus the
+  no-thread-leak / loop-converges-to-STOPPED guarantee (executor convergence).
+
+These drive raw paramiko channels (byte-exact, lighter than netmiko) against real
+``AsyncSshServer`` listeners on the SimNOS-owned shared loop.
+"""
+
+from concurrent.futures import ThreadPoolExecutor
+from contextlib import contextmanager
+import os
+import socket
+import threading
+import time
+
+import paramiko
+import pytest
+
+from simnos import SimNOS
+from simnos.core.shared_loop import LoopState
+from tests.utils import TEST_PASSWORD, TEST_USERNAME
+
+_HOST = "127.0.0.1"
+
+# Stage 2 AC is "100 hosts, 0 failures". Tunable down for a constrained CI box via
+# the env var; the default exercises the real acceptance number.
+_STRESS_HOSTS = int(os.environ.get("SIMNOS_ASYNC_STRESS_HOSTS", "100"))
+
+
+def _free_ports(n: int) -> list[int]:
+    """Allocate *n* distinct free TCP ports (bound simultaneously, then released)."""
+    socks = []
+    try:
+        for _ in range(n):
+            s = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+            s.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, True)
+            s.bind(("", 0))
+            socks.append(s)
+        return [s.getsockname()[1] for s in socks]
+    finally:
+        for s in socks:
+            s.close()
+
+
+def _multi_host_inventory(ports: list[int], device_type: str = "cisco_ios") -> dict:
+    """Build an N-host single-platform inventory keyed by port."""
+    hosts = {
+        f"h{i}": {
+            "username": TEST_USERNAME,
+            "password": TEST_PASSWORD,
+            "port": port,
+            "device_type": device_type,
+        }
+        for i, port in enumerate(ports)
+    }
+    return {"hosts": hosts}
+
+
+def _run_one_command(port: int, command: bytes, expect: bytes) -> bool:
+    """Connect, auth, run *command* over a raw paramiko channel; True if *expect* seen."""
+    sock = socket.create_connection((_HOST, port), timeout=10)
+    transport = paramiko.Transport(sock)
+    try:
+        transport.start_client(timeout=10)
+        transport.auth_password(TEST_USERNAME, TEST_PASSWORD)
+        channel = transport.open_session(timeout=10)
+        channel.get_pty()
+        channel.invoke_shell()
+        channel.sendall(command)
+        channel.settimeout(10)
+        buf = b""
+        deadline = time.monotonic() + 10
+        while expect not in buf and time.monotonic() < deadline:
+            try:
+                chunk = channel.recv(4096)
+            except TimeoutError:
+                break
+            if not chunk:
+                break
+            buf += chunk
+        channel.close()
+        return expect in buf
+    finally:
+        transport.close()
+
+
+@contextmanager
+def _running(inventory: dict):
+    net = SimNOS(inventory=inventory)
+    net.start()
+    try:
+        yield net
+    finally:
+        net.stop()
+
+
+@pytest.mark.timeout(180)
+def test_async_ssh_100_host_concurrent_no_failures():
+    """100 hosts, one concurrent client each, every session must succeed (§5).
+
+    This is the spike's failure scenario (W2-without-W3 dropped sessions under
+    100-host load). With W3 push dispatch on the shared loop + bounded executor,
+    failures must be 0. After stop the loop converges to STOPPED with no leaked
+    thread (executor convergence — the dispatch worker pool is released).
+    """
+    n = _STRESS_HOSTS
+    ports = _free_ports(n)
+    inventory = _multi_host_inventory(ports)
+    baseline = threading.active_count()
+    with _running(inventory) as net:
+        with ThreadPoolExecutor(max_workers=n) as pool:
+            results = list(pool.map(lambda p: _run_one_command(p, b"show vlan\r", b"VLAN Name"), ports))
+        assert all(results), f"{results.count(False)}/{n} concurrent sessions failed"
+        assert net._shared_loop.refcount == n
+
+    assert net._shared_loop.state is LoopState.STOPPED
+    # Executor convergence: the loop thread + bounded dispatch pool are released.
+    deadline = time.monotonic() + 5
+    while threading.active_count() > baseline and time.monotonic() < deadline:
+        time.sleep(0.05)
+    assert threading.active_count() <= baseline, f"threads did not converge: {[t.name for t in threading.enumerate()]}"
+
+
+def test_partial_stop_keeps_other_host_serving():
+    """Stopping one async host leaves the loop up and the other host reachable (§1)."""
+    ports = _free_ports(2)
+    inventory = _multi_host_inventory(ports)
+    with _running(inventory) as net:
+        # Stop only h0; the shared loop must keep running for h1.
+        net.stop(hosts=["h0"])
+        assert net._shared_loop.state is LoopState.RUNNING
+        assert net._shared_loop.refcount == 1
+        # h1 still serves.
+        assert _run_one_command(ports[1], b"show vlan\r", b"VLAN Name")
+        # h0's port is free again (listener released) — a fresh connect is refused.
+        with pytest.raises((ConnectionRefusedError, OSError)):
+            socket.create_connection((_HOST, ports[0]), timeout=2).close()
+
+
+def test_restart_after_full_stop():
+    """A host can be stopped and started again on the same SimNOS (restart, §1)."""
+    ports = _free_ports(1)
+    inventory = _multi_host_inventory(ports)
+    net = SimNOS(inventory=inventory)
+    try:
+        net.start()
+        assert _run_one_command(ports[0], b"show vlan\r", b"VLAN Name")
+        net.stop()
+        assert net._shared_loop.state is LoopState.STOPPED
+        net.start()  # restart: loop lazily recreated
+        assert net._shared_loop.state is LoopState.RUNNING
+        assert _run_one_command(ports[0], b"show vlan\r", b"VLAN Name")
+    finally:
+        net.stop()
+
+
+def test_double_stop_is_idempotent():
+    """Calling stop twice must not raise and leaves the loop STOPPED (§1a)."""
+    ports = _free_ports(1)
+    with _running(_multi_host_inventory(ports)) as net:
+        net.stop()
+        net.stop()  # second stop is a no-op
+        assert net._shared_loop.state is LoopState.STOPPED
+
+
+def _write_authorized_keys(tmp_path, key: paramiko.PKey) -> str:
+    """Write *key*'s public half to an OpenSSH authorized_keys file; return its path."""
+    path = tmp_path / "authorized_keys"
+    path.write_text(f"{key.get_name()} {key.get_base64()}\n")
+    return str(path)
+
+
+def _host_with_authorized_keys(port: int, authorized_keys: str) -> dict:
+    return {
+        "hosts": {
+            "device": {
+                "username": TEST_USERNAME,
+                "password": TEST_PASSWORD,
+                "port": port,
+                "device_type": "cisco_ios",
+                "server": {
+                    "plugin": "AsyncSshServer",
+                    "configuration": {"address": "127.0.0.1", "authorized_keys": authorized_keys},
+                },
+            }
+        }
+    }
+
+
+def test_publickey_auth_accepts_authorized_key(tmp_path):
+    """An authorized public key authenticates (asyncssh validate_public_key)."""
+    (port,) = _free_ports(1)
+    key = paramiko.RSAKey.generate(2048)
+    inventory = _host_with_authorized_keys(port, _write_authorized_keys(tmp_path, key))
+    with _running(inventory):
+        sock = socket.create_connection((_HOST, port), timeout=10)
+        transport = paramiko.Transport(sock)
+        try:
+            transport.start_client(timeout=10)
+            transport.auth_publickey(TEST_USERNAME, key)  # raises on failure
+            assert transport.is_authenticated()
+        finally:
+            transport.close()
+
+
+def _advertised_auth_methods(port: int) -> list[str]:
+    """Return the auth methods the server advertises (via paramiko's auth_none probe)."""
+    sock = socket.create_connection((_HOST, port), timeout=10)
+    transport = paramiko.Transport(sock)
+    try:
+        transport.start_client(timeout=10)
+        try:
+            transport.auth_none(TEST_USERNAME)
+            return []  # none accepted (no auth required) — not our cisco_ios case
+        except paramiko.BadAuthenticationType as e:
+            return list(e.allowed_types)
+    finally:
+        transport.close()
+
+
+def test_publickey_advertised_only_with_authorized_keys(tmp_path):
+    """publickey is advertised iff authorized_keys is set (paramiko parity, E2).
+
+    Advertising it on a no-keys host would invite a key-offering paramiko client
+    into the auth-retry SERVICE_REQUEST-resend disconnect; password-first clients
+    are unaffected either way.
+    """
+    (no_keys_port, keys_port) = _free_ports(2)
+    key = paramiko.RSAKey.generate(2048)
+    authed = _host_with_authorized_keys(keys_port, _write_authorized_keys(tmp_path, key))
+
+    with _running(_multi_host_inventory([no_keys_port])):
+        methods = _advertised_auth_methods(no_keys_port)
+        assert "password" in methods
+        assert "publickey" not in methods  # no keys -> not advertised
+
+    with _running(authed):
+        methods = _advertised_auth_methods(keys_port)
+        assert "publickey" in methods  # keys configured -> advertised
+
+
+def test_mixed_ssh_async_and_telnet():
+    """Async SSH and paramiko-era Telnet coexist and both tear down cleanly (§1).
+
+    During the Stage 2-3 migration an inventory can mix AsyncSshServer (shared
+    loop, managed_threads == []) and TelnetServer (its own thread). Both must
+    stop and the process must return to its thread baseline.
+    """
+    ssh_port, telnet_port = _free_ports(2)
+    inventory = {
+        "hosts": {
+            "ssh": {
+                "username": TEST_USERNAME,
+                "password": TEST_PASSWORD,
+                "port": ssh_port,
+                "device_type": "cisco_ios",
+            },
+            "telnet": {
+                "username": TEST_USERNAME,
+                "password": TEST_PASSWORD,
+                "port": telnet_port,
+                "device_type": "cisco_ios",
+                "server": {"plugin": "TelnetServer", "configuration": {"address": "127.0.0.1"}},
+            },
+        }
+    }
+    baseline = threading.active_count()
+    with _running(inventory) as net:
+        assert _run_one_command(ssh_port, b"show vlan\r", b"VLAN Name")
+        assert net._shared_loop.refcount == 1
+
+    assert net._shared_loop.state is LoopState.STOPPED
+    deadline = time.monotonic() + 5
+    while threading.active_count() > baseline and time.monotonic() < deadline:
+        time.sleep(0.05)
+    assert threading.active_count() <= baseline

--- a/tests/plugins/test_ssh_asyncssh.py
+++ b/tests/plugins/test_ssh_asyncssh.py
@@ -25,6 +25,7 @@ import pytest
 
 from simnos import SimNOS
 from simnos.core.shared_loop import LoopState
+from simnos.plugins.shell.cmd_shell import CMDShell
 from tests.utils import TEST_PASSWORD, TEST_USERNAME
 
 _HOST = "127.0.0.1"
@@ -186,8 +187,6 @@ def test_stop_converges_with_inflight_slow_dispatch(monkeypatch):
     isolation — the result never reaches the wire). The orphaned worker exits on its
     own afterwards. Here we pin the convergence + STOPPED state under that load.
     """
-    from simnos.plugins.shell.cmd_shell import CMDShell
-
     original_dispatch = CMDShell.dispatch
 
     def slow_dispatch(self, line):

--- a/tests/plugins/test_ssh_asyncssh.py
+++ b/tests/plugins/test_ssh_asyncssh.py
@@ -33,6 +33,13 @@ _HOST = "127.0.0.1"
 # the env var; the default exercises the real acceptance number.
 _STRESS_HOSTS = int(os.environ.get("SIMNOS_ASYNC_STRESS_HOSTS", "100"))
 
+# Budget for the dispatch worker pool to drain after stop. The bounded executor is
+# shut down with wait=False (does not join the daemon `simnos-dispatch` workers, by
+# design — a non-cooperative handler must not block stop), so the workers exit on
+# their own shortly after; a generous deadline keeps the convergence assertion from
+# flaking on a loaded CI box (claude 1st#2).
+_THREAD_CONVERGE_DEADLINE = 10
+
 
 def _free_ports(n: int) -> list[int]:
     """Allocate *n* distinct free TCP ports (bound simultaneously, then released)."""
@@ -122,7 +129,7 @@ def test_async_ssh_100_host_concurrent_no_failures():
 
     assert net._shared_loop.state is LoopState.STOPPED
     # Executor convergence: the loop thread + bounded dispatch pool are released.
-    deadline = time.monotonic() + 5
+    deadline = time.monotonic() + _THREAD_CONVERGE_DEADLINE
     while threading.active_count() > baseline and time.monotonic() < deadline:
         time.sleep(0.05)
     assert threading.active_count() <= baseline, f"threads did not converge: {[t.name for t in threading.enumerate()]}"
@@ -168,6 +175,51 @@ def test_double_stop_is_idempotent():
         net.stop()
         net.stop()  # second stop is a no-op
         assert net._shared_loop.state is LoopState.STOPPED
+
+
+def test_stop_converges_with_inflight_slow_dispatch(monkeypatch):
+    """stop must converge even with a non-cooperative (slow) in-flight dispatch (codex 1st#3).
+
+    A dispatch that blocks the executor thread (can't be cancelled) must not hang
+    stop: aclose closes the session and cancels the awaiting task within the bounded
+    budget, and the late executor result lands on a closed transport (generation
+    isolation — the result never reaches the wire). The orphaned worker exits on its
+    own afterwards. Here we pin the convergence + STOPPED state under that load.
+    """
+    from simnos.plugins.shell.cmd_shell import CMDShell
+
+    original_dispatch = CMDShell.dispatch
+
+    def slow_dispatch(self, line):
+        if line == "slowcmd":
+            time.sleep(3)  # non-cooperative: blocks the dispatch worker thread
+        return original_dispatch(self, line)
+
+    monkeypatch.setattr(CMDShell, "dispatch", slow_dispatch)
+
+    (port,) = _free_ports(1)
+    with _running(_multi_host_inventory([port])) as net:
+        sock = socket.create_connection((_HOST, port), timeout=10)
+        transport = paramiko.Transport(sock)
+        try:
+            transport.start_client(timeout=10)
+            transport.auth_password(TEST_USERNAME, TEST_PASSWORD)
+            channel = transport.open_session(timeout=10)
+            channel.get_pty()
+            channel.invoke_shell()
+            time.sleep(0.3)  # let the intro flush
+            channel.sendall(b"slowcmd\r")  # dispatch now sleeping in the executor
+            time.sleep(0.5)
+            started = time.monotonic()
+            net.stop()  # stop while the dispatch is in-flight
+            elapsed = time.monotonic() - started
+        finally:
+            transport.close()
+
+    assert net._shared_loop.state is LoopState.STOPPED
+    # Must converge well under the drain budget (10s): a regression that blocks on
+    # the non-cooperative dispatch instead of detaching it stalls to ~10s.
+    assert elapsed < 8, f"stop did not converge with an in-flight dispatch ({elapsed:.1f}s)"
 
 
 def _write_authorized_keys(tmp_path, key: paramiko.PKey) -> str:
@@ -277,7 +329,7 @@ def test_mixed_ssh_async_and_telnet():
         assert net._shared_loop.refcount == 1
 
     assert net._shared_loop.state is LoopState.STOPPED
-    deadline = time.monotonic() + 5
+    deadline = time.monotonic() + _THREAD_CONVERGE_DEADLINE
     while threading.active_count() > baseline and time.monotonic() < deadline:
         time.sleep(0.05)
     assert threading.active_count() <= baseline

--- a/uv.lock
+++ b/uv.lock
@@ -28,6 +28,39 @@ wheels = [
 ]
 
 [[package]]
+name = "ansible-pylibssh"
+version = "1.4.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/56/a9/1437294eb6e093c538262688d97979cc92407c033da92997d6e09348a248/ansible_pylibssh-1.4.0.tar.gz", hash = "sha256:a48b5e6db21062bc6258548e6a3e4363043d40128f0e6b796774a59b6a7dbe82", size = 167863, upload-time = "2026-03-16T11:32:02.192Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ea/61/d22a9dd1a3bfae24ed79cb0a2a3aa8c9fd4d1ff0ea38888b5e42b0e138d1/ansible_pylibssh-1.4.0-cp313-cp313-macosx_15_0_x86_64.whl", hash = "sha256:77a9fd00bb252096f4af72acedc0c0abe1a3d0657707d9930b8aa1c97bd7d69a", size = 2571603, upload-time = "2026-03-16T11:31:30.22Z" },
+    { url = "https://files.pythonhosted.org/packages/39/10/669d86b634c4e4b4d0378288441e800e1e8c99704326b37461502718829a/ansible_pylibssh-1.4.0-cp313-cp313-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:5af9bec14acd3939acac14668b5acbd91e87f870379aa6f1eec5690045346306", size = 2439821, upload-time = "2026-03-16T11:31:31.852Z" },
+    { url = "https://files.pythonhosted.org/packages/17/92/9d1765c7c216aecaf58de56c5bc2fd92b427519274c66ff50eb04f7fcaee/ansible_pylibssh-1.4.0-cp313-cp313-manylinux_2_27_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:82f5c4199b94b1e2f6f2ae01809c88794ce01f221338b199d30d4f6178fb5bfd", size = 2794721, upload-time = "2026-03-16T11:31:33.563Z" },
+    { url = "https://files.pythonhosted.org/packages/24/52/54ac4301fec8b5dc405a11cc78fe2091c15032848b9d8b87d6ffa0dc8559/ansible_pylibssh-1.4.0-cp313-cp313-manylinux_2_27_s390x.manylinux_2_28_s390x.whl", hash = "sha256:60873764078fe7ebb6acedb1001ac7614142221f50f74c8463881f163661b61c", size = 2273877, upload-time = "2026-03-16T11:31:35.141Z" },
+    { url = "https://files.pythonhosted.org/packages/fd/d2/702d776f1682cce55aacd9a14784f1fffc73e6c17a7530e22e5dd6312b79/ansible_pylibssh-1.4.0-cp313-cp313-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:736fb126b981085a45113cc5b4d864b533b9065c1248e3e87b1c19d9344b71ac", size = 2661217, upload-time = "2026-03-16T11:31:37.095Z" },
+    { url = "https://files.pythonhosted.org/packages/de/b1/256bb116e1d112cedea2d962dfcc4b322ef8e2e6438bc3cf5dc37bf539af/ansible_pylibssh-1.4.0-cp313-cp313-manylinux_2_28_armv7l.manylinux_2_31_armv7l.whl", hash = "sha256:f652e307691a2c5212eda1a19339834bf9adafbae7fbd61add8ebcb65c9d54c7", size = 2074576, upload-time = "2026-03-16T11:31:38.802Z" },
+    { url = "https://files.pythonhosted.org/packages/98/5b/2732f4e412d728fbc1dc6ee994cae75b54f77bb59fe1abed1f874fd32024/ansible_pylibssh-1.4.0-cp314-cp314-macosx_15_0_x86_64.whl", hash = "sha256:50f71b64af4a2aa6accb34436d38d8428e9d2fe065006a634d354e320611baf2", size = 2572430, upload-time = "2026-03-16T11:31:41.012Z" },
+    { url = "https://files.pythonhosted.org/packages/c5/36/157b0d556896211e2141f880969bfeb212037cff6318f69f7212d8f47c88/ansible_pylibssh-1.4.0-cp314-cp314-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:cdbdc5025475677e5fd0540dfad6678d4b9e290ce84c6c7f545ab86ebe3d630f", size = 2439771, upload-time = "2026-03-16T11:31:42.597Z" },
+    { url = "https://files.pythonhosted.org/packages/37/e9/a0cace9aac2c323acff97c6dd8157676c0875204ef265ac318dba03e2892/ansible_pylibssh-1.4.0-cp314-cp314-manylinux_2_27_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:8ac32823b92b0abc35f6ee625d2e48ceea24d7fa928f0f90efe4117d1cd43c49", size = 2794936, upload-time = "2026-03-16T11:31:44.184Z" },
+    { url = "https://files.pythonhosted.org/packages/bc/a2/58a99c8083ea35b662f5e77f97457eafd3ea6394b415fbdfd581b60d7ff3/ansible_pylibssh-1.4.0-cp314-cp314-manylinux_2_27_s390x.manylinux_2_28_s390x.whl", hash = "sha256:14001de0c82b27e2b11b64a06c6e58f383a27402b3de0db0064acee80cd31e62", size = 2273424, upload-time = "2026-03-16T11:31:46.393Z" },
+    { url = "https://files.pythonhosted.org/packages/d4/44/c749274e7968a83666c364b0fa022a640087b6df95c94a7c21f7f3102ddd/ansible_pylibssh-1.4.0-cp314-cp314-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:74343611d2b5ab332077873307b9eae152b48b1de22d8c16c682e7673afc9641", size = 2661392, upload-time = "2026-03-16T11:31:48.01Z" },
+    { url = "https://files.pythonhosted.org/packages/7e/63/a13c5b56b3ab8cdc477c062760e236578c7fcd7fe11fd0ddbfb1a24e9693/ansible_pylibssh-1.4.0-cp314-cp314-manylinux_2_28_armv7l.manylinux_2_31_armv7l.whl", hash = "sha256:58fc3c084a203a06dd3a18cc6d40b4c4da38c51aa6f6b06974ef06b8c40de929", size = 2076547, upload-time = "2026-03-16T11:31:50.186Z" },
+]
+
+[[package]]
+name = "asyncssh"
+version = "2.23.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "cryptography" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/a4/95/212d3d394f2a6ccb3f95056d3b9a7ce13c2f58503cbd6a38d037ef48cb13/asyncssh-2.23.1.tar.gz", hash = "sha256:d9dc3bc0206f3e4b5d80d1c0e6a24af2b4ad4beb556884c41fb2ad1c7ca3f44f", size = 542883, upload-time = "2026-06-07T14:15:18.832Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ef/94/9aa81bde40627af70388d634152e7c53e7533788e662b8093047501a1473/asyncssh-2.23.1-py3-none-any.whl", hash = "sha256:f68e55476d41253d785bcac9a90834ae5fdea0f417bd6d7182608bda248de88e", size = 376054, upload-time = "2026-06-07T14:15:17.375Z" },
+]
+
+[[package]]
 name = "babel"
 version = "2.18.0"
 source = { registry = "https://pypi.org/simple" }
@@ -1226,6 +1259,7 @@ name = "simnos"
 version = "2.4.0"
 source = { editable = "." }
 dependencies = [
+    { name = "asyncssh" },
     { name = "jinja2" },
     { name = "paramiko" },
     { name = "pydantic" },
@@ -1235,6 +1269,7 @@ dependencies = [
 [package.dev-dependencies]
 compatibility = [
     { name = "ansible-core" },
+    { name = "ansible-pylibssh" },
     { name = "scrapli" },
 ]
 dev = [
@@ -1260,6 +1295,7 @@ dev = [
 
 [package.metadata]
 requires-dist = [
+    { name = "asyncssh", specifier = ">=2.23,<3.0" },
     { name = "jinja2", specifier = ">=3.1.6" },
     { name = "paramiko", specifier = ">=4.0,<6.0" },
     { name = "pydantic", specifier = "<3.0" },
@@ -1269,6 +1305,7 @@ requires-dist = [
 [package.metadata.requires-dev]
 compatibility = [
     { name = "ansible-core" },
+    { name = "ansible-pylibssh" },
     { name = "scrapli" },
 ]
 dev = [


### PR DESCRIPTION
🐙claude:

## 概要 (#297 P2 Stage 2)

SSH transport を **paramiko → asyncssh + 共有 event loop** へ移行し、Stage 1 (PR #299) で単独実証済の W3 push dispatch core を async session に載せ替える。spike (#296) が特性化した「W2-without-W3 hybrid の 100 台失敗」を解消する。**対外仕様不変 (wire byte / scraper 互換 / 既存テスト) が不可侵条項**で、byte parity golden は Stage 1 と同一物を asyncssh path で再利用して担保。

設計 SSoT: `design/20260623_181913_claude_issue-297-p2-transport-shell-async.md` (§1/§1a/§2/§2a/§3a/§4/§5)。

> v3 運用: base=`v3`、`Closes #N` なし(#297 は v3→main merge 時まで OPEN 維持)。

## 主な変更

**新規 (production)**
- `core/shared_loop.py` — `SharedLoop` (§1/§1a/§2a): SimNOS 所有の asyncio loop (専用スレッド) + bounded `ThreadPoolExecutor` (`SIMNOS_DISPATCH_WORKERS` override) + listener registry (refcount/単一 lock) + 状態機械 `RUNNING/STOPPING/STOPPED/FAILED` + partial drain / global teardown (loop thread が `shutdown_default_executor`+`close` を finally 実行 = 確定的 join、leak なし)。
- `plugins/servers/async_session.py` — async push session driver (§3a): event-driven read loop、dispatch のみ bounded executor 経由 = **per-session thread なし** (W3 の肝)。Stage 1 の `_render_intro`/`_render_response` 再利用で byte parity。auth_none channel login の async 版同梱。
- `plugins/servers/ssh_server_asyncssh.py` — `AsyncSshServer` (§2、ParamikoSshServer と同一 `__init__` + `simnos` 参照) + `_SimnosSSHServer` (auth、publickey は authorized_keys 設定時のみ広告 = paramiko parity) + `AsyncSSHProcessTransport`。`managed_threads=[]`。pre-auth banner も送出。

**配線 (production)**
- `core/simnos.py` — `_shared_loop` 所有 + `ensure_shared_loop()` + `stop()` 末尾で `teardown_if_idle()`。`default_inventory` の SSH default を `AsyncSshServer` へ。
- `core/host.py` / registry / `pydantic_models.py` — `simnos` 伝播 + `AsyncSshServer` registry/schema 追加。paramiko/telnet は `simnos` kwarg 受理・無視。
- `pyproject.toml` — `asyncssh>=2.23,<3.0` を deps、`ansible-pylibssh` を compatibility group へ。`docker/inventory.yaml` も AsyncSshServer に。

## auth-retry interop (テーマE / E2)

E1 (asyncssh の auth-retry 許容) は public API で**達成不可と実機 probe で確定** (paramiko の SERVICE_REQUEST 再送 → asyncssh code-7 切断、ハードコード)。実現した auth = **paramiko-parity advertising** (publickey は鍵設定時のみ広告) + **E2** (ansible は `ansible_network_cli_ssh_type: libssh` = ansible-pylibssh)。netmiko/scrapli は password-first で無影響。

## テスト / AC

- **byte parity golden 4 件を asyncssh path で再利用** (default 切替で自動 gate、byte 一致)。
- **100 台同時 = 失敗 0** + executor 収束 (stop 後 thread baseline 復帰)。
- lifecycle: partial stop / restart / 二重 stop / mixed SSH+Telnet / FAILED 回復 / start-失敗収束 / slow-dispatch detach 収束。
- SharedLoop 単体 11 + async driver 単体 10 + 統合 12 + publickey 認証/広告ルール。
- **full suite (minus docker) = 1293 passed**、lint + ty green。Python 3.13 (CI で 3.14)。

## レビュー / 既知事項

- cross-review **3 round 収束** (codex: SHOULD→SUGG→SUGG / gemini: MUST→SHOULD→SUGG / claude: SUGG→SUGG→**LGTM**)。全 reviewer が lifecycle 失敗パス・concurrency・byte-parity 維持を検証済。
- **B1a gather 最適化は defer** (実測 100-host 起動 193ms で実益なし、follow-up 候補)。
- Telnet は本 Stage では旧 cmdloop 据え置き (Stage 3 で telnetlib3+push 一括)。GEX workaround 削除は Stage 4。
- docker test は提出者ホストの docker networking 破損で local 未実行 (0.0.0.0 bind + `simnos up` CLI path は検証済、container は CI 依存)。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
