### PR TITLE
fix: docs build を griffe 2.x 分割対応で修復 (griffe umbrella を明示依存に) (v3)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -175,6 +175,12 @@ dev = [
     "netmiko",
     "requests",
     "mkdocstrings[crystal,python]",
+    # griffe 2.x split into griffe(umbrella)/griffelib/griffecli. mkdocstrings-python
+    # depends only on `griffelib` yet imports `from griffe import ...`, so the
+    # `griffe` umbrella (which provides the importable `griffe` module) must be
+    # pulled explicitly — without it `mkdocs build` fails with `ImportError: cannot
+    # import name 'Alias' from 'griffe'` (#docs build fix).
+    "griffe>=2.1.0",
     "mkdocs-material",
     "mkdocs-static-i18n",
     "pymdown-extensions",

--- a/uv.lock
+++ b/uv.lock
@@ -471,12 +471,38 @@ wheels = [
 ]
 
 [[package]]
-name = "griffelib"
-version = "2.0.0"
+name = "griffe"
+version = "2.1.0"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/ad/06/eccbd311c9e2b3ca45dbc063b93134c57a1ccc7607c5e545264ad092c4a9/griffelib-2.0.0.tar.gz", hash = "sha256:e504d637a089f5cab9b5daf18f7645970509bf4f53eda8d79ed71cce8bd97934", size = 166312, upload-time = "2026-03-23T21:06:55.954Z" }
+dependencies = [
+    { name = "griffecli" },
+    { name = "griffelib" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/00/44/63913c007814cab5ba9d36f25ad40dfc640c2e2931d195bd2d05f774a5d6/griffe-2.1.0.tar.gz", hash = "sha256:c58845df5a364feaabd05ee8c767b97b03e478da8aa18b9923553c812fb0d955", size = 244879, upload-time = "2026-06-19T12:05:41.262Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/4d/51/c936033e16d12b627ea334aaaaf42229c37620d0f15593456ab69ab48161/griffelib-2.0.0-py3-none-any.whl", hash = "sha256:01284878c966508b6d6f1dbff9b6fa607bc062d8261c5c7253cb285b06422a7f", size = 142004, upload-time = "2026-02-09T19:09:40.561Z" },
+    { url = "https://files.pythonhosted.org/packages/6b/fb/3c65d392feae6c36dc2b55a14dd8270b7b35a3171c93b71a4d2ee4abf241/griffe-2.1.0-py3-none-any.whl", hash = "sha256:2ccdab17fb9cd76f278d7b5611cfc8f68cbe846d8d48df63dff80b62ecfa6f65", size = 5140, upload-time = "2026-06-19T12:05:39.913Z" },
+]
+
+[[package]]
+name = "griffecli"
+version = "2.1.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "colorama" },
+    { name = "griffelib" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/8e/c6/90f85d47af96300d629b38c25b71aad9467a620cac964a39280e822efc8a/griffecli-2.1.0.tar.gz", hash = "sha256:2ff68dbee9395fdb668b10374c51683392d697b226ac60159798f4add1ee716c", size = 56913, upload-time = "2026-06-19T12:05:43.119Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/80/2f/513232ec1d5f5da182e4ce45a11427e37dd210844a9e2bca451fc9661fb3/griffecli-2.1.0-py3-none-any.whl", hash = "sha256:6e22b1423d562ddc510997b4be1fe89de59e19dcff78831c0f4bfc3b8134a718", size = 9500, upload-time = "2026-06-19T12:05:37.517Z" },
+]
+
+[[package]]
+name = "griffelib"
+version = "2.1.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/33/e4/8d187ea29c2e30b3a09505c567513077d6117861bde1fbd997a167f262ec/griffelib-2.1.0.tar.gz", hash = "sha256:762a186d2c6fd6794d4ea20d428d597ffb857cb56b66421651cbba15bdd5e813", size = 216234, upload-time = "2026-06-19T12:05:42.278Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e4/d3/5268aeabf2ad82658c4e2ff3a060648d0f02f3926cb53247c0e4d0dab49e/griffelib-2.1.0-py3-none-any.whl", hash = "sha256:cc7b3d2d2865ad0b909fcc38086e3f554b5ea7acbaa7bbb7ecaa3f5dfb7d9f00", size = 142560, upload-time = "2026-06-19T12:05:38.742Z" },
 ]
 
 [[package]]
