### PR TITLE
feat: コマンド省略マッチ + Tab token-grain 補完 (#303 P3-2)

### DIFF
--- a/docs/usage/getting_started.ja.md
+++ b/docs/usage/getting_started.ja.md
@@ -39,6 +39,27 @@ ssh -p 6001 user@localhost # huawei_smartax
 
 行編集は **SSH 専用**です。Telnet サーバーはプレーン（編集なし）のストリームを維持します。
 
+## コマンドの省略入力
+
+実機の NOS と同様に、SIMNOS は**コマンドの省略入力**を受け付けます。各トークンを
+曖昧でない範囲で短縮でき、`sh ver` は `show version`、`conf t` は
+`configure terminal` として実行されます。SSH / Telnet の双方で、また直接入力と
+Tab 補完の双方で機能します。
+
+- すべてのトークンが必要で、末尾のトークンは省略できません。より長いコマンドの
+  単なる接頭辞（例: `sh ip`）は、実機 IOS と同じく `% Incomplete command.` を
+  返します。
+- 複数のコマンドに一致する省略入力は `% Ambiguous command:  "<入力>"` を返します。
+- 省略入力は、入力行が**完全一致コマンドでない**ときにのみ発火します。そのため
+  完全なコマンドの wire 上のバイト列は不変で、コマンドをまるごと送信する scraper
+  には一切影響しません。
+
+解決と Tab 補完は各コマンドの **canonical（正規）** な綴りに寄せられるため、
+別名（alias）は canonical な綴りへ解決されます（別名も完全に入力すれば動作します）。
+既定の `% Ambiguous` / `% Incomplete` 文言は Cisco IOS 形式ですが、各プラットフォーム
+はデータ側で上書きできます（`_default_` と並ぶ `_ambiguous_` / `_incomplete_`
+コマンド）。
+
 上記のコードを実行する代わりに、引数なしで SIMNOS CLI を実行することもできます:
 
 ```bash

--- a/docs/usage/getting_started.md
+++ b/docs/usage/getting_started.md
@@ -41,6 +41,28 @@ Netmiko at the same port.
 Line editing is **SSH-only**; the Telnet server keeps the plain (non-editing)
 stream.
 
+## Command abbreviation
+
+Like a real NOS, SIMNOS accepts **abbreviated commands**: each token may be
+shortened to an unambiguous prefix, so `sh ver` runs `show version` and `conf t`
+runs `configure terminal`. This works on both SSH and Telnet, and on both the
+exact-typed and Tab-completed forms.
+
+- Every token must be present — trailing tokens cannot be dropped. A strict
+  prefix of a longer command (e.g. `sh ip`) answers `% Incomplete command.`,
+  matching real IOS.
+- An abbreviation that matches more than one command answers
+  `% Ambiguous command:  "<input>"`.
+- Abbreviation only fires when the typed line is **not** an exact command, so a
+  full command's bytes on the wire are unchanged — scrapers that send full
+  commands are never affected.
+
+Resolution and Tab completion target each command's **canonical** spelling, so
+aliases resolve toward their canonical form (a full alias still works when typed
+in full). The default `% Ambiguous` / `% Incomplete` wording is Cisco IOS style;
+a platform can override it from its data (the `_ambiguous_` / `_incomplete_`
+commands, alongside `_default_`).
+
 The equivalent to running above code would be to run SIMNOS CLI without
 any arguments:
 

--- a/simnos/plugins/servers/async_session.py
+++ b/simnos/plugins/servers/async_session.py
@@ -267,15 +267,16 @@ class _LineEditor:
 
 
 def _complete(editor: _LineEditor, shell: "PushShell", transport: AsyncPushTransport) -> None:
-    """Tab completion: exact-prefix over the current-mode command names (#303 P3-1).
+    """Tab completion over the current-mode command names (#303 P3-1 / P3-2).
 
     One candidate completes the line (+ a trailing space); several are listed on a
     fresh line and the prompt + line are redrawn; none rings the bell. None of this
     is byte-parity-pinned: the contract rests on a scraper never sending Tab (nor
     BS / ESC). The goldens contain none; a platform that one day embeds a literal
-    tab in a command payload would be intercepted here and diverge — out of P3-1
-    scope (claude 1st#5). Completion uses the whole line (cursor-position-aware
-    completion is P3-2, gemini/claude 1st).
+    tab in a command payload would be intercepted here and diverge — out of scope
+    (claude 1st#5). The candidate list comes from ``shell.completion_candidates``,
+    which P3-2 widened from exact-prefix to leading-token abbreviation while still
+    returning whole-line command names, so this driver is unchanged.
     """
     candidates = shell.completion_candidates(editor.line_text)
     if len(candidates) == 1:

--- a/simnos/plugins/servers/tap_bridge.py
+++ b/simnos/plugins/servers/tap_bridge.py
@@ -52,7 +52,12 @@ class PushShell(Protocol):
     def dispatch(self, line: str) -> "DispatchResult": ...
 
     def completion_candidates(self, prefix: str) -> list[str]:
-        """Current-mode command names starting with ``prefix`` (#303 P3-1 Tab)."""
+        """Whole-line current-mode command names completing ``prefix`` (#303 Tab).
+
+        P3-1 matched an exact prefix; P3-2 widened this to leading-token
+        abbreviation, still returning whole-line names (the line-replacement
+        contract is unchanged).
+        """
         ...
 
 

--- a/simnos/plugins/shell/cmd_shell.py
+++ b/simnos/plugins/shell/cmd_shell.py
@@ -54,6 +54,27 @@ BASIC_COMMANDS: dict = {
         "output": "Unknown command",
         "help": "Output to print for unknown commands",
     },
+    # Abbreviation diagnostics (#303 / P3-2). Overridable specials like
+    # `_default_` — the default wording is Cisco IOS style (no captured oracle
+    # exists, so it follows public IOS documentation; re-pin if a capture is
+    # obtained), and huawei/junos can override it from platform data. The
+    # dispatcher fills a literal `{input}` placeholder with the typed line via
+    # `str.replace`. These entries flow through the legacy adapter
+    # (`format_template_to_jinja`), which treats `{...}` as a `str.format` field
+    # and rejects any field but `base_prompt`, so the placeholder is written
+    # **escaped** as `{{input}}` here: the adapter collapses it to a literal
+    # `{input}` (no template render), which `_dispatch_general` then substitutes.
+    # An override may carry `{input}` only as literal / A3 `.j2` text or via a
+    # handler (which formats itself from its `command` argument); a legacy
+    # py-module str.format template with a bare `{input}` fails loudly at load.
+    "_ambiguous_": {
+        "output": '% Ambiguous command:  "{{input}}"',
+        "help": "Output for an ambiguous command abbreviation",
+    },
+    "_incomplete_": {
+        "output": "% Incomplete command.",
+        "help": "Output for an incomplete command abbreviation",
+    },
 }
 
 # Wire response when a command handler (callable output) crashes. Real NOSes
@@ -495,13 +516,114 @@ class CMDShell(Cmd):
             if not (name.startswith("_") and name.endswith("_")) and self._in_current_mode(cmd)
         ]
 
-    def completion_candidates(self, prefix: str) -> list[str]:
-        """Current-mode command names that start with `prefix` (#303 P3-1, Tab).
+    def _abbrev_candidates(self) -> list[tuple[str, ResolvedCommand, list[str]]]:
+        """Abbreviation resolution space: current-mode canonical commands (#303 P3-2).
 
-        Exact-prefix only (a flat ``startswith`` over the whole command name);
-        leading-token abbreviation is P3-2. Sorted for a stable completion menu.
+        `_dispatchable_commands()` already applies the mode / `_special_` filter;
+        this further keeps only `name == cmd.canonical_name` (the real commands,
+        dropping aliases). Excluding alias surface tokens from the search space
+        is what kills false ambiguity / false pruning between word-variant
+        aliases of one canonical (e.g. `terminal length 0` real vs `term length
+        0` alias). Each candidate carries its token list so callers narrow
+        positionally. The canonical surface is the spelling the platform author
+        chose as canonical (`canonical_name` = alias target name), not
+        necessarily the longest form — so an alias's *partial* abbreviation
+        resolves toward that canonical (cisco_ios canonical = full form; arista
+        `conf t` canonical = short form).
         """
-        return sorted(name for name, _cmd in self._dispatchable_commands() if name.startswith(prefix))
+        return [(name, cmd, name.split()) for name, cmd in self._dispatchable_commands() if name == cmd.canonical_name]
+
+    def _narrow(self, tokens: list[str]) -> tuple[str, list[tuple[str, ResolvedCommand, list[str]]]]:
+        """Positionally narrow the canonical candidates by `tokens` (#303 P3-2).
+
+        Returns ``(status, candidates)`` with status ``"ok"`` (narrowed, possibly
+        still longer than the input), ``"ambiguous"`` (a position matches more
+        than one distinct surface token), or ``"none"`` (nothing matches).
+
+        Commands shorter than the input can never match, so they are pruned up
+        front — this also keeps `c[2][j]` in range for the whole loop and stops a
+        short command from pruning a longer one. At each position an exact token
+        match wins over a strict-prefix match (so `ip` is not shadowed by `ipv6`).
+        Because the candidate set is canonical-only, distinct surface tokens at a
+        position mean distinct real commands = genuine ambiguity.
+        """
+        candidates = [c for c in self._abbrev_candidates() if len(c[2]) >= len(tokens)]
+        if not candidates:
+            return ("none", [])
+        for j, itok in enumerate(tokens):
+            matched = [c for c in candidates if c[2][j].startswith(itok)]
+            if not matched:
+                return ("none", [])
+            exact = [c for c in matched if c[2][j] == itok]
+            if exact:
+                matched = exact
+            if len({c[2][j] for c in matched}) > 1:
+                return ("ambiguous", [])
+            candidates = matched
+        return ("ok", candidates)
+
+    def _resolve_abbreviation(self, line: str) -> tuple[str, ResolvedCommand | str | None]:
+        """Resolve an abbreviated command line, real-IOS style (#303 P3-2).
+
+        Called only after the exact-match lookup misses, so full commands never
+        reach here and their wire stays byte-identical. Returns ``(kind,
+        payload)``:
+
+        - ``("command", ResolvedCommand)``: a unique full command (token counts
+          match, each input token a prefix of the canonical token).
+        - ``("ambiguous", line)``: a position matches more than one command.
+        - ``("incomplete", line)``: the input is a strict prefix of a longer
+          command but reaches no full command (trailing tokens cannot be
+          omitted, matching IOS).
+        - ``("none", None)``: nothing matches → caller falls back to `_default_`.
+        """
+        tokens = line.split()  # collapses whitespace, like a real device
+        if not tokens:
+            return ("none", None)
+        status, candidates = self._narrow(tokens)
+        if status == "ambiguous":
+            return ("ambiguous", line)
+        if status == "none":
+            return ("none", None)
+        full = [c for c in candidates if len(c[2]) == len(tokens)]
+        if full:  # dict keys are unique, so at most one full match
+            return ("command", full[0][1])
+        return ("incomplete", line)
+
+    def _resolve_prefix_path(self, head: list[str]) -> list[tuple[str, ResolvedCommand, list[str]]]:
+        """Canonical candidates under `head` for Tab completion (#303 P3-2).
+
+        Empty `head` (empty prefix / trailing space) lists every current-mode
+        canonical command, preserving P3-1's "empty input lists all"; an
+        ambiguous / unmatched head returns ``[]`` (Tab stays silent where
+        dispatch would answer with a diagnostic).
+        """
+        if not head:
+            return self._abbrev_candidates()
+        status, candidates = self._narrow(head)
+        return candidates if status == "ok" else []
+
+    def completion_candidates(self, prefix: str) -> list[str]:
+        """Whole-line command names completing `prefix`, token-grain (#303 P3-2).
+
+        Extends P3-1's flat exact-prefix `startswith` to leading-token
+        abbreviation: the head tokens are resolved positionally (`_resolve_prefix_path`,
+        shared with `_resolve_abbreviation`) and the last token prefix-matches the
+        next canonical token. The return stays a list of whole-line full command
+        names so the SSH `_complete` line-replacement contract (and its tests) is
+        unchanged — `sh ip i<TAB>` expands to `show ip interface`, IOS style.
+        Candidates are canonical-only (aliases resolve toward their canonical),
+        so Tab is asymmetric with the help listing, which still shows aliases.
+        Sorted for a stable completion menu.
+        """
+        tokens = prefix.split()
+        trailing = prefix == "" or prefix.endswith(" ")
+        head = tokens if trailing else tokens[:-1]
+        last = "" if trailing else tokens[-1]
+        resolved = self._resolve_prefix_path(head)
+        return sorted(
+            {name for name, _cmd, toks in resolved if len(toks) > len(head) and toks[len(head)].startswith(last)}
+        )
 
     def _help_body(self) -> str:
         """Build the help listing for the current mode as body text (no I/O).
@@ -600,6 +722,24 @@ class CMDShell(Cmd):
         """
         log.debug("shell.default '%s' running command '%s'", self.base_prompt, [line])
         cmd = self.commands.get(line)
+        # Command abbreviation (#303 / P3-2): only on an exact-match miss, so a
+        # full command's wire is byte-identical (scrapers send full commands and
+        # never reach here). An ambiguous / incomplete abbreviation swaps in the
+        # `_ambiguous_` / `_incomplete_` overridable special so it flows through
+        # the very same dispatch pipeline as `_default_` (handler / new_mode
+        # supported); `abbrev_input` then drives the `{input}` interpolation
+        # after the body is finalized.
+        abbrev_input = None
+        if cmd is None:
+            kind, payload = self._resolve_abbreviation(line)
+            if kind == "command":
+                cmd = cast("ResolvedCommand", payload)
+            elif kind == "ambiguous":
+                cmd = self.commands.get("_ambiguous_")
+                abbrev_input = line
+            elif kind == "incomplete":
+                cmd = self.commands.get("_incomplete_")
+                abbrev_input = line
         if cmd is not None and self._in_current_mode(cmd):
             if cmd.exit:
                 return None, True
@@ -649,6 +789,16 @@ class CMDShell(Cmd):
             body = result.get("output")
         else:
             body = output.render(self.base_prompt)
+        # Interpolate the typed line into an abbreviation diagnostic (#303 / P3-2),
+        # after the body is finalized and before the transition / shutdown checks.
+        # Restricted to literal / template kinds: a handler already receives `line`
+        # and formats its own body, so replacing here would double-substitute; the
+        # `body is not None` guard keeps a handler / none kind override from
+        # crashing on `None.replace`. `output` (not `cmd.output`) keys the kind so
+        # the rare degraded path — special missing, `cmd` fell back to None /
+        # `_default_` — is None-safe.
+        if abbrev_input is not None and body is not None and output.kind in ("literal", "template"):
+            body = body.replace("{input}", abbrev_input)
         if transition is not None:
             self._apply_new_mode(transition, line)
         # Server shutdown observed mid-dispatch: close without writing the body

--- a/simnos/plugins/shell/cmd_shell.py
+++ b/simnos/plugins/shell/cmd_shell.py
@@ -556,8 +556,8 @@ class CMDShell(Cmd):
                 return ("none", [])
             exact = [c for c in matched if c[2][j] == itok]
             if exact:
-                matched = exact
-            if len({c[2][j] for c in matched}) > 1:
+                matched = exact  # all share this exact token -> never ambiguous here
+            elif len({c[2][j] for c in matched}) > 1:
                 return ("ambiguous", [])
             candidates = matched
         return ("ok", candidates)
@@ -734,12 +734,11 @@ class CMDShell(Cmd):
             kind, payload = self._resolve_abbreviation(line)
             if kind == "command":
                 cmd = cast("ResolvedCommand", payload)
-            elif kind == "ambiguous":
-                cmd = self.commands.get("_ambiguous_")
-                abbrev_input = line
-            elif kind == "incomplete":
-                cmd = self.commands.get("_incomplete_")
-                abbrev_input = line
+            elif kind in ("ambiguous", "incomplete"):
+                special = self.commands.get("_ambiguous_" if kind == "ambiguous" else "_incomplete_")
+                if special is not None:  # BASIC always provides these; guard the degraded case
+                    cmd = special
+                    abbrev_input = line  # set only when the special was actually swapped in
         if cmd is not None and self._in_current_mode(cmd):
             if cmd.exit:
                 return None, True
@@ -791,12 +790,12 @@ class CMDShell(Cmd):
             body = output.render(self.base_prompt)
         # Interpolate the typed line into an abbreviation diagnostic (#303 / P3-2),
         # after the body is finalized and before the transition / shutdown checks.
+        # `abbrev_input` is set only when an `_ambiguous_` / `_incomplete_` special
+        # was actually swapped in above, so this never fires on the normal path.
         # Restricted to literal / template kinds: a handler already receives `line`
         # and formats its own body, so replacing here would double-substitute; the
         # `body is not None` guard keeps a handler / none kind override from
-        # crashing on `None.replace`. `output` (not `cmd.output`) keys the kind so
-        # the rare degraded path — special missing, `cmd` fell back to None /
-        # `_default_` — is None-safe.
+        # crashing on `None.replace`.
         if abbrev_input is not None and body is not None and output.kind in ("literal", "template"):
             body = body.replace("{input}", abbrev_input)
         if transition is not None:

--- a/tests/plugins/test_abbreviation.py
+++ b/tests/plugins/test_abbreviation.py
@@ -1,0 +1,326 @@
+"""Command abbreviation + Tab token-grain completion (#303 / P3-2).
+
+The shell resolves an abbreviated command line (``sh ver`` -> ``show version``)
+only after the exact-match lookup misses, so a full command's wire stays
+byte-identical (the byte-parity goldens pin that separately). These tests cover:
+
+1. full commands are never diverted to abbreviation (positive invariant);
+2. genuinely unknown input still answers with ``_default_`` (negative fixture);
+3. abbreviation / ambiguous / incomplete resolution on real cisco_ios data;
+4. alias safety on real arista_eos data (canonical-only candidate set);
+5. multi-space full commands resolve via ``split()`` collapse;
+6. Tab completion returns whole-line names, token-grain;
+7. the ``_ambiguous_`` / ``_incomplete_`` specials are overridable and flow
+   through the normal dispatch pipeline (handler override is None-safe, and the
+   specials never transition or close);
+8. abbreviation works on the telnet (``default``) and SSH (``dispatch``) paths.
+"""
+
+import dataclasses
+import io
+import threading
+
+import pytest
+
+from simnos.core.nos import Nos
+from simnos.core.resolved_command import ResolvedOutput
+from simnos.plugins.nos import nos_plugins
+from simnos.plugins.shell.cmd_shell import CMDShell
+
+# The packaged Cisco-style defaults (BASIC_COMMANDS), after the adapter collapses
+# the escaped ``{{input}}`` to a literal ``{input}`` and dispatch substitutes it.
+AMBIGUOUS_PREFIX = '% Ambiguous command:  "'
+INCOMPLETE_DIAG = "% Incomplete command."
+
+# A small, representative cross-platform sweep: A3-only (cisco_ios), A3 + legacy
+# py overrides (arista_eos), and two more NOS families, so the special-command
+# invariants are not pinned on cisco_ios alone.
+SWEEP_PLATFORMS = ["cisco_ios", "arista_eos", "huawei_smartax", "juniper_junos"]
+
+
+def _shell(name: str, *, stdout=None) -> CMDShell:
+    """A real merged-platform shell for `name`, ready to dispatch."""
+    is_running = threading.Event()
+    is_running.set()  # otherwise _dispatch_general reports server shutdown
+    return CMDShell(
+        stdin=None,
+        stdout=stdout,
+        nos=Nos(filename=nos_plugins[name]),
+        nos_inventory_config={},
+        base_prompt="device",
+        is_running=is_running,
+    )
+
+
+def _legacy_shell(commands: dict, *, stdout=None) -> CMDShell:
+    """A legacy (3-prompt) shell built from an in-memory command dict."""
+    nos = Nos()
+    nos.from_dict(
+        {
+            "name": "synthetic",
+            "initial_prompt": "{base_prompt}>",
+            "enable_prompt": "{base_prompt}#",
+            "config_prompt": "{base_prompt}(config)#",
+            "commands": commands,
+        }
+    )
+    is_running = threading.Event()
+    is_running.set()
+    return CMDShell(
+        stdin=None,
+        stdout=stdout,
+        nos=nos,
+        nos_inventory_config={},
+        base_prompt="device",
+        is_running=is_running,
+    )
+
+
+def _enable(shell: CMDShell) -> CMDShell:
+    """Put a cisco-like shell in enable mode (where the show tree is valid)."""
+    shell.current_mode = "enable"
+    return shell
+
+
+# --------------------------------------------------------------- 1. positive invariant
+def test_full_commands_never_diverted_to_abbreviation():
+    """Every real command resolves by exact match, never via abbreviation.
+
+    Abbreviation only fires on an exact-match miss, so a full command's dispatch
+    output is whatever the exact ResolvedCommand produces — never an ambiguous /
+    incomplete diagnostic. Pinned across the sweep so the byte-parity-protected
+    full-command path cannot silently regress when abbreviation is in play.
+    """
+    for platform in SWEEP_PLATFORMS:
+        shell = _shell(platform)
+        for name, cmd in list(shell.commands.items()):
+            if name.startswith("_") and name.endswith("_"):
+                continue  # specials are not dispatched by name
+            shell.current_mode = next(iter(cmd.modes)) if cmd.modes else shell.platform.initial_mode
+            body, close = shell._dispatch_general(name)
+            assert body != INCOMPLETE_DIAG, f"{platform}:{name!r} fell through to incomplete"
+            assert not (body or "").startswith(AMBIGUOUS_PREFIX), f"{platform}:{name!r} fell through to ambiguous"
+            if cmd.exit:
+                assert close is True
+            elif cmd.output.kind in ("literal", "template") and not cmd.variants:
+                # exact-match output, unperturbed by the abbreviation machinery
+                assert body == cmd.output.render(shell.base_prompt)
+
+
+# --------------------------------------------------------------- 2. negative fixture
+# `(platform, mode, input, reason)` — inputs that must stay `_default_`, NOT be
+# coerced into a command / ambiguous / incomplete by abbreviation. Seeded from
+# the cisco_ios byte-parity golden's unknown-command steps (`no such command`,
+# `exit` out-of-mode) plus a few clearly-foreign tokens.
+NEGATIVE_FIXTURE = [
+    ("cisco_ios", "enable", "no such command", "golden step 8 unknown -> _default_"),
+    ("cisco_ios", "enable", "exit", "golden step 12: exit is config-only -> _default_"),
+    ("cisco_ios", "enable", "zzz", "foreign single token"),
+    ("cisco_ios", "enable", "frobnicate the widget", "foreign multi token"),
+    ("arista_eos", "enable", "configure t", "alias long-form abbreviation is not canonical -> _default_"),
+    ("arista_eos", "enable", "wibble", "foreign single token"),
+]
+
+
+@pytest.mark.parametrize(("platform", "mode", "line", "reason"), NEGATIVE_FIXTURE)
+def test_unknown_input_stays_default(platform, mode, line, reason):
+    shell = _shell(platform)
+    shell.current_mode = mode
+    expected = shell.commands["_default_"].output.render(shell.base_prompt)
+    body, _close = shell._dispatch_general(line)
+    assert body == expected, reason
+
+
+# --------------------------------------------------------------- 3. abbreviation positive (cisco_ios)
+@pytest.mark.parametrize(
+    ("line", "expect"),
+    [
+        ("sh ver", "command"),  # show version
+        ("conf t", "command"),  # configure terminal (canonical = full form)
+        ("sh ip int br", "command"),  # show ip interface brief
+        ("s i i b", "ambiguous"),  # 's' (and 'i') match multiple commands
+        ("sh ip", "incomplete"),  # strict prefix of longer commands, no full match
+    ],
+)
+def test_abbreviation_resolution_cisco(line, expect):
+    shell = _enable(_shell("cisco_ios"))
+    kind, _payload = shell._resolve_abbreviation(line)
+    assert kind == expect
+
+
+def test_abbreviation_dispatches_expected_output_cisco():
+    shell = _enable(_shell("cisco_ios"))
+    # `sh ip int br` resolves to the same body as the full command.
+    abbrev, _ = shell._dispatch_general("sh ip int br")
+    full, _ = shell._dispatch_general("show ip interface brief")
+    assert abbrev == full
+    # ambiguous / incomplete render the (input-interpolated) diagnostics.
+    amb, amb_close = shell._dispatch_general("s i i b")
+    assert amb == '% Ambiguous command:  "s i i b"'
+    assert amb_close is False
+    inc, inc_close = shell._dispatch_general("sh ip")
+    assert inc == INCOMPLETE_DIAG
+    assert inc_close is False
+
+
+# --------------------------------------------------------------- 4. alias safety (arista_eos real data)
+def test_alias_safety_arista():
+    """Canonical-only candidates: word-variant aliases neither falsely-ambiguate
+    nor falsely-prune, and a long-form alias of a short canonical does not
+    abbreviation-resolve (a documented data-dependent limitation, Decision 5)."""
+    shell = _enable(_shell("arista_eos"))
+    # canonical `terminal length 0`, alias `term length 0`: no false ambiguity.
+    kind, payload = shell._resolve_abbreviation("te l 0")
+    assert kind == "command"
+    assert payload.canonical_name == "terminal length 0"
+    # `term l 0` (abbreviating the alias's own surface, which shares the canonical
+    # prefix) also resolves to the canonical.
+    kind, _ = shell._resolve_abbreviation("term l 0")
+    assert kind == "command"
+    # canonical is the SHORT form `conf t`; the long-form alias `configure
+    # terminal` resolves only by exact match, its abbreviation does not.
+    assert shell.commands.get("configure terminal") is not None  # exact alias entry exists
+    kind, _ = shell._resolve_abbreviation("configure t")
+    assert kind == "none"  # -> _default_, not the config-mode transition
+
+
+# --------------------------------------------------------------- 5. multi-space full command
+def test_multi_space_full_command_resolves_cisco():
+    """`split()` collapses runs of spaces, so a double-spaced full command (a
+    miss for the exact dict lookup) resolves through abbreviation — more faithful
+    than v2's `_default_`, and outside the byte-parity contract (the input was
+    not an exact match)."""
+    shell = _enable(_shell("cisco_ios"))
+    spaced, _ = shell._dispatch_general("show  version")
+    full, _ = shell._dispatch_general("show version")
+    assert spaced == full
+
+
+# --------------------------------------------------------------- 6. Tab token-grain completion
+def test_completion_token_grain_cisco():
+    shell = _enable(_shell("cisco_ios"))
+    # leading-token abbreviation expands to whole-line full command names
+    assert shell.completion_candidates("sh ip i") == ["show ip interface", "show ip interface brief"]
+    # trailing space lists the next token's candidates (head fully consumed)
+    trailing = shell.completion_candidates("sh ip ")
+    assert "show ip route" in trailing
+    assert all(c.startswith("show ip ") for c in trailing)
+    # exact-prefix (P3-1 behaviour) still works
+    assert "show version" in shell.completion_candidates("show v")
+    # empty prefix lists every current-mode canonical command (and only canonical)
+    everything = shell.completion_candidates("")
+    assert "show version" in everything
+    assert everything == sorted(everything)
+    # an ambiguous *head* (a committed, non-last token matching multiple
+    # commands) returns nothing — Tab stays silent where dispatch would diagnose.
+    # ("s i " trailing-space: head ["s","i"]; position 1 "i" matches
+    # interface/inventory/ip/ipv6/isdn/isis -> ambiguous.)
+    assert shell.completion_candidates("s i ") == []
+
+
+def test_completion_is_canonical_only_cisco():
+    """Tab lists canonical names, not aliases (asymmetric with the help listing)."""
+    shell = _enable(_shell("arista_eos"))
+    everything = shell.completion_candidates("")
+    assert "conf t" in everything  # canonical
+    assert "configure terminal" not in everything  # alias is hidden from Tab
+
+
+# --------------------------------------------------------------- 7. overridable specials + handler
+def test_specials_overridable_literal():
+    shell = _legacy_shell(
+        {
+            "clear counters": {"output": "cleared", "prompt": "{base_prompt}#"},
+            "clock set": {"output": "set", "prompt": "{base_prompt}#"},
+            "show version": {"output": "v1", "prompt": "{base_prompt}#"},
+            # literal override carrying the placeholder (escaped for the adapter)
+            "_ambiguous_": {"output": "AMB <{{input}}>", "help": ""},
+            "_incomplete_": {"output": "INC!", "help": ""},
+        }
+    )
+    shell.current_mode = "enable"
+    amb, _ = shell._dispatch_general("cl")  # clear vs clock -> ambiguous
+    assert amb == "AMB <cl>"  # custom wording + {input} interpolation
+    inc, _ = shell._dispatch_general("show")  # strict prefix of "show version"
+    assert inc == "INC!"
+
+
+def test_special_handler_override_is_none_safe_and_no_double_substitution():
+    """A handler-kind `_ambiguous_` override flows through the normal dispatch
+    pipeline (the cmd-swap, not a render-only helper), so `render()` returning
+    None for a handler does not crash, and a literal `{input}` the handler emits
+    itself is NOT re-substituted (handler formats from its own `command` arg)."""
+    shell = _legacy_shell(
+        {
+            "clear counters": {"output": "cleared", "prompt": "{base_prompt}#"},
+            "clock set": {"output": "set", "prompt": "{base_prompt}#"},
+        }
+    )
+    shell.current_mode = "enable"
+
+    def handler(device, *, base_prompt, current_mode, current_prompt, command):
+        # body deliberately contains a literal "{input}" to prove it is NOT replaced
+        return f"H:{command} {{input}}"
+
+    shell.commands = {
+        **shell.commands,
+        "_ambiguous_": dataclasses.replace(
+            shell.commands["_ambiguous_"], output=ResolvedOutput(kind="handler", handler=handler)
+        ),
+    }
+    body, close = shell._dispatch_general("cl")  # ambiguous -> handler special
+    assert body == "H:cl {input}"  # handler ran, {input} left intact (no double sub)
+    assert close is False
+
+
+def test_special_none_kind_override_does_not_crash():
+    """A none-kind (empty) `_ambiguous_` override yields no body and never the
+    `None.replace` crash the render-only helper would have hit."""
+    shell = _legacy_shell(
+        {
+            "clear counters": {"output": "cleared", "prompt": "{base_prompt}#"},
+            "clock set": {"output": "set", "prompt": "{base_prompt}#"},
+        }
+    )
+    shell.current_mode = "enable"
+    shell.commands = {
+        **shell.commands,
+        "_ambiguous_": dataclasses.replace(shell.commands["_ambiguous_"], output=ResolvedOutput(kind="none")),
+    }
+    body, close = shell._dispatch_general("cl")
+    assert body is None
+    assert close is False
+
+
+@pytest.mark.parametrize("platform", SWEEP_PLATFORMS)
+def test_packaged_specials_never_transition_or_close(platform):
+    """The packaged `_ambiguous_` / `_incomplete_` defaults must not transition
+    the mode or close the session — they ride the normal dispatch pipeline, so
+    an authoring slip that set `new_mode` / `exit` would otherwise leak through."""
+    shell = _shell(platform)
+    for cmd_name in ("_ambiguous_", "_incomplete_"):
+        cmd = shell.commands[cmd_name]
+        assert cmd.new_mode is None
+        assert cmd.exit is False
+        assert not cmd.modes  # valid in every mode (no prompt)
+
+
+# --------------------------------------------------------------- 8. telnet + ssh paths
+def test_abbreviation_on_telnet_default_path():
+    """The cmd.Cmd `default` adapter (telnet cmdloop) shares `_dispatch_general`,
+    so abbreviation works there too — line editing stays SSH-only (pinned in
+    test_ssh_line_editor), but the resolution itself is path-independent."""
+    out = io.StringIO()
+    shell = _enable(_shell("cisco_ios", stdout=out))
+    close = shell.default("sh ver")
+    assert close is False
+    assert "Cisco IOS" in out.getvalue()
+
+
+def test_abbreviation_on_ssh_dispatch_path():
+    """The push dispatch core (SSH) resolves abbreviations and reports them via
+    DispatchResult without writing to stdout."""
+    shell = _enable(_shell("cisco_ios"))
+    result = shell.dispatch("s i i b")  # ambiguous
+    assert result.body == '% Ambiguous command:  "s i i b"'
+    assert result.close is False

--- a/tests/plugins/test_abbreviation.py
+++ b/tests/plugins/test_abbreviation.py
@@ -23,7 +23,7 @@ import threading
 import pytest
 
 from simnos.core.nos import Nos
-from simnos.core.resolved_command import ResolvedOutput
+from simnos.core.resolved_command import ResolvedCommand, ResolvedOutput
 from simnos.plugins.nos import nos_plugins
 from simnos.plugins.servers.async_session import _complete, _LineEditor
 from simnos.plugins.shell.cmd_shell import CMDShell
@@ -175,6 +175,7 @@ def test_alias_safety_arista():
     # canonical `terminal length 0`, alias `term length 0`: no false ambiguity.
     kind, payload = shell._resolve_abbreviation("te l 0")
     assert kind == "command"
+    assert isinstance(payload, ResolvedCommand)
     assert payload.canonical_name == "terminal length 0"
     # `term l 0` (abbreviating the alias's own surface, which shares the canonical
     # prefix) also resolves to the canonical.

--- a/tests/plugins/test_abbreviation.py
+++ b/tests/plugins/test_abbreviation.py
@@ -25,7 +25,10 @@ import pytest
 from simnos.core.nos import Nos
 from simnos.core.resolved_command import ResolvedOutput
 from simnos.plugins.nos import nos_plugins
+from simnos.plugins.servers.async_session import _complete, _LineEditor
 from simnos.plugins.shell.cmd_shell import CMDShell
+from tests.plugins.test_async_session import _FakeTransport
+from tests.plugins.test_ssh_line_editor import _feed
 
 # The packaged Cisco-style defaults (BASIC_COMMANDS), after the adapter collapses
 # the escaped ``{{input}}`` to a literal ``{input}`` and dispatch substitutes it.
@@ -324,3 +327,41 @@ def test_abbreviation_on_ssh_dispatch_path():
     result = shell.dispatch("s i i b")  # ambiguous
     assert result.body == '% Ambiguous command:  "s i i b"'
     assert result.close is False
+
+
+def test_complete_abbreviated_leading_token_through_real_complete():
+    """End-to-end: a real shell's token-grain `completion_candidates` drives the
+    SSH `_complete` line-replacement so a leading-token abbreviation expands the
+    whole line (#303 P3-2, claude 1st#3). The async_session `_complete` unit
+    tests use a flat-`startswith` stub, so this is the only place the real
+    token-grain completion meets the real line editor."""
+    shell = _enable(_shell("cisco_ios"))
+    tr = _FakeTransport([])
+    editor = _LineEditor(tr.send)
+    _feed(editor, b"sh ver")  # leading-token abbreviation, unique -> show version
+    _complete(editor, shell, tr)
+    assert editor.take_line() == b"show version "
+
+
+def test_abbreviation_handler_receives_typed_line():
+    """A handler reached via abbreviation gets the *typed* (abbreviated) line as
+    its `command`, consistent with exact dispatch (the handler always sees the
+    literal typed line; the wire echo shows what the user typed). Pinned so the
+    contract is intentional rather than incidental (codex 1st#4)."""
+    shell = _legacy_shell({"show version": {"output": "v", "prompt": "{base_prompt}#"}})
+    shell.current_mode = "enable"
+    seen = []
+
+    def handler(device, *, base_prompt, current_mode, current_prompt, command):
+        seen.append(command)
+        return "ok"
+
+    shell.commands = {
+        **shell.commands,
+        "show version": dataclasses.replace(
+            shell.commands["show version"], output=ResolvedOutput(kind="handler", handler=handler)
+        ),
+    }
+    body, _ = shell._dispatch_general("sh ver")  # abbreviation -> handler command
+    assert body == "ok"
+    assert seen == ["sh ver"]  # the typed abbreviation, not the canonical "show version"


### PR DESCRIPTION
🐙claude:

## 概要 (#303 P3-2、epic #263)

実機式の **コマンド省略マッチ(token 単位 abbreviation)** + **Tab token-grain 補完** を共有 dispatch core に default-on で実装します。`sh ver` → `show version`、`conf t` → `configure terminal`。SSH / Telnet 両方、直接入力 / Tab 補完両方に効きます。

**完全一致 (full command) の wire は 1 byte も変えません** — abbreviation は exact-match miss 時のみ発火するため、scraper (Netmiko/Scrapli/Ansible) が送る full command は abbreviation 経路に入らず byte-parity golden は無変更です(検証ペルソナの不可侵条項)。

設計確定書(cross-review design 3 round 収束)に準拠。マスター設計 `20260625_181318` の P3-2 spec を 2 点上書き(Decision 1: 永続 Trie → 都度 linear positional filter / Decision 2: 短語入力 = 実機式 `% Incomplete command.`、ユーザー承認済)。

## 主な変更

**`simnos/plugins/shell/cmd_shell.py`**
- 解決 helper 4 つ新設: `_abbrev_candidates`(**canonical-only** = `name == cmd.canonical_name`、alias surface を解決空間から除外し語形違い alias の誤曖昧/誤 prune を根絶)/ `_narrow`(都度 linear positional filter、length 事前フィルタ + exact-token 優先 + per-token 曖昧検出)/ `_resolve_abbreviation`(command/ambiguous/incomplete/none)/ `_resolve_prefix_path`(Tab 用、head 空 → 全 canonical)
- `_dispatch_general` の miss 分岐拡張: ambiguous/incomplete は `_ambiguous_`/`_incomplete_` に **cmd 差し替え → 正規 dispatch パイプライン経由**(handler/new_mode サポート、None セーフ)。`{input}` 補間は body 確定後・literal/template 限定
- `completion_candidates` を token-grain 化(返値は whole-line 維持で SSH `_complete` 行置換契約 + 既存 test 不変)
- `BASIC_COMMANDS` に overridable special `_ambiguous_` / `_incomplete_` を追加(`_default_` 同様 platform 上書き可)

**曖昧/不完全文言**
- デフォルトは Cisco IOS 式(`% Ambiguous command:  "<input>"` / `% Incomplete command.`)。huawei/junos 等は data 上書き可
- ⚠ BASIC default の `{input}` は legacy adapter(`format_template_to_jinja`)で format field と誤認され load 時 ValueError になるため、`{{input}}` エスケープで literal `{input}` に collapse させて回避(実装中に発見した設計穴。authoring 契約を docstring/docs に明記)

**docs**: `getting_started` 英日に「Command abbreviation」節を追記

## テスト

- 新規 `tests/plugins/test_abbreviation.py`(28 tests): positive invariant / negative fixture(golden seed)/ abbreviation positive(cisco_ios)/ alias safety(arista 実データ)/ multi-space / Tab token-grain / 文言+handler/none override(None セーフ)+ 無遷移無close sweep(4 platform)/ telnet+ssh path / **real `_complete` × 省略補完 結合 e2e**
- byte-parity golden 無変更(`tests/assets/golden_transcripts/` 差分なし)+ byte-parity SSH/telnet test 6 passed
- full suite **1085 passed, 7 skipped, 1 xfailed**(docker 2 件は実行環境の iptables 問題で deselect、コード無関係)
- `invoke ruff` / `invoke yamllint` / `invoke ty` 全 pass

## cross-review

- **design 3 round** 収束(claude LGTM + final-refactor)
- **code 1st round** = 総合 SUGGESTION(claude/codex SUGGESTION・gemini LGTM、MUST/SHOULD ゼロ)→ Tab e2e 結合 test 追加 / degraded guard 厳密化 / handler `command` 引数 pin / comment 追従 / `_narrow` elif 化 を取り込み。非取り込み 2 件(negative fixture programmatic 化・set→list)は理由明記済
- final-refactor 通過

## 補足

- base = `v3`。本 PR は v3 ブランチへの取り込みで、issue #303 / epic #263 は **v3 → main マージ時に close**(本 PR では OPEN 維持、`Closes` は付けません)
- follow-up(本 PR 後): マスター設計 `20260625_181318` + epic #263 の P3-2 記述を新方針(linear filter / 実機式 incomplete / overridable special)へ追従修正

🤖 Generated with [Claude Code](https://claude.com/claude-code)
