### PR TITLE
refactor: cmd.Cmd 完全撤去 + 自前 _parseline + CMDShellConfig forbid (#303 P3-3)

### DIFF
--- a/simnos/core/command_contract.py
+++ b/simnos/core/command_contract.py
@@ -3,9 +3,9 @@
 A NOS plugin may set a command's ``output`` to a callable instead of a
 static string (see :mod:`simnos.plugins.nos.platforms_py.cisco_ios` for a
 live example). This module is the single place where that callable's
-signature and return shape are written down — `CMDShell.default()`
-dispatches against it and plugin authors can import it for type
-annotations (optional; plain functions matching the shape work as-is).
+signature and return shape are written down — `CMDShell._dispatch_general()`
+(via `_invoke_handler`) dispatches against it and plugin authors can import it
+for type annotations (optional; plain functions matching the shape work as-is).
 """
 
 from typing import TYPE_CHECKING, Protocol, TypedDict

--- a/simnos/core/pydantic_models.py
+++ b/simnos/core/pydantic_models.py
@@ -374,14 +374,22 @@ class TelnetServerPlugin(BaseModel):
 
 
 class CMDShellConfig(BaseModel):
-    """
-    Pydantic model for CMD shell configuration.
+    """Pydantic model for CMD shell configuration.
+
+    `ruler` / `completekey` were cmd.Cmd cmdloop-only knobs and were removed with
+    the cmd.Cmd base in #303 P3-3; `extra="forbid"` now rejects them (and any
+    other unknown key) at load time rather than letting it reach
+    `CMDShell.__init__` as an unexpected keyword and crash at connect time.
+    `base_prompt` is injected by `Host` (`shell.configuration` setdefault) and
+    may also be set in inventory to override the host-name prompt, so it is an
+    explicit field here to stay forbid-compatible.
     """
 
+    model_config = ConfigDict(extra="forbid")
+
     intro: StrictStr | None = "Custom SSH Shell"
-    ruler: StrictStr | None = ""
-    completekey: StrictStr | None = "tab"
     newline: StrictStr | None = "\r\n"
+    base_prompt: StrictStr | None = Field(default=None, description="Overrides the default host-name base prompt")
 
 
 class CMDShellPlugin(BaseModel):

--- a/simnos/plugins/servers/async_server_base.py
+++ b/simnos/plugins/servers/async_server_base.py
@@ -26,7 +26,6 @@ and drive each accepted connection through :meth:`_session_scope` +
 import asyncio
 import concurrent.futures
 import contextlib
-import io
 import logging
 import threading
 from typing import TYPE_CHECKING, Protocol
@@ -303,8 +302,6 @@ class AsyncServerBase:
     def _build_shell(self):
         """Build the per-session shell (shared NOS data + per-host render config)."""
         return self.shell(
-            stdin=io.StringIO(),
-            stdout=io.StringIO(),
             nos=self.nos,
             nos_inventory_config=self.nos_inventory_config,
             is_running=self._is_running,

--- a/simnos/plugins/servers/tap_bridge.py
+++ b/simnos/plugins/servers/tap_bridge.py
@@ -93,9 +93,9 @@ def _render_response(shell: PushShell, result: "DispatchResult") -> bytes:
     The line-terminator echo (``\\r\\n``) is held until dispatch completes and
     emitted as the first part of this single write unit, reproducing the legacy
     echo coalescing without the timing-dependent ``_COALESCE_DELAY``. On a close
-    result neither body nor prompt is emitted (the legacy `default` wrote
-    nothing on its close paths), leaving just the newline echo. Body lines
-    reproduce `writeline`'s per-line ``newline``.
+    result neither body nor prompt is emitted (the legacy `default` adapter wrote
+    nothing on its close paths), leaving just the newline echo. Each body line
+    gets a trailing ``newline``, reproducing the legacy per-line shell output.
     """
     writes: list[str] = ["\r\n"]  # line-terminator echo, held until dispatch
     if not result.close:

--- a/simnos/plugins/servers/tap_bridge.py
+++ b/simnos/plugins/servers/tap_bridge.py
@@ -75,9 +75,10 @@ def _assemble_wire(writes: list[str]) -> bytes:
 def _render_intro(shell: PushShell) -> bytes:
     """Initial wire bytes: the shell intro line + the first prompt (#297 / §3a).
 
-    Mirrors `cmd.Cmd.cmdloop` writing ``str(intro)+"\\n"`` then ``self.prompt``
-    as two stdout writes (assembled per write so CR/LF/NUL normalization matches
-    the legacy `shell_to_client_tap`).
+    Reproduces the framing the legacy `cmd.Cmd.cmdloop` produced (removed in #303
+    P3-3): ``str(intro)+"\\n"`` then ``self.prompt`` as two stdout writes
+    (assembled per write so CR/LF/NUL normalization matches the legacy
+    `shell_to_client_tap`).
     """
     writes: list[str] = []
     if shell.intro:

--- a/simnos/plugins/shell/cmd_shell.py
+++ b/simnos/plugins/shell/cmd_shell.py
@@ -461,9 +461,9 @@ class CMDShell:
             except Exception:
                 # Broad except, like the dispatch core's handler guard: any
                 # plugin error must not crash the session. Roll back the partial
-                # nos mutation so the
-                # broken file does not poison subsequent reloads, then log the
-                # traceback so a genuine plugin bug stays diagnosable.
+                # nos mutation so the broken file does not poison subsequent
+                # reloads, then log the traceback so a genuine plugin bug stays
+                # diagnosable.
                 self.nos.commands = snapshot_commands
                 for attr, value in snapshot_attrs.items():
                     setattr(self.nos, attr, value)

--- a/simnos/plugins/shell/cmd_shell.py
+++ b/simnos/plugins/shell/cmd_shell.py
@@ -2,13 +2,13 @@
 Custom shell class to interact with NOS.
 """
 
-from cmd import Cmd
 import copy
 from dataclasses import dataclass
 import hashlib
 import logging
 import os
 import random
+import string
 import traceback
 from typing import TYPE_CHECKING, cast
 
@@ -144,15 +144,16 @@ def build_resolved_platform(
 class DispatchResult:
     """Structured result of one dispatched line (#297 / §3a).
 
-    The push session driver turns this into wire bytes. ``cmd.Cmd.cmdloop`` /
-    ``onecmd`` cannot represent multi-line output, no output, session close, or
-    a post-transition prompt in a single ``str``, so the I/O-independent
-    dispatch core returns the pieces explicitly:
+    The push session driver turns this into wire bytes. The legacy
+    ``cmd.Cmd.cmdloop`` / ``onecmd`` (removed in #303 P3-3) could not represent
+    multi-line output, no output, session close, or a post-transition prompt in
+    a single ``str``, so the I/O-independent dispatch core returns the pieces
+    explicitly:
 
     - ``body``: text to render with ``writeline`` semantics, or ``None`` for no
       output (empty line, EOF, a handler returning no ``output``). The driver
-      suppresses it when ``close`` is set — the legacy ``default`` never wrote a
-      body on any close path.
+      suppresses it when ``close`` is set — the legacy ``default`` adapter never
+      wrote a body on any close path.
     - ``prompt``: the prompt to show after this line (already reflects a mode
       transition applied during dispatch).
     - ``close``: the session should close after this line.
@@ -165,12 +166,15 @@ class DispatchResult:
     mode: str
 
 
-class CMDShell(Cmd):
+class CMDShell:
     """
     Custom shell class to interact with NOS.
     """
 
-    use_rawinput = False
+    # Same value as the former ``cmd.Cmd.identchars``; ``_parseline`` reads
+    # ``self.identchars`` to extract the leading command token, so it must be a
+    # class attr now that the ``cmd.Cmd`` base is gone (#303 P3-3).
+    identchars = string.ascii_letters + string.digits + "_"
 
     def __init__(
         self,
@@ -181,8 +185,6 @@ class CMDShell(Cmd):
         base_prompt,
         is_running,
         intro="Custom SSH Shell",
-        ruler="",
-        completekey="tab",
         newline="\r\n",
         resolved_platform=None,
         render_config=None,
@@ -194,7 +196,6 @@ class CMDShell(Cmd):
         # frozen value, not `self.nos.name`, or a hijacked name would permanently
         # skip this session's own A3 platform reload.
         self._platform_name: str = nos.name
-        self.ruler = ruler
         self.intro = intro
         self.base_prompt = base_prompt
         self.newline = newline
@@ -236,12 +237,10 @@ class CMDShell(Cmd):
             resolved_platform = build_resolved_platform(self.nos, self._inventory_commands, self._render_config)
         self._apply_platform(resolved_platform)
 
-        # call the base constructor of cmd.Cmd, with our own stdin and stdout
-        super().__init__(
-            completekey=completekey,
-            stdin=stdin,
-            stdout=stdout,
-        )
+        # Hold our own stdin/stdout. These were formerly set by `cmd.Cmd.__init__`
+        # (removed with the base class in #303 P3-3); `writeline` uses `stdout`.
+        self.stdin = stdin
+        self.stdout = stdout
 
     @staticmethod
     def build_shared_platform(
@@ -403,25 +402,10 @@ class CMDShell(Cmd):
         """
         self._apply_platform(build_resolved_platform(self.nos, self._inventory_commands, self._render_config))
 
-    def start(self):
-        """Method to start the shell"""
-        self.cmdloop()
-
-    def stop(self):
-        """Method to stop the shell"""
-        self.stdin.write("exit" + self.newline)
-
     def writeline(self, value):
         """Method to write a line to stdout with newline at the end"""
         for line in str(value).splitlines():
             self.stdout.write(line + self.newline)
-
-    def do_EOF(self, line):
-        """Handle EOF from readline — exit the shell gracefully."""
-        return True
-
-    def emptyline(self):
-        """This method to do nothing if empty line entered"""
 
     # `Nos` state `from_file` mutates; snapshotted per reload target so a target
     # that loads but fails to normalize can be rolled back (2nd round codex #1).
@@ -475,8 +459,9 @@ class CMDShell(Cmd):
                 self.nos.from_file(target)
                 self._rebuild()
             except Exception:
-                # Broad except, like `default()`: any plugin error must not
-                # crash the session. Roll back the partial nos mutation so the
+                # Broad except, like the dispatch core's handler guard: any
+                # plugin error must not crash the session. Roll back the partial
+                # nos mutation so the
                 # broken file does not poison subsequent reloads, then log the
                 # traceback so a genuine plugin bug stays diagnosable.
                 self.nos.commands = snapshot_commands
@@ -628,10 +613,10 @@ class CMDShell(Cmd):
     def _help_body(self) -> str:
         """Build the help listing for the current mode as body text (no I/O).
 
-        Extracted from `do_help` so the cmd.Cmd cmdloop path (telnet) and the
-        push dispatch core (#297, SSH) share one implementation. Returns the
-        lines joined by `self.newline`; the caller applies `writeline`
-        semantics (cmdloop via `do_help`, push via the session handler).
+        Called by the push `dispatch` core when the parsed command is `help`
+        (a leading `?` or a typed `help`), shared by both transports (#297 / #303
+        P3-3). Returns the lines joined by `self.newline`; the session handler
+        applies `writeline` semantics to render it.
 
         Intentional refinement over v2 (2nd round claude #2): v2 `do_help`
         read the raw unmerged entries, so an alias without its own prompt was
@@ -653,10 +638,6 @@ class CMDShell(Cmd):
             padding = " " * (width - len(k)) + "  "
             help_msg.append(f"{k}{padding}{v}")
         return self.newline.join(help_msg)
-
-    def do_help(self, arg):
-        """List help for commands valid in the current mode (cmd.Cmd cmdloop adapter)."""
-        self.writeline(self._help_body())
 
     def _apply_new_mode(self, mode_name: str, command: str) -> None:
         """Transition to `mode_name`; an unknown name keeps the current mode.
@@ -704,13 +685,13 @@ class CMDShell(Cmd):
     def _dispatch_general(self, line) -> tuple[str | None, bool]:
         """Resolve + invoke one general command; return ``(body, close)``.
 
-        The I/O-independent heart of dispatch, shared by the cmd.Cmd `default`
-        adapter (telnet cmdloop) and the push `dispatch` core (#297, SSH).
-        Applies a mode transition as a live-session side effect (§1a) but
-        writes nothing — the caller renders `body`.
+        The I/O-independent heart of dispatch, called by the push `dispatch`
+        core (#297, SSH; both transports since #303 P3-3). Applies a mode
+        transition as a live-session side effect (§1a) but writes nothing — the
+        caller renders `body`.
 
         ``close`` is True for an exit command, a handler returning ``exit``, or
-        a server shutdown observed mid-dispatch. The legacy `default`
+        a server shutdown observed mid-dispatch. The legacy `default` adapter
         suppressed the body on every one of those close paths, so callers MUST
         NOT render `body` when `close` is set.
 
@@ -720,7 +701,7 @@ class CMDShell(Cmd):
         `_apply_new_mode`), so `HANDLER_ERROR_OUTPUT` structurally means "a
         command handler crashed" and nothing else (#241 / #264).
         """
-        log.debug("shell.default '%s' running command '%s'", self.base_prompt, [line])
+        log.debug("shell.dispatch '%s' running command '%s'", self.base_prompt, [line])
         cmd = self.commands.get(line)
         # Command abbreviation (#303 / P3-2): only on an exact-match miss, so a
         # full command's wire is byte-identical (scrapers send full commands and
@@ -764,7 +745,7 @@ class CMDShell(Cmd):
                 # Keep the unknown-command trail v2 logged (observability for
                 # typo / undefined-command diagnosis); the wire answer is the
                 # same `_default_` output (2nd round claude #5).
-                log.debug("shell.default '%s' command %r not found", self.base_prompt, line)
+                log.debug("shell.dispatch '%s' command %r not found", self.base_prompt, line)
             # Unknown command and mode mismatch both answer with the `_default_`
             # output — a silent shell would make clients (e.g. Netmiko) wait for
             # a timeout. The `_default_` answer never applies a transition.
@@ -806,49 +787,55 @@ class CMDShell(Cmd):
             return body, True
         return body, False
 
-    def default(self, line):
-        """Dispatch one general command for the cmd.Cmd cmdloop (telnet path).
+    def _parseline(self, line: str) -> tuple[str | None, str | None, str]:
+        """Lex one line into ``(command, arg, line)``, replacing cmd.Cmd.parseline (#303 P3-3).
 
-        Thin adapter over `_dispatch_general` (#297): the push SSH driver calls
-        the core directly, while telnet still routes through `cmd.Cmd.cmdloop`,
-        which calls this. The body is written only when the session is not
-        closing — matching the legacy suppression of the body on every close
-        path — and the bool return drives `cmd.Cmd`'s stop handling.
+        Byte-for-byte compatible with the stdlib behaviour `dispatch` relied on:
+        strips the line, maps a leading ``?`` to ``help ...`` (drives the help
+        golden), and extracts the leading identifier as the command token. SIMNOS
+        defines no ``do_shell`` (and `dispatch` only special-cases EOF / help),
+        so a leading ``!`` yields no command and falls through to ``_default_`` —
+        exactly as cmd.Cmd did. That ``!`` branch depends on the no-``do_shell``
+        contract.
         """
-        body, close = self._dispatch_general(line)
-        if not close and body is not None:
-            self.writeline(body)
-        return close
+        line = line.strip()
+        if not line:
+            return None, None, line
+        if line[0] == "?":
+            line = "help " + line[1:]
+        elif line[0] == "!":
+            return None, None, line  # no do_shell -> falls through to the _default_ path
+        i, n = 0, len(line)
+        while i < n and line[i] in self.identchars:
+            i += 1
+        return line[:i], line[i:].strip(), line
 
     def dispatch(self, line: str) -> DispatchResult:
         """I/O-independent dispatch core for the push session driver (#297 / §3a).
 
-        Reproduces `cmd.Cmd.onecmd`'s routing (precmd -> help / EOF / empty /
-        general -> postcmd) so the SSH push session produces the same wire as
-        the telnet cmdloop path (which still routes through `cmd.Cmd`). Returns
-        a structured `DispatchResult` the session handler renders to wire bytes;
-        it never writes to stdout. Mode transitions / variant / hot-reload run
-        as today via `_dispatch_general` / `precmd`.
+        Lexes the line with `_parseline` and routes it (precmd -> help / EOF /
+        blank / general -> postcmd) so both transports (SSH asyncssh, Telnet
+        telnetlib3) produce the same wire (#303 P3-3 replaced the former cmd.Cmd
+        `onecmd`/`cmdloop` path). Returns a structured `DispatchResult` the
+        session handler renders to wire bytes; it never writes to stdout. Mode
+        transitions / variant / hot-reload run via `_dispatch_general` / `precmd`.
 
-        Only `do_EOF` / `do_help` exist on this shell, so the routing maps them
-        explicitly and sends everything else to `_dispatch_general` (the
-        `default` target). A NOS command named `help` / `EOF` stays shadowed by
-        the `do_*` method exactly as under `cmd.Cmd`.
+        The router special-cases only `EOF` (close) and `help` (current-mode
+        listing); everything else goes to `_dispatch_general`. A NOS command
+        named `help` / `EOF` stays shadowed by these explicit branches.
         """
         line = self.precmd(line)
-        cmd_name, _arg, parsed = self.parseline(line)
+        cmd_name, _arg, parsed = self._parseline(line)
         if not parsed:
-            body, close = None, False  # emptyline(): no output
+            body, close = None, False  # blank line: no output
         elif cmd_name == "EOF":
-            body, close = None, True  # do_EOF: stop
+            body, close = None, True  # EOF line: close session
         elif cmd_name == "help":
-            body, close = self._help_body(), False  # do_help (current-mode listing)
+            body, close = self._help_body(), False  # leading `?` / `help`: current-mode listing
         else:
-            body, close = self._dispatch_general(parsed)  # cmd '' or unknown do_* -> default
-        # postcmd gets the post-precmd line (pre-parseline), matching
-        # cmd.Cmd.cmdloop's `self.postcmd(stop, line)` — not the parseline-
-        # transformed `parsed` (e.g. "?" -> "help ") — so a postcmd override
-        # sees the same argument on the telnet (cmdloop) and SSH (push) paths
-        # (#297, claude#1).
+            body, close = self._dispatch_general(parsed)  # general command path
+        # postcmd gets the post-precmd line (pre-parseline) — not the
+        # parseline-transformed `parsed` (e.g. "?" -> "help ") — so a postcmd
+        # override sees the line as typed on both transports (#297, claude#1).
         close = bool(self.postcmd(close, line))
         return DispatchResult(body=body, prompt=self.prompt, close=close, mode=self.current_mode)

--- a/simnos/plugins/shell/cmd_shell.py
+++ b/simnos/plugins/shell/cmd_shell.py
@@ -150,10 +150,10 @@ class DispatchResult:
     a single ``str``, so the I/O-independent dispatch core returns the pieces
     explicitly:
 
-    - ``body``: text to render with ``writeline`` semantics, or ``None`` for no
-      output (empty line, EOF, a handler returning no ``output``). The driver
-      suppresses it when ``close`` is set — the legacy ``default`` adapter never
-      wrote a body on any close path.
+    - ``body``: text the driver renders line-by-line with ``newline``, or
+      ``None`` for no output (empty line, EOF, a handler returning no
+      ``output``). The driver suppresses it when ``close`` is set — the legacy
+      ``default`` adapter never wrote a body on any close path.
     - ``prompt``: the prompt to show after this line (already reflects a mode
       transition applied during dispatch).
     - ``close``: the session should close after this line.
@@ -178,8 +178,6 @@ class CMDShell:
 
     def __init__(
         self,
-        stdin,
-        stdout,
         nos,
         nos_inventory_config,
         base_prompt,
@@ -236,11 +234,6 @@ class CMDShell:
         if resolved_platform is None:
             resolved_platform = build_resolved_platform(self.nos, self._inventory_commands, self._render_config)
         self._apply_platform(resolved_platform)
-
-        # Hold our own stdin/stdout. These were formerly set by `cmd.Cmd.__init__`
-        # (removed with the base class in #303 P3-3); `writeline` uses `stdout`.
-        self.stdin = stdin
-        self.stdout = stdout
 
     @staticmethod
     def build_shared_platform(
@@ -401,11 +394,6 @@ class CMDShell:
         hot reload does not silently drop it (#286 / C1).
         """
         self._apply_platform(build_resolved_platform(self.nos, self._inventory_commands, self._render_config))
-
-    def writeline(self, value):
-        """Method to write a line to stdout with newline at the end"""
-        for line in str(value).splitlines():
-            self.stdout.write(line + self.newline)
 
     # `Nos` state `from_file` mutates; snapshotted per reload target so a target
     # that loads but fails to normalize can be rolled back (2nd round codex #1).
@@ -615,8 +603,8 @@ class CMDShell:
 
         Called by the push `dispatch` core when the parsed command is `help`
         (a leading `?` or a typed `help`), shared by both transports (#297 / #303
-        P3-3). Returns the lines joined by `self.newline`; the session handler
-        applies `writeline` semantics to render it.
+        P3-3). Returns the lines joined by `self.newline`; the driver renders the
+        resulting body to the wire.
 
         Intentional refinement over v2 (2nd round claude #2): v2 `do_help`
         read the raw unmerged entries, so an alias without its own prompt was
@@ -781,8 +769,8 @@ class CMDShell:
             body = body.replace("{input}", abbrev_input)
         if transition is not None:
             self._apply_new_mode(transition, line)
-        # Server shutdown observed mid-dispatch: close without writing the body
-        # (the legacy `default` returned True here before any writeline).
+        # Server shutdown observed mid-dispatch: close without rendering the body
+        # (the legacy `default` adapter returned True here before writing output).
         if not self.is_running.is_set():
             return body, True
         return body, False

--- a/tests/core/oracle_projection.py
+++ b/tests/core/oracle_projection.py
@@ -10,7 +10,8 @@ through this one function, so the snapshot and the test can never drift apart.
 history + design D7 hold the conversion record.)
 
 The projection captures the client-observable behavior: rendered output as
-``splitlines()`` (wire-equivalent — ``writeline`` absorbs trailing newlines),
+``splitlines()`` (wire-equivalent — the driver's ``_render_response`` joins each
+body line with ``newline``, absorbing trailing newlines),
 the modes a command is visible in, the transition target, exit / help, and the
 full multi-capture variant list (each variant's name + rendered body, not just
 the count — so a variant-body conversion error is caught, not only a missing

--- a/tests/core/test_netmiko_init_compat.py
+++ b/tests/core/test_netmiko_init_compat.py
@@ -228,7 +228,7 @@ def _classify_callable_commands(
     non-time reasons.
 
     The expected value is computed by invoking the callable with the
-    same 4-arg contract as `cmd_shell.default` (device, base_prompt=,
+    same 4-arg contract as `CMDShell._invoke_handler` (device, base_prompt=,
     current_prompt=, command=) and taken **verbatim** — the shell does
     not apply `.format(base_prompt=...)` to callable output (#241 /
     D-b: handlers receive base_prompt and format themselves), so the

--- a/tests/core/test_netmiko_init_compat.py
+++ b/tests/core/test_netmiko_init_compat.py
@@ -503,7 +503,7 @@ class TestShutdownEOF:
 
     @pytest.mark.timeout(30)
     def test_shell_exits_cleanly_on_server_stop(self):
-        """Shell should exit via do_EOF when server stops, no thread leaks."""
+        """Shell should exit on EOF (dispatch close branch) when server stops, no thread leaks."""
         port = get_free_port()
         net = _make_simnos("cisco_ios", port)
         try:

--- a/tests/core/test_pydantic_models.py
+++ b/tests/core/test_pydantic_models.py
@@ -7,6 +7,7 @@ from pydantic import ValidationError
 import pytest
 
 from simnos.core.pydantic_models import (
+    CMDShellConfig,
     InventoryDefaultSection,
     ModelCommandAuthoring,
     ModelHost,
@@ -167,3 +168,36 @@ class TestModelPlatformMeta:
     def test_rejects_initial_mode_not_in_modes(self):
         with pytest.raises(ValidationError, match="initial_mode"):
             ModelPlatformMeta(modes={"user": {"prompt": ">"}}, initial_mode="enable")  # ty: ignore[invalid-argument-type]
+
+
+class TestCMDShellConfig:
+    """Schema pins for the shell configuration after the cmd.Cmd removal (#303 P3-3).
+
+    `ruler` / `completekey` were cmd.Cmd cmdloop-only knobs and were removed with
+    the base class; `extra="forbid"` now rejects them (and any other unknown key)
+    at load time rather than letting them reach `CMDShell.__init__` as unexpected
+    keywords and crash at connect time. `base_prompt` stays an accepted field
+    because `Host` injects it (and inventory may override it).
+    """
+
+    def test_accepts_supported_fields(self):
+        """intro / newline / base_prompt are the surviving live knobs."""
+        cfg = CMDShellConfig(intro="hi", newline="\n", base_prompt="r1")
+        assert cfg.intro == "hi"
+        assert cfg.newline == "\n"
+        assert cfg.base_prompt == "r1"
+
+    def test_empty_config_is_valid(self):
+        """A bare `{}` (the default inventory shell config) validates."""
+        assert CMDShellConfig().base_prompt is None
+
+    @pytest.mark.parametrize("removed_key", ["ruler", "completekey"])
+    def test_rejects_removed_cmdloop_knobs(self, removed_key):
+        """The removed cmd.Cmd knobs are now loud ValidationErrors, not silent."""
+        with pytest.raises(ValidationError):
+            CMDShellConfig(**{removed_key: "x"})
+
+    def test_rejects_unknown_key(self):
+        """Any unknown key is rejected at load time (extra='forbid')."""
+        with pytest.raises(ValidationError):
+            CMDShellConfig(typo="x")  # ty: ignore[unknown-argument]  # intentional: forbid pin

--- a/tests/plugins/nos/device_helpers.py
+++ b/tests/plugins/nos/device_helpers.py
@@ -2,7 +2,7 @@
 Shared helpers for the device-class unit tests in this package (T-14 / #230).
 
 Each test_<nos>.py invokes plugin callables with the same contract as
-`cmd_shell.default` (device, base_prompt=, current_mode=, current_prompt=,
+`CMDShell._invoke_handler` (device, base_prompt=, current_mode=, current_prompt=,
 command=); this module holds that invocation and the common base_prompt so the
 per-platform files stay focused on their pins.
 """

--- a/tests/plugins/nos/test_cisco_ios.py
+++ b/tests/plugins/nos/test_cisco_ios.py
@@ -2,7 +2,7 @@
 Device-class unit tests for the cisco_ios Python plugin (T-14 / #230).
 
 Producer-side pins for the callable outputs: each callable is invoked
-with the same 4-arg contract as `cmd_shell.default` (device,
+with the same 4-arg contract as `CMDShell._invoke_handler` (device,
 base_prompt=, current_prompt=, command=). Full render comparison would
 be a tautology against the Jinja2 template, so these tests pin
 meaningful invariants instead: key substrings, `{{base_prompt}}`

--- a/tests/plugins/test_abbreviation.py
+++ b/tests/plugins/test_abbreviation.py
@@ -40,13 +40,11 @@ INCOMPLETE_DIAG = "% Incomplete command."
 SWEEP_PLATFORMS = ["cisco_ios", "arista_eos", "huawei_smartax", "juniper_junos"]
 
 
-def _shell(name: str, *, stdout=None) -> CMDShell:
+def _shell(name: str) -> CMDShell:
     """A real merged-platform shell for `name`, ready to dispatch."""
     is_running = threading.Event()
     is_running.set()  # otherwise _dispatch_general reports server shutdown
     return CMDShell(
-        stdin=None,
-        stdout=stdout,
         nos=Nos(filename=nos_plugins[name]),
         nos_inventory_config={},
         base_prompt="device",
@@ -54,7 +52,7 @@ def _shell(name: str, *, stdout=None) -> CMDShell:
     )
 
 
-def _legacy_shell(commands: dict, *, stdout=None) -> CMDShell:
+def _legacy_shell(commands: dict) -> CMDShell:
     """A legacy (3-prompt) shell built from an in-memory command dict."""
     nos = Nos()
     nos.from_dict(
@@ -69,8 +67,6 @@ def _legacy_shell(commands: dict, *, stdout=None) -> CMDShell:
     is_running = threading.Event()
     is_running.set()
     return CMDShell(
-        stdin=None,
-        stdout=stdout,
         nos=nos,
         nos_inventory_config={},
         base_prompt="device",

--- a/tests/plugins/test_abbreviation.py
+++ b/tests/plugins/test_abbreviation.py
@@ -17,7 +17,6 @@ byte-identical (the byte-parity goldens pin that separately). These tests cover:
 """
 
 import dataclasses
-import io
 import threading
 
 import pytest
@@ -309,16 +308,17 @@ def test_packaged_specials_never_transition_or_close(platform):
         assert not cmd.modes  # valid in every mode (no prompt)
 
 
-# --------------------------------------------------------------- 8. telnet + ssh paths
-def test_abbreviation_on_telnet_default_path():
-    """The cmd.Cmd `default` adapter (telnet cmdloop) shares `_dispatch_general`,
-    so abbreviation works there too — line editing stays SSH-only (pinned in
-    test_ssh_line_editor), but the resolution itself is path-independent."""
-    out = io.StringIO()
-    shell = _enable(_shell("cisco_ios", stdout=out))
-    close = shell.default("sh ver")
+# --------------------------------------------------------------- 8. shared dispatch core path
+def test_abbreviation_through_dispatch_general_core():
+    """Both transports share `_dispatch_general`, so abbreviation works on the
+    shared core regardless of transport — line editing stays SSH-only (pinned in
+    test_ssh_line_editor), but the resolution itself is path-independent
+    (cmd.Cmd `default` adapter removed in #303 P3-3)."""
+    shell = _enable(_shell("cisco_ios"))
+    body, close = shell._dispatch_general("sh ver")
     assert close is False
-    assert "Cisco IOS" in out.getvalue()
+    assert body is not None
+    assert "Cisco IOS" in body
 
 
 def test_abbreviation_on_ssh_dispatch_path():

--- a/tests/plugins/test_abbreviation.py
+++ b/tests/plugins/test_abbreviation.py
@@ -13,7 +13,7 @@ byte-identical (the byte-parity goldens pin that separately). These tests cover:
 7. the ``_ambiguous_`` / ``_incomplete_`` specials are overridable and flow
    through the normal dispatch pipeline (handler override is None-safe, and the
    specials never transition or close);
-8. abbreviation works on the telnet (``default``) and SSH (``dispatch``) paths.
+8. abbreviation works on the shared ``_dispatch_general`` core both transports use.
 """
 
 import dataclasses

--- a/tests/plugins/test_cmd_shell.py
+++ b/tests/plugins/test_cmd_shell.py
@@ -40,8 +40,6 @@ def _nos_from_yaml_asset(path: str = "tests/assets/yaml_nos.yaml") -> Nos:
 def make_cmd_shell_args() -> dict:
     """Build the CMDShell constructor kwargs shared across cmd_shell tests (SSoT)."""
     return {
-        "stdin": None,
-        "stdout": None,
         "nos": _nos_from_yaml_asset(),
         "nos_inventory_config": {},
         "base_prompt": "test",
@@ -134,6 +132,18 @@ def test_parseline_matches_stdlib_oracle(cmd_shell_args, line):
     assert shell._parseline(line) == cmd.Cmd().parseline(line)
 
 
+def test_no_do_shell_keeps_bang_fall_through():
+    """CMDShell defines no `do_shell`, which `_parseline`'s `!` branch relies on (#303 P3-3).
+
+    `_parseline` maps a leading `!` to `(None, None, line)` (fall-through to
+    `_default_`) precisely because there is no `do_shell` to route to, and
+    `dispatch` special-cases only EOF / help. This guards that contract: the
+    oracle test compares against a bare `cmd.Cmd()`, so a `do_shell` added to
+    CMDShell would silently change the `!` wire without failing it.
+    """
+    assert not hasattr(CMDShell, "do_shell")
+
+
 # pylint: disable=too-many-public-methods
 class TestCmdShell(TestCase):
     """Test the CmdShell class."""
@@ -187,13 +197,6 @@ class TestCmdShell(TestCase):
         )
         with self.assertRaises(ValueError):
             CMDShell(**self.arguments)
-
-    def test_writeline(self):
-        """Test that the writeline method writes a line to stdout with a newline at the end."""
-        shell = CMDShell(**self.arguments)
-        stdout = set_attr(shell, "stdout", Mock())
-        shell.writeline("test")
-        stdout.write.assert_called_once_with("test\r\n")
 
     def test_dispatch_blank_line_no_output(self):
         """A blank line dispatches to no output and does not close (was test_emptyline).

--- a/tests/plugins/test_cmd_shell.py
+++ b/tests/plugins/test_cmd_shell.py
@@ -2,6 +2,7 @@
 Module to test the cmd_shell plugin.
 """
 
+import cmd
 import importlib
 import os
 import shutil
@@ -55,11 +56,12 @@ def cmd_shell_args():
 
 
 def _expected_baseline(args: dict) -> dict:
-    """Attribute values a CMDShell takes with no optional kwargs."""
+    """Attribute values a CMDShell takes with no optional kwargs.
+
+    `ruler` / `completekey` were removed with the cmd.Cmd base in #303 P3-3.
+    """
     return {
         "intro": "Custom SSH Shell",
-        "ruler": "",
-        "completekey": "tab",
         "newline": "\r\n",
         "prompt": "test>",
         "base_prompt": args["base_prompt"],
@@ -71,25 +73,19 @@ def _expected_baseline(args: dict) -> dict:
     [
         ({}, {}),  # no optional kwargs (baseline)
         ({"intro": "Test Intro"}, {"intro": "Test Intro"}),
-        ({"ruler": "Test Ruler"}, {"ruler": "Test Ruler"}),
-        ({"completekey": "Test Completekey"}, {"completekey": "Test Completekey"}),
         ({"newline": "Test Newline"}, {"newline": "Test Newline"}),
         (
             {
                 "intro": "Test Intro",
-                "ruler": "Test Ruler",
-                "completekey": "Test Completekey",
                 "newline": "Test Newline",
             },
             {
                 "intro": "Test Intro",
-                "ruler": "Test Ruler",
-                "completekey": "Test Completekey",
                 "newline": "Test Newline",
             },
         ),
     ],
-    ids=["baseline", "intro", "ruler", "completekey", "newline", "all"],
+    ids=["baseline", "intro", "newline", "all"],
 )
 def test_init_kwargs(cmd_shell_args, override_kwargs, expected_override):
     """baseline + each optional kwarg; untouched attrs stay at their defaults."""
@@ -101,6 +97,41 @@ def test_init_kwargs(cmd_shell_args, override_kwargs, expected_override):
     assert shell.is_running is cmd_shell_args["is_running"]
     assert shell.nos is cmd_shell_args["nos"]
     assert shell.commands != {}
+
+
+@pytest.mark.parametrize(
+    "line",
+    [
+        "",
+        "   ",
+        "\t",
+        "show version",
+        "show  version",
+        "sh ver",
+        "?",
+        "?show version",
+        "? show version",
+        "!foo",
+        "! foo",
+        "/foo",
+        "-x",
+        "1cmd",
+        "show-version",
+        "show ?",
+        "EOF",
+        "exit\r",
+    ],
+)
+def test_parseline_matches_stdlib_oracle(cmd_shell_args, line):
+    """`_parseline` stays byte-identical to the cmd.Cmd.parseline it replaced (#303 P3-3).
+
+    Production no longer depends on stdlib `cmd`; this test imports it only as a
+    reference oracle so any drift from the historical lexing contract (strip,
+    leading ``?`` -> ``help ``, no-``do_shell`` ``!`` fall-through, identchars
+    scan) fails loudly. SIMNOS defines no `do_shell`, matching a bare `cmd.Cmd()`.
+    """
+    shell = CMDShell(**cmd_shell_args)
+    assert shell._parseline(line) == cmd.Cmd().parseline(line)
 
 
 # pylint: disable=too-many-public-methods
@@ -157,20 +188,6 @@ class TestCmdShell(TestCase):
         with self.assertRaises(ValueError):
             CMDShell(**self.arguments)
 
-    def test_start(self):
-        """Test that the start method calls cmdloop."""
-        shell = CMDShell(**self.arguments)
-        mock_cmdloop = set_attr(shell, "cmdloop", Mock())
-        shell.start()
-        mock_cmdloop.assert_called_once()
-
-    def test_stop(self):
-        """Test that the stop method writes "exit" to stdin."""
-        shell = CMDShell(**self.arguments)
-        stdin = set_attr(shell, "stdin", Mock())
-        shell.stop()
-        stdin.write.assert_called_once_with("exit\r\n")
-
     def test_writeline(self):
         """Test that the writeline method writes a line to stdout with a newline at the end."""
         shell = CMDShell(**self.arguments)
@@ -178,11 +195,17 @@ class TestCmdShell(TestCase):
         shell.writeline("test")
         stdout.write.assert_called_once_with("test\r\n")
 
-    def test_emptyline(self):
-        """Test that the emptyline method does nothing."""
+    def test_dispatch_blank_line_no_output(self):
+        """A blank line dispatches to no output and does not close (was test_emptyline).
+
+        The cmd.Cmd `emptyline` hook was removed in #303 P3-3; `dispatch` now
+        handles the empty case via `_parseline` returning a falsy parsed line.
+        """
         shell = CMDShell(**self.arguments)
-        result = shell.emptyline()
-        self.assertIsNone(result)
+        shell.is_running.set()
+        result = shell.dispatch("")
+        self.assertIsNone(result.body)
+        self.assertFalse(result.close)
 
     def test_precmd(self):
         """Test that the precmd method returns the line."""
@@ -214,11 +237,13 @@ class TestCmdShell(TestCase):
         shell = CMDShell(**self.arguments)
         self.assertEqual(shell.postcmd(False, ""), False)
 
-    def test_do_help(self):
-        """Test that the do_help method writes the help message to stdout."""
+    def test_help_body(self):
+        """`_help_body` builds the current-mode help listing (was do_help).
+
+        `do_help` was removed in #303 P3-3; `dispatch` calls `_help_body`
+        directly when the parsed command is `help` (a leading `?` or `help`).
+        """
         shell = CMDShell(**self.arguments)
-        writeline = set_attr(shell, "writeline", Mock())
-        shell.do_help("")
         expected_output: list[str] = [
             "exit                Exit commands shell",
             "enable              enter exec prompt",
@@ -227,10 +252,10 @@ class TestCmdShell(TestCase):
             "terminal width 511  Set terminal width to 511",
             "terminal length 0   Set terminal length to 0",
         ]
-        writeline.assert_called_once_with("\r\n".join(expected_output))
+        self.assertEqual(shell._help_body(), "\r\n".join(expected_output))
 
-    def test_do_help_alias_hidden_outside_target_modes(self):
-        """do_help lists a prompt-less alias only in its target modes (#264 / claude #2).
+    def test_help_body_alias_hidden_outside_target_modes(self):
+        """`_help_body` lists a prompt-less alias only in its target modes (#264 / claude #2).
 
         Intentional refinement over v2 (which listed prompt-less aliases in
         every mode via the raw unmerged entry): `sh clock` aliases `show clock`
@@ -238,13 +263,9 @@ class TestCmdShell(TestCase):
         Dispatch was already mode-scoped in v2; only the help listing changes.
         """
         shell = CMDShell(**self.arguments)  # current_mode == "user"
-        writeline = set_attr(shell, "writeline", Mock())
-        shell.do_help("")
-        self.assertIn("sh clock", writeline.call_args[0][0])
+        self.assertIn("sh clock", shell._help_body())
         shell.current_mode = "config"
-        writeline.reset_mock()
-        shell.do_help("")
-        self.assertNotIn("sh clock", writeline.call_args[0][0])
+        self.assertNotIn("sh clock", shell._help_body())
 
     def test__in_current_mode_empty_modes_always_visible(self):
         """A command with no declared modes is valid in every mode (#264 / D5).
@@ -273,36 +294,36 @@ class TestCmdShell(TestCase):
         shell.current_mode = "config"
         self.assertFalse(shell._in_current_mode(clock))
 
-    def test_default_command_correct(self):
-        """Test that the default method does nothing."""
+    def test_dispatch_general_command_correct(self):
+        """A known command returns its rendered body and does not close (was default)."""
         self.arguments["is_running"].set()
         shell = CMDShell(**self.arguments)
-        writeline = set_attr(shell, "writeline", Mock())
-        shell.default("show clock")
-        writeline.assert_called_once_with("*21:01:33.000 AET 01 01 01 2022")
+        body, close = shell._dispatch_general("show clock")
+        self.assertEqual(body, "*21:01:33.000 AET 01 01 01 2022")
+        self.assertFalse(close)
 
-    def test_default_command_with_alias(self):
-        """Test that the default method does nothing."""
+    def test_dispatch_general_command_with_alias(self):
+        """An alias resolves to the same body as its target (was default)."""
         self.arguments["is_running"].set()
         shell = CMDShell(**self.arguments)
-        writeline = set_attr(shell, "writeline", Mock())
-        shell.default("sh clock")
-        writeline.assert_called_once_with("*21:01:33.000 AET 01 01 01 2022")
+        body, close = shell._dispatch_general("sh clock")
+        self.assertEqual(body, "*21:01:33.000 AET 01 01 01 2022")
+        self.assertFalse(close)
 
-    def test_default_command_is_function(self):
-        """Test that the default method does nothing."""
+    def test_dispatch_general_command_is_function(self):
+        """A callable-output command returns its computed body (was default)."""
         self.arguments["is_running"].set()
         self.arguments["nos"] = Nos(filename="tests/assets/module.py")
         shell = CMDShell(**self.arguments)
-        writeline = set_attr(shell, "writeline", Mock())
-        shell.default("show clock")
-        writeline.assert_called_once_with(time.ctime())
+        body, close = shell._dispatch_general("show clock")
+        self.assertEqual(body, time.ctime())
+        self.assertFalse(close)
 
     def _make_callable_dict_shell(self, output_callable):
         """Build a shell whose 'cmd' command output is `output_callable`.
 
-        Consumer-side pins for the handler dispatch branch of `default()` —
-        the dict-returning cases (new_mode transition / exit / output
+        Consumer-side pins for the handler dispatch branch of `_dispatch_general`
+        — the dict-returning cases (new_mode transition / exit / output
         extraction, the counterpart of the producer-side device-class tests
         in tests/plugins/nos/, T-14 / #230), plus the str-passthrough (D-b)
         and crash (D4) pins. The synthetic platform declares all three
@@ -328,26 +349,24 @@ class TestCmdShell(TestCase):
         shell = CMDShell(**self.arguments)
         return shell
 
-    def test_default_callable_dict_new_mode(self):
+    def test_dispatch_callable_dict_new_mode(self):
         """Callable dict with new_mode transitions the shell to that mode."""
         shell = self._make_callable_dict_shell(lambda device, **kwargs: {"output": "", "new_mode": "enable"})
-        writeline = set_attr(shell, "writeline", Mock())
-        stop = shell.default("cmd")
-        self.assertFalse(stop)
+        body, close = shell._dispatch_general("cmd")
+        self.assertFalse(close)
         self.assertEqual(shell.current_mode, "enable")
         self.assertEqual(shell.prompt, "test#")
-        writeline.assert_called_once_with("")
+        self.assertEqual(body, "")
 
-    def test_default_callable_dict_unknown_new_mode_is_lenient(self):
+    def test_dispatch_callable_dict_unknown_new_mode_is_lenient(self):
         """A handler returning an unknown mode logs and stays put (#264 / D5)."""
         shell = self._make_callable_dict_shell(lambda device, **kwargs: {"output": "body", "new_mode": "nope"})
-        writeline = set_attr(shell, "writeline", Mock())
         with self.assertLogs("simnos.plugins.shell.cmd_shell", level="ERROR") as captured:
-            stop = shell.default("cmd")
-        self.assertFalse(stop)
+            body, close = shell._dispatch_general("cmd")
+        self.assertFalse(close)
         self.assertEqual(shell.current_mode, "user")  # unchanged
         self.assertTrue(any("unknown mode 'nope'" in msg for msg in captured.output))
-        writeline.assert_called_once_with("body")
+        self.assertEqual(body, "body")
 
     def test_default_static_new_mode_wins_over_handler(self):
         """A command's static new_mode overrides a handler-returned one (#264 / claude #8).
@@ -373,26 +392,28 @@ class TestCmdShell(TestCase):
             }
         )
         shell = CMDShell(**self.arguments)
-        set_attr(shell, "writeline", Mock())
-        shell.default("cmd")
+        shell._dispatch_general("cmd")
         self.assertEqual(shell.current_mode, "enable")  # static new_mode, not handler's "config"
 
-    def test_default_callable_dict_exit(self):
-        """Callable dict with exit=True signals shell termination."""
-        shell = self._make_callable_dict_shell(lambda device, **kwargs: {"exit": True})
-        writeline = set_attr(shell, "writeline", Mock())
-        stop = shell.default("cmd")
-        self.assertTrue(stop)
-        writeline.assert_not_called()
+    def test_dispatch_callable_dict_exit(self):
+        """Callable dict with exit=True closes with no body (was default suppression).
 
-    def test_default_callable_dict_output_only(self):
-        """Callable dict with output only writes it, prompt unchanged."""
+        The exit path returns `(None, True)`, so there is no body to suppress —
+        the close-time body-suppression contract itself lives in the driver and
+        is pinned by the byte-parity goldens (#303 P3-3).
+        """
+        shell = self._make_callable_dict_shell(lambda device, **kwargs: {"exit": True})
+        body, close = shell._dispatch_general("cmd")
+        self.assertTrue(close)
+        self.assertIsNone(body)
+
+    def test_dispatch_callable_dict_output_only(self):
+        """Callable dict with output only returns it, prompt unchanged."""
         shell = self._make_callable_dict_shell(lambda device, **kwargs: {"output": "dynamic body"})
-        writeline = set_attr(shell, "writeline", Mock())
-        stop = shell.default("cmd")
-        self.assertFalse(stop)
+        body, close = shell._dispatch_general("cmd")
+        self.assertFalse(close)
         self.assertEqual(shell.prompt, "test>")
-        writeline.assert_called_once_with("dynamic body")
+        self.assertEqual(body, "dynamic body")
 
     def _make_prompt_form_shell(self, prompt_value):
         """Build a shell whose 'cmd' command uses the given `prompt` authoring form.
@@ -419,21 +440,19 @@ class TestCmdShell(TestCase):
         shell = CMDShell(**self.arguments)
         return shell
 
-    def test_default_prompt_str_authoring_dispatches(self):
+    def test_dispatch_prompt_str_authoring_dispatches(self):
         """A bare-str `prompt` resolves to the current mode and dispatches."""
         shell = self._make_prompt_form_shell("{base_prompt}>")
-        writeline = set_attr(shell, "writeline", Mock())
-        stop = shell.default("cmd")
-        self.assertFalse(stop)
-        writeline.assert_called_once_with("form ok")
+        body, close = shell._dispatch_general("cmd")
+        self.assertFalse(close)
+        self.assertEqual(body, "form ok")
 
-    def test_default_prompt_list_authoring_dispatches(self):
+    def test_dispatch_prompt_list_authoring_dispatches(self):
         """A list `prompt` resolves to a mode set including the current mode."""
         shell = self._make_prompt_form_shell(["{base_prompt}>", "{base_prompt}#"])
-        writeline = set_attr(shell, "writeline", Mock())
-        stop = shell.default("cmd")
-        self.assertFalse(stop)
-        writeline.assert_called_once_with("form ok")
+        body, close = shell._dispatch_general("cmd")
+        self.assertFalse(close)
+        self.assertEqual(body, "form ok")
 
     def test_inventory_commands_resolve_through_adapter_and_dispatch(self):
         """Inventory-defined commands are normalized through the adapter too.
@@ -453,29 +472,26 @@ class TestCmdShell(TestCase):
             },
         }
         shell = CMDShell(**self.arguments)
-        writeline = set_attr(shell, "writeline", Mock())
         # The inventory command is normalized through the adapter like any
         # inflow: its "{base_prompt}>" prompt resolves to the user mode.
         self.assertEqual(shell.commands["inv cmd"].modes, frozenset({"user"}))
-        stop = shell.default("inv cmd")
-        self.assertFalse(stop)
-        writeline.assert_called_once_with("inventory ok")
+        body, close = shell._dispatch_general("inv cmd")
+        self.assertFalse(close)
+        self.assertEqual(body, "inventory ok")
 
-    def test_default_command_not_matching_prompt(self):
-        """Test that the default method does nothing."""
+    def test_dispatch_command_not_matching_prompt(self):
+        """A command not valid in the current mode answers with `_default_`."""
         self.arguments["is_running"].set()
         shell = CMDShell(**self.arguments)
-        writeline = set_attr(shell, "writeline", Mock())
-        shell.default("show version")
-        writeline.assert_called_once_with("% Invalid input detected at '^' marker.")
+        body, _close = shell._dispatch_general("show version")
+        self.assertEqual(body, "% Invalid input detected at '^' marker.")
 
-    def test_default_command_incorrect(self):
-        """Test that the default method does nothing."""
+    def test_dispatch_command_incorrect(self):
+        """An unknown command answers with the `_default_` output."""
         self.arguments["is_running"].set()
         shell = CMDShell(**self.arguments)
-        writeline = set_attr(shell, "writeline", Mock())
-        shell.default("test")
-        writeline.assert_called_once_with("% Invalid input detected at '^' marker.")
+        body, _close = shell._dispatch_general("test")
+        self.assertEqual(body, "% Invalid input detected at '^' marker.")
 
     def test_default_alias_target_missing_falls_back_default(self):
         """An alias whose target command is gone degrades to `_default_`.
@@ -498,9 +514,8 @@ class TestCmdShell(TestCase):
             )
             shell = CMDShell(**self.arguments)
         self.assertNotIn("broken alias", shell.commands)
-        writeline = set_attr(shell, "writeline", Mock())
-        shell.default("broken alias")
-        writeline.assert_called_once_with("% Invalid input")
+        body, _close = shell._dispatch_general("broken alias")
+        self.assertEqual(body, "% Invalid input")
 
     def test_invoke_handler_str_return_normalized(self):
         """`_invoke_handler` wraps a str return into a CommandResult dict.
@@ -568,25 +583,23 @@ class TestCmdShell(TestCase):
         shell = CMDShell(**self.arguments)
         return shell
 
-    def test_default_callable_default_invoked_on_unknown_command(self):
+    def test_dispatch_callable_default_invoked_on_unknown_command(self):
         """An unknown command invokes a callable `_default_` (#241)."""
         shell = self._make_callable_default_shell()
-        writeline = set_attr(shell, "writeline", Mock())
-        stop = shell.default("nope")
-        self.assertFalse(stop)
-        writeline.assert_called_once_with("dynamic unknown: nope")
+        body, close = shell._dispatch_general("nope")
+        self.assertFalse(close)
+        self.assertEqual(body, "dynamic unknown: nope")
 
-    def test_default_callable_default_invoked_on_mode_mismatch(self):
+    def test_dispatch_callable_default_invoked_on_mode_mismatch(self):
         """A mode mismatch invokes a callable `_default_` (#241 / #264).
 
         `known` is enable-only; typed in user mode it misses, and the fallback
         invokes the callable `_default_` through `_invoke_handler`.
         """
         shell = self._make_callable_default_shell()
-        writeline = set_attr(shell, "writeline", Mock())
-        stop = shell.default("known")  # valid only in enable, current mode is user
-        self.assertFalse(stop)
-        writeline.assert_called_once_with("dynamic unknown: known")
+        body, close = shell._dispatch_general("known")  # valid only in enable, current mode is user
+        self.assertFalse(close)
+        self.assertEqual(body, "dynamic unknown: known")
 
     def test_default_callable_default_dict_return_gets_full_dispatch(self):
         """A dict-returning callable `_default_` gets the same dispatch (#241 / #264).
@@ -610,12 +623,11 @@ class TestCmdShell(TestCase):
             }
         )
         shell = CMDShell(**self.arguments)
-        writeline = set_attr(shell, "writeline", Mock())
-        stop = shell.default("nope")
-        self.assertFalse(stop)
+        body, close = shell._dispatch_general("nope")
+        self.assertFalse(close)
         self.assertEqual(shell.current_mode, "enable")
         self.assertEqual(shell.prompt, "test#")
-        writeline.assert_called_once_with("locked out")
+        self.assertEqual(body, "locked out")
 
     def test_default_handler_crash_writes_fixed_error_line(self):
         """A crashing handler answers with HANDLER_ERROR_OUTPUT only.
@@ -630,11 +642,10 @@ class TestCmdShell(TestCase):
             raise RuntimeError("boom")
 
         shell = self._make_callable_dict_shell(crash)
-        writeline = set_attr(shell, "writeline", Mock())
         with self.assertLogs("simnos.plugins.shell.cmd_shell", level="ERROR"):
-            stop = shell.default("cmd")
-        self.assertFalse(stop)
-        writeline.assert_called_once_with(HANDLER_ERROR_OUTPUT)
+            body, close = shell._dispatch_general("cmd")
+        self.assertFalse(close)
+        self.assertEqual(body, HANDLER_ERROR_OUTPUT)
 
     def test_default_handler_crash_logs_full_traceback(self):
         """A crashing handler's traceback goes to the server log.
@@ -649,12 +660,10 @@ class TestCmdShell(TestCase):
             raise RuntimeError("boom-for-log")
 
         shell = self._make_callable_dict_shell(crash)
-        # crash-path guard: default() writes HANDLER_ERROR_OUTPUT via writeline,
-        # and stdout is None, so writeline must be mocked even though this test
-        # only asserts on the log (return unused → bare set_attr).
-        set_attr(shell, "writeline", Mock())
+        # `_dispatch_general` returns (body, close) without writing, so no
+        # writeline mock is needed; this test only asserts on the log.
         with self.assertLogs("simnos.plugins.shell.cmd_shell", level="ERROR") as captured:
-            shell.default("cmd")
+            shell._dispatch_general("cmd")
         self.assertEqual(len(captured.output), 1)
         self.assertIn("handler crashed", captured.output[0])
         self.assertIn("RuntimeError: boom-for-log", captured.output[0])
@@ -668,11 +677,10 @@ class TestCmdShell(TestCase):
         output, hence **no error log**. Holds for dict and str returns alike.
         """
         shell = self._make_callable_dict_shell(lambda device, **kwargs: {"output": "value is {base_prompt.foo}"})
-        writeline = set_attr(shell, "writeline", Mock())
         with self.assertNoLogs("simnos.plugins.shell.cmd_shell", level="ERROR"):
-            stop = shell.default("cmd")
-        self.assertFalse(stop)
-        writeline.assert_called_once_with("value is {base_prompt.foo}")
+            body, close = shell._dispatch_general("cmd")
+        self.assertFalse(close)
+        self.assertEqual(body, "value is {base_prompt.foo}")
 
     def test_default_callable_str_output_passed_through_unformatted(self):
         """Callable str output is written verbatim too (#241 / D-b).
@@ -682,11 +690,10 @@ class TestCmdShell(TestCase):
         wire untouched, with no render step and no error log.
         """
         shell = self._make_callable_dict_shell(lambda device, **kwargs: "literal {brace} stays")
-        writeline = set_attr(shell, "writeline", Mock())
         with self.assertNoLogs("simnos.plugins.shell.cmd_shell", level="ERROR"):
-            stop = shell.default("cmd")
-        self.assertFalse(stop)
-        writeline.assert_called_once_with("literal {brace} stays")
+            body, close = shell._dispatch_general("cmd")
+        self.assertFalse(close)
+        self.assertEqual(body, "literal {brace} stays")
 
     def test_default_command_transitions_mode(self):
         """A command with a new_mode transitions the shell and re-renders the prompt.
@@ -697,22 +704,22 @@ class TestCmdShell(TestCase):
         """
         self.arguments["is_running"].set()
         shell = CMDShell(**self.arguments)
-        set_attr(shell, "writeline", Mock())  # stdout is None; guard only
-        shell.default("enable")
+        shell._dispatch_general("enable")
         self.assertEqual(shell.current_mode, "enable")
         self.assertEqual(shell.prompt, "test#")
 
-    def test_default_command_exit(self):
-        """Test that the default method does nothing."""
+    def test_dispatch_command_exit(self):
+        """An exit command closes the session (was default returning True)."""
         self.arguments["is_running"].set()
         shell = CMDShell(**self.arguments)
-        self.assertTrue(shell.default("exit"))
+        _body, close = shell._dispatch_general("exit")
+        self.assertTrue(close)
 
-    def test_do_eof(self):
-        """Test that do_EOF returns True to exit cmdloop gracefully."""
+    def test_dispatch_eof_closes_session(self):
+        """`dispatch("EOF")` closes the session (was do_EOF returning True)."""
         self.arguments["is_running"].set()
         shell = CMDShell(**self.arguments)
-        self.assertTrue(shell.do_EOF(""))
+        self.assertTrue(shell.dispatch("EOF").close)
 
 
 class HotReloadTest(TestCase):
@@ -908,21 +915,3 @@ class HotReloadTest(TestCase):
                 assert output == "test output"
             finally:
                 undo_change_file()
-
-
-def test_dispatch_router_assumes_only_eof_and_help_do_methods():
-    """Pin the do_* method set the push `dispatch()` router hardcodes (#297, claude#2).
-
-    `CMDShell.dispatch()` reproduces `cmd.Cmd.onecmd` routing by handling
-    `do_EOF` / `do_help` by name and sending everything else to
-    `_dispatch_general` (the `default` target). A newly added `do_*` method would
-    be invoked by the telnet cmdloop (`cmd.Cmd.onecmd` -> `getattr`) but fall
-    through to `_dispatch_general` on the SSH push path, silently diverging the
-    wire. This guard fails loudly so the new method's routing must be added to
-    `dispatch()` alongside it.
-    """
-    do_methods = {m for m in dir(CMDShell) if m.startswith("do_")}
-    assert do_methods == {"do_EOF", "do_help"}, (
-        f"CMDShell gained do_* method(s) {do_methods - {'do_EOF', 'do_help'}}; "
-        f"add their routing to CMDShell.dispatch() (#297) and update this pin."
-    )

--- a/tests/plugins/test_cmd_shell.py
+++ b/tests/plugins/test_cmd_shell.py
@@ -368,7 +368,7 @@ class TestCmdShell(TestCase):
         self.assertTrue(any("unknown mode 'nope'" in msg for msg in captured.output))
         self.assertEqual(body, "body")
 
-    def test_default_static_new_mode_wins_over_handler(self):
+    def test_dispatch_static_new_mode_wins_over_handler(self):
         """A command's static new_mode overrides a handler-returned one (#264 / claude #8).
 
         Replicates v2's write order (handler new_prompt applied first, the
@@ -493,7 +493,7 @@ class TestCmdShell(TestCase):
         body, _close = shell._dispatch_general("test")
         self.assertEqual(body, "% Invalid input detected at '^' marker.")
 
-    def test_default_alias_target_missing_falls_back_default(self):
+    def test_dispatch_alias_target_missing_falls_back_default(self):
         """An alias whose target command is gone degrades to `_default_`.
 
         The adapter drops a broken alias at load (logged), so it never reaches
@@ -601,7 +601,7 @@ class TestCmdShell(TestCase):
         self.assertFalse(close)
         self.assertEqual(body, "dynamic unknown: known")
 
-    def test_default_callable_default_dict_return_gets_full_dispatch(self):
+    def test_dispatch_callable_default_dict_return_gets_full_dispatch(self):
         """A dict-returning callable `_default_` gets the same dispatch (#241 / #264).
 
         Pins that the unification is complete: a callable `_default_` flows
@@ -629,7 +629,7 @@ class TestCmdShell(TestCase):
         self.assertEqual(shell.prompt, "test#")
         self.assertEqual(body, "locked out")
 
-    def test_default_handler_crash_writes_fixed_error_line(self):
+    def test_dispatch_handler_crash_writes_fixed_error_line(self):
         """A crashing handler answers with HANDLER_ERROR_OUTPUT only.
 
         Pins #241/D4: real NOSes never print Python tracebacks, and the
@@ -647,7 +647,7 @@ class TestCmdShell(TestCase):
         self.assertFalse(close)
         self.assertEqual(body, HANDLER_ERROR_OUTPUT)
 
-    def test_default_handler_crash_logs_full_traceback(self):
+    def test_dispatch_handler_crash_logs_full_traceback(self):
         """A crashing handler's traceback goes to the server log.
 
         Pins #241/D4 (the diagnosability half): dropping the wire
@@ -669,7 +669,7 @@ class TestCmdShell(TestCase):
         self.assertIn("RuntimeError: boom-for-log", captured.output[0])
         self.assertIn("Traceback", captured.output[0])
 
-    def test_default_callable_dict_output_passed_through_unformatted(self):
+    def test_dispatch_callable_dict_output_passed_through_unformatted(self):
         """Callable-dict output is written verbatim, never re-rendered (#241 / D-b).
 
         Handlers render themselves, so brace-containing device output reaches
@@ -682,7 +682,7 @@ class TestCmdShell(TestCase):
         self.assertFalse(close)
         self.assertEqual(body, "value is {base_prompt.foo}")
 
-    def test_default_callable_str_output_passed_through_unformatted(self):
+    def test_dispatch_callable_str_output_passed_through_unformatted(self):
         """Callable str output is written verbatim too (#241 / D-b).
 
         The str-return twin of the dict pin above: literal braces in a
@@ -695,7 +695,7 @@ class TestCmdShell(TestCase):
         self.assertFalse(close)
         self.assertEqual(body, "literal {brace} stays")
 
-    def test_default_command_transitions_mode(self):
+    def test_dispatch_command_transitions_mode(self):
         """A command with a new_mode transitions the shell and re-renders the prompt.
 
         `enable` (yaml_nos) declares new_mode=enable; dispatching it from the

--- a/tests/plugins/test_cmd_shell.py
+++ b/tests/plugins/test_cmd_shell.py
@@ -739,7 +739,7 @@ class HotReloadTest(TestCase):
             os.environ.pop("SIMNOS_RELOAD_COMMANDS")
 
     def test_hot_reload_not_activated_doesnt_enter(self):
-        """Test that the if is not set  hot_reload method does nothing."""
+        """Test that precmd's hot-reload branch is skipped when SIMNOS_RELOAD_COMMANDS is unset."""
         os.environ.pop("SIMNOS_RELOAD_COMMANDS")
         shell = CMDShell(**self.arguments)
         mock_get_files_changed = set_attr(shell, "get_files_changed", Mock())

--- a/tests/plugins/test_cmd_shell_a3.py
+++ b/tests/plugins/test_cmd_shell_a3.py
@@ -56,8 +56,6 @@ def _a3_platform(tmp_path, *, auth=None):
 
 def _shell_for(nos, *, inventory_config=None):
     return CMDShell(
-        stdin=None,
-        stdout=None,
         nos=nos,
         nos_inventory_config=inventory_config or {},
         base_prompt="R1",
@@ -146,8 +144,6 @@ class TestShellA3Path:
         nos = Nos(filename=str(_a3_platform(tmp_path)))
         shared = build_resolved_platform(nos, {})
         shell = CMDShell(
-            stdin=None,
-            stdout=None,
             nos=nos,
             nos_inventory_config={},
             base_prompt="R1",

--- a/tests/plugins/test_cmd_shell_a3.py
+++ b/tests/plugins/test_cmd_shell_a3.py
@@ -390,7 +390,7 @@ class TestA3HotReload:
         """A reload that drops the current mode resets the session to initial_mode."""
         platform_dir = _a3_platform(tmp_path)
         shell = _shell_for(Nos(filename=str(platform_dir)))
-        shell.default("enable")
+        shell._dispatch_general("enable")
         assert shell.current_mode == "enable"
         # Rewrite the platform as user-only (and retarget/remove the commands
         # that referenced the enable mode, so the reload itself succeeds).

--- a/tests/plugins/test_variant_selection.py
+++ b/tests/plugins/test_variant_selection.py
@@ -67,10 +67,13 @@ def _running_event():
 
 
 def _served(shell, line="show test"):
-    """Dispatch a line and return the wire text the shell wrote."""
-    shell.stdout = io.StringIO()
-    shell.default(line)
-    return shell.stdout.getvalue()
+    """Dispatch a line through the shared core and return its rendered body.
+
+    `default` was removed in #303 P3-3; `_dispatch_general` returns the body the
+    shell would have written (variant outputs here are single-line).
+    """
+    body, _close = shell._dispatch_general(line)
+    return body or ""
 
 
 class TestIntSelect:

--- a/tests/plugins/test_variant_selection.py
+++ b/tests/plugins/test_variant_selection.py
@@ -10,7 +10,6 @@ The shell is built directly against tmp A3 platforms (the real tree is never
 mutated), mirroring `test_cmd_shell_a3.py`.
 """
 
-import io
 import threading
 
 import pytest
@@ -50,8 +49,6 @@ def _platform_with_variants(tmp_path, *, n=3, extra_yaml: dict[str, str] | None 
 def _shell(nos, *, policy=None, host_name="R1", base_prompt="R1"):
     render_config = HostRenderConfig(variants_policy=policy, host_name=host_name)
     return CMDShell(
-        stdin=None,
-        stdout=io.StringIO(),
         nos=nos,
         nos_inventory_config={},
         base_prompt=base_prompt,

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -205,19 +205,19 @@ def set_attr[T](obj: object, name: str, value: T) -> T:
 
     For tests only — it deliberately bypasses static type checks, so do not use
     it in production code. Tests mock attributes that are typed as methods
-    (e.g. ``shell.writeline``), which ty rejects on plain assignment and ruff
-    B010 rejects via ``setattr(obj, "literal", ...)``. Routing the assignment
-    through this helper (variable ``name`` → not B010; ``obj: object`` → ty
-    accepts) sidesteps both.
+    (e.g. ``shell.get_files_changed``), which ty rejects on plain assignment and
+    ruff B010 rejects via ``setattr(obj, "literal", ...)``. Routing the
+    assignment through this helper (variable ``name`` → not B010; ``obj: object``
+    → ty accepts) sidesteps both.
 
     ``value`` is generic so a single helper covers every test assignment:
     ``Mock()``, ``Mock(side_effect=...)``, a plain function, or a dict literal.
 
     Two call styles are both intended:
-    - bound: ``wl = set_attr(shell, "writeline", Mock())`` then ``wl.assert_*``
-      — the ``-> T`` return drops the access-side ``cast(Mock, ...)``.
-    - bare: ``set_attr(shell, "writeline", Mock())`` — return ignored, used when
-      the mock only guards a side effect (e.g. stdout=None) and is not asserted.
+    - bound: ``m = set_attr(shell, "get_files_changed", Mock())`` then
+      ``m.assert_*`` — the ``-> T`` return drops the access-side ``cast(Mock, ...)``.
+    - bare: ``set_attr(shell.nos, "from_file", Mock(side_effect=...))`` — return
+      ignored, used when the mock only drives a side effect and is not asserted.
     """
     setattr(obj, name, value)
     return value


### PR DESCRIPTION
🐙claude: v3 P3-3（cmd.Cmd 完全撤去）。epic #263 / issue #303 配下。

## 背景
P2 Stage 3 (#297, PR #301) で SSH/telnet 両 transport が async push (`run_async_push_session` → `shell.dispatch()`) に移行し、`cmd.Cmd.cmdloop` は既に実行経路から外れていた。残存していた cmd.Cmd 足場を clean-rewrite 方針で一掃する。**byte-parity golden 不可侵**（cleanup で wire 完全不変）。

## 変更内容
- **cmd.Cmd 継承撤去**: `CMDShell(Cmd)` → `CMDShell`、`from cmd import Cmd` 削除。dead method 6 (`start`/`stop`/`default`/`do_help`/`do_EOF`/`emptyline`) + attr (`use_rawinput`/`ruler`) 除去。
- **`_parseline` 自前実装**: live で使っていた `cmd.Cmd.parseline` を byte-identical な自前実装に置換（`?`→`help ` 変換 / `!`→no-`do_shell` fall-through / identchars scan）。`identchars` は class attr 化。stdlib `cmd.Cmd().parseline` を oracle にした parametrized 全一致 test で回帰を gate。
- **公開 config 整理**: `CMDShellConfig` から cmdloop 専用 inert knob (`ruler`/`completekey`) を削除 + `model_config = ConfigDict(extra="forbid")` 追加（旧 knob / 未知キーを load-time `ValidationError` で loud reject = connect 時 `TypeError` の latent crash を起動時へ前倒し）。`base_prompt` は `Host` 注入の live override なので explicit field 化。
- **dead I/O surface 撤去**: cmd.Cmd 撤去で production-dead 化した `writeline` / `stdin` / `stdout` を一掃（async_server_base の io.StringIO ダミー + 未使用 import io 含む）。両 transport は `DispatchResult` + tap_bridge 経由で wire を描画。
- **stale comment 是正**: cmd.Cmd/cmdloop/default 言及を docstring/comment/log で実態へ。byte-parity 由来 rationale (DispatchResult / tap_bridge / v2 do_help) は過去形 anchor として維持。
- **test 移行**: `.default()`/`do_help`/`do_EOF`/`emptyline` 呼び出しを `dispatch`/`_dispatch_general`/`_help_body` へ。production-dead test (`test_start`/`test_stop`/introspection guard) 削除。`CMDShellConfig` schema regression + `do_shell` guard pin 追加。

## 破壊的変更
`CMDShellConfig` の `ruler`/`completekey` 撤去 + `extra="forbid"` 化。両 knob は cmdloop 専用で既に inert なので機能影響なし（v3 clean-rewrite として許容）。inventory で設定していた利用者は load 時 `ValidationError` で loud に弾かれる。

## 検証
- byte-parity golden **無変更**（`test_ssh_byte_parity.py` / `test_telnet_byte_parity.py`）
- full suite **1103 passed**, 7 skipped, 1 xfailed（docker 2 errors は env iptables、無関係）
- ruff check / format / ty / yamllint 全 pass

## レビュー
design cross-review 4 round 収束 + code cross-review 2 round 収束（いずれも最終 SUGGESTION/LGTM、MUST/SHOULD ゼロ）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)