### PR TITLE
chore: メジャー依存更新 invoke / pre-commit / pymdown-extensions (v3)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -171,7 +171,7 @@ dev = [
     "bandit",
     "coverage",
     "invoke",
-    "pre-commit>=3.8.0,<4.0.0",
+    "pre-commit>=4.0.0,<5.0.0",
     "netmiko",
     "requests",
     "mkdocstrings[crystal,python]",

--- a/uv.lock
+++ b/uv.lock
@@ -508,11 +508,11 @@ wheels = [
 
 [[package]]
 name = "invoke"
-version = "2.2.1"
+version = "3.0.3"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/de/bd/b461d3424a24c80490313fd77feeb666ca4f6a28c7e72713e3d9095719b4/invoke-2.2.1.tar.gz", hash = "sha256:515bf49b4a48932b79b024590348da22f39c4942dff991ad1fb8b8baea1be707", size = 304762, upload-time = "2025-10-11T00:36:35.172Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/33/f6/227c48c5fe47fa178ccf1fda8f047d16c97ba926567b661e9ce2045c600c/invoke-3.0.3.tar.gz", hash = "sha256:437b6a622223824380bfb4e64f612711a6b648c795f565efc8625af66fb57f0c", size = 343419, upload-time = "2026-04-07T15:17:48.307Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/32/4b/b99e37f88336009971405cbb7630610322ed6fbfa31e1d7ab3fbf3049a2d/invoke-2.2.1-py3-none-any.whl", hash = "sha256:2413bc441b376e5cd3f55bb5d364f973ad8bdd7bf87e53c79de3c11bf3feecc8", size = 160287, upload-time = "2025-10-11T00:36:33.703Z" },
+    { url = "https://files.pythonhosted.org/packages/5a/de/bbc12563bbf979618d17625a4e753ff7a078523e28d870d3626daa97261a/invoke-3.0.3-py3-none-any.whl", hash = "sha256:f11327165e5cbb89b2ad1d88d3292b5113332c43b8553b494da435d6ec6f5053", size = 160958, upload-time = "2026-04-07T15:17:46.875Z" },
 ]
 
 [[package]]
@@ -894,7 +894,7 @@ wheels = [
 
 [[package]]
 name = "pre-commit"
-version = "3.8.0"
+version = "4.6.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "cfgv" },
@@ -903,9 +903,9 @@ dependencies = [
     { name = "pyyaml" },
     { name = "virtualenv" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/64/10/97ee2fa54dff1e9da9badbc5e35d0bbaef0776271ea5907eccf64140f72f/pre_commit-3.8.0.tar.gz", hash = "sha256:8bb6494d4a20423842e198980c9ecf9f96607a07ea29549e180eef9ae80fe7af", size = 177815, upload-time = "2024-07-28T19:59:01.538Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/8e/22/2de9408ac81acbb8a7d05d4cc064a152ccf33b3d480ebe0cd292153db239/pre_commit-4.6.0.tar.gz", hash = "sha256:718d2208cef53fdc38206e40524a6d4d9576d103eb16f0fec11c875e7716e9d9", size = 198525, upload-time = "2026-04-21T20:31:41.613Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/07/92/caae8c86e94681b42c246f0bca35c059a2f0529e5b92619f6aba4cf7e7b6/pre_commit-3.8.0-py2.py3-none-any.whl", hash = "sha256:9a90a53bf82fdd8778d58085faf8d83df56e40dfe18f45b19446e26bf1b3a63f", size = 204643, upload-time = "2024-07-28T19:58:59.335Z" },
+    { url = "https://files.pythonhosted.org/packages/80/6e/4b28b62ecb6aae56769c34a8ff1d661473ec1e9519e2d5f8b2c150086b26/pre_commit-4.6.0-py2.py3-none-any.whl", hash = "sha256:e2cf246f7299edcabcf15f9b0571fdce06058527f0a06535068a86d38089f29b", size = 226472, upload-time = "2026-04-21T20:31:40.092Z" },
 ]
 
 [[package]]
@@ -999,15 +999,15 @@ wheels = [
 
 [[package]]
 name = "pymdown-extensions"
-version = "10.21.3"
+version = "11.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "markdown" },
     { name = "pyyaml" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/9e/26/d1015444da4d952a1ca487a236b522eb979766f0295a0bd0c5fc089989a9/pymdown_extensions-10.21.3.tar.gz", hash = "sha256:72cfcf55f07aea0d4af2c4f11dd4e52466ddfb1bb819673146398e0bd3a77354", size = 854140, upload-time = "2026-05-13T12:57:32.267Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/47/67/f1e79672a5f91985577c7984c9709ca110e4fd37fe7fd167b60422e6ccc2/pymdown_extensions-11.0.tar.gz", hash = "sha256:8269cef0247f9e2d0a62fcea10860aba05c1cbab5470fd4b63230b96434dc589", size = 857049, upload-time = "2026-06-23T02:27:45.146Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/7e/85/545a951eecc270fcd688288c600017e2050a1aacb56c711d208586d3e470/pymdown_extensions-10.21.3-py3-none-any.whl", hash = "sha256:d7a5d08014fc571e80ca21dd6f854e31f94c489800350564d55d15b3c41e76b6", size = 269002, upload-time = "2026-05-13T12:57:30.296Z" },
+    { url = "https://files.pythonhosted.org/packages/af/b6/1ae53367e28b9cffa3be7574e13fbe4589694272fd47710fbdbafd3d63c6/pymdown_extensions-11.0-py3-none-any.whl", hash = "sha256:fbc4acb641814fa9d17521bbd21a5240ef739a662f11c06330c4b78c93e954d6", size = 269415, upload-time = "2026-06-23T02:27:43.826Z" },
 ]
 
 [[package]]
@@ -1337,7 +1337,7 @@ dev = [
     { name = "mkdocstrings", extras = ["crystal", "python"] },
     { name = "netmiko" },
     { name = "paramiko", specifier = ">=4.0,<6.0" },
-    { name = "pre-commit", specifier = ">=3.8.0,<4.0.0" },
+    { name = "pre-commit", specifier = ">=4.0.0,<5.0.0" },
     { name = "pymdown-extensions" },
     { name = "pytest" },
     { name = "pytest-rerunfailures" },


### PR DESCRIPTION
🐙claude:

## 概要

メジャー更新のうち、**コード変更不要で安全に上げられる 3 つ**を更新。変更は `pyproject.toml`（pre-commit の上限緩和）+ `uv.lock`。

| package | 旧 → 新 | 確認 |
|---|---|---|
| **invoke** | 2.2.1 → **3.0.3** | tasks.py が invoke 3 で動作（ruff/yamllint/bandit 実行 OK） |
| **pre-commit** | 3.8.0 → **4.6.0** | pyproject 制約 `>=3.8.0,<4.0.0` → `>=4.0.0,<5.0.0`、`validate-config` OK |
| **pymdown-extensions** | 10.21.3 → **11.0** | mkdocs config ロード OK |

## ty は本 PR から除外（0.0.23 据え置き）
ty 0.0.55 は新診断 **29 件**（protocol 厳格化等、production+tests+stdlib に分散・一部 pre-1.0 の誤検知含む）を生むため、**分類 → 別 PR で対応**（churn 判断のため切り出し）。

## 検証
- full suite **1129 passed** / 7 skipped / 1 xfailed（docker 2 error = ローカル env iptables、無関係）
- ruff(check+format) / yamllint / lint-platform-data / ty(0.0.23) 全 green

## 注記（本 PR 無関係の pre-existing）
`mkdocs build` が griffe の ImportError（`cannot import name 'Alias' from 'griffe'`、mkdocstrings-python 2.0.3 と griffe 不整合）で失敗する既存問題を発見。docs ツールチェーンの別バグで本 bump とは無関係。別 issue 候補。

base = v3。`Closes` 無し。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