@@ -780,16 +806,16 @@ wheels = [
 
 [[package]]
 name = "mkdocstrings-python"
-version = "2.0.3"
+version = "2.0.5"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "griffelib" },
     { name = "mkdocs-autorefs" },
     { name = "mkdocstrings" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/29/33/c225eaf898634bdda489a6766fc35d1683c640bffe0e0acd10646b13536d/mkdocstrings_python-2.0.3.tar.gz", hash = "sha256:c518632751cc869439b31c9d3177678ad2bfa5c21b79b863956ad68fc92c13b8", size = 199083, upload-time = "2026-02-20T10:38:36.368Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/b1/b6/e858701499d57eee8b3fd8e78168083956c6683ddbe727b46758b19e1119/mkdocstrings_python-2.0.5.tar.gz", hash = "sha256:3a4d92556ad39637e88af94a5374213af9a8e3040c3824ceaed04b486c017594", size = 199578, upload-time = "2026-06-19T10:41:08.868Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/32/28/79f0f8de97cce916d5ae88a7bee1ad724855e83e6019c0b4d5b3fabc80f3/mkdocstrings_python-2.0.3-py3-none-any.whl", hash = "sha256:0b83513478bdfd803ff05aa43e9b1fca9dd22bcd9471f09ca6257f009bc5ee12", size = 104779, upload-time = "2026-02-20T10:38:34.517Z" },
+    { url = "https://files.pythonhosted.org/packages/d1/fc/10ab7e80650a9c9e8f4f1105f8c8e73567f88ed0c06ada589ab81d38687c/mkdocstrings_python-2.0.5-py3-none-any.whl", hash = "sha256:30c837bbff016549f659fcba6539ac351303f0fd7e713c89a040611072236e9d", size = 104951, upload-time = "2026-06-19T10:41:07.378Z" },
 ]
 
 [[package]]
@@ -1294,6 +1320,7 @@ compatibility = [
 dev = [
     { name = "bandit" },
     { name = "coverage" },
+    { name = "griffe" },
     { name = "invoke" },
     { name = "mkdocs-material" },
     { name = "mkdocs-static-i18n" },
@@ -1331,6 +1358,7 @@ compatibility = [
 dev = [
     { name = "bandit" },
     { name = "coverage" },
+    { name = "griffe", specifier = ">=2.1.0" },
     { name = "invoke" },
     { name = "mkdocs-material" },
     { name = "mkdocs-static-i18n" },


### PR DESCRIPTION
🐙claude:

## 概要

`mkdocs build` が `ImportError: cannot import name 'Alias' from 'griffe'` で失敗していた**既存の docs ビルド破損**を修復。docs CI（`mkdocs build --clean`）は v3 で RED だった（pre-existing、依存更新 #310/#311/#312 起因ではない）。

## 原因（griffe 2.x のエコシステム分割の過渡期破損）

1. griffe は 2.x で **`griffe`(umbrella) / `griffelib`(ライブラリ実体) / `griffecli`(CLI)** に3分割（全て公式 pawamoy 製、typosquat ではない）。
2. `mkdocstrings-python` 2.x は依存に **`griffelib` のみ**宣言する一方、コードは `from griffe import ...`（umbrella の `griffe` モジュール）を import。
3. SIMNOS の lock は **`griffelib 2.0.0`（import 不可の空の過渡期リリース）のみ**で `griffe` umbrella が無く、import 解決不能。

## 修正

docs 依存に **`griffe>=2.1.0`（umbrella）を明示追加** → uv が `griffe` / `griffecli` / `griffelib` を 2.1.0 で整合、`mkdocstrings-python` も 2.0.5 へ。

```
+ griffe v2.1.0
+ griffecli v2.1.0
  griffelib 2.0.0 → 2.1.0
  mkdocstrings-python 2.0.3 → 2.0.5
```

## 検証
- **`mkdocs build --clean` がクリーン状態で成功**（ImportError 解消、warning のみ）
- full suite **1129 passed** / 7 skipped / 1 xfailed（docker 2 error = ローカル env iptables、無関係）
- ruff(check+format) / yamllint / lint-platform-data / ty(0.0.55) 全 green

base = v3。`Closes` 無し。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
