### PR TITLE
feat: Category B 8 NOS に session paging-disable コマンドを追加 (#309)

### DIFF
--- a/simnos/plugins/nos/platforms/aruba_aoscx/commands/no_page.yaml
+++ b/simnos/plugins/nos/platforms/aruba_aoscx/commands/no_page.yaml
@@ -1,0 +1,7 @@
+command: no page
+type: simnos
+disables_paging: true
+help: disable paging
+mode:
+- user
+- enable

--- a/simnos/plugins/nos/platforms/aruba_os/commands/no_paging.yaml
+++ b/simnos/plugins/nos/platforms/aruba_os/commands/no_paging.yaml
@@ -1,0 +1,7 @@
+command: no paging
+type: simnos
+disables_paging: true
+help: disable paging
+mode:
+- user
+- enable

--- a/simnos/plugins/nos/platforms/cisco_viptela/commands/paginate_false.yaml
+++ b/simnos/plugins/nos/platforms/cisco_viptela/commands/paginate_false.yaml
@@ -1,0 +1,7 @@
+command: paginate false
+type: simnos
+disables_paging: true
+help: disable paging
+mode:
+- user
+- enable

--- a/simnos/plugins/nos/platforms/cisco_wlc_ssh/commands/config_paging_disable.yaml
+++ b/simnos/plugins/nos/platforms/cisco_wlc_ssh/commands/config_paging_disable.yaml
@@ -1,0 +1,7 @@
+command: config paging disable
+type: simnos
+disables_paging: true
+help: disable paging
+mode:
+- user
+- enable

--- a/simnos/plugins/nos/platforms/dlink_ds/commands/disable_clipaging.txt
+++ b/simnos/plugins/nos/platforms/dlink_ds/commands/disable_clipaging.txt
@@ -1,0 +1,3 @@
+Command: disable clipaging
+
+Success.

--- a/simnos/plugins/nos/platforms/dlink_ds/commands/disable_clipaging.yaml
+++ b/simnos/plugins/nos/platforms/dlink_ds/commands/disable_clipaging.yaml
@@ -1,0 +1,7 @@
+command: disable clipaging
+type: simnos
+disables_paging: true
+help: disable paging
+mode:
+- user
+output: disable_clipaging.txt

--- a/simnos/plugins/nos/platforms/dlink_ds/commands/enable_clipaging.txt
+++ b/simnos/plugins/nos/platforms/dlink_ds/commands/enable_clipaging.txt
@@ -1,3 +1,3 @@
-Command: disable clipaging
+Command: enable clipaging
 
 Success.

--- a/simnos/plugins/nos/platforms/dlink_ds/commands/enable_clipaging.yaml
+++ b/simnos/plugins/nos/platforms/dlink_ds/commands/enable_clipaging.yaml
@@ -1,7 +1,6 @@
 command: enable clipaging
 type: simnos
-help: enters the mmi mode (machine-machine interface)
+help: enable paging
 mode:
 - user
-new_mode: user
 output: enable_clipaging.txt

--- a/simnos/plugins/nos/platforms/extreme_slxos/commands/terminal_length_0.yaml
+++ b/simnos/plugins/nos/platforms/extreme_slxos/commands/terminal_length_0.yaml
@@ -1,0 +1,6 @@
+command: terminal length 0
+type: simnos
+disables_paging: true
+help: disable paging
+mode:
+- user

--- a/simnos/plugins/nos/platforms/ruckus_fastiron/commands/skip-page-display.yaml
+++ b/simnos/plugins/nos/platforms/ruckus_fastiron/commands/skip-page-display.yaml
@@ -1,0 +1,7 @@
+command: skip-page-display
+type: simnos
+disables_paging: true
+help: disable paging
+mode:
+- user
+- enable

--- a/simnos/plugins/nos/platforms/zte_zxros/commands/terminal_length_0.yaml
+++ b/simnos/plugins/nos/platforms/zte_zxros/commands/terminal_length_0.yaml
@@ -1,0 +1,7 @@
+command: terminal length 0
+type: simnos
+disables_paging: true
+help: disable paging
+mode:
+- user
+- enable

--- a/tests/assets/oracle/aruba_aoscx.json
+++ b/tests/assets/oracle/aruba_aoscx.json
@@ -19,6 +19,17 @@
     "output": null,
     "variants": []
   },
+  "no page": {
+    "exit": false,
+    "help": "disable paging",
+    "modes": [
+      "enable",
+      "user"
+    ],
+    "new_mode": null,
+    "output": null,
+    "variants": []
+  },
   "show aaa authentication port-access interface all client-status": {
     "exit": false,
     "help": "execute the command \"show aaa authentication port-access interface all client-status\"",

--- a/tests/assets/oracle/aruba_os.json
+++ b/tests/assets/oracle/aruba_os.json
@@ -9,6 +9,17 @@
     "output": null,
     "variants": []
   },
+  "no paging": {
+    "exit": false,
+    "help": "disable paging",
+    "modes": [
+      "enable",
+      "user"
+    ],
+    "new_mode": null,
+    "output": null,
+    "variants": []
+  },
   "show ap bss-table details": {
     "exit": false,
     "help": "execute the command \"show ap bss-table details\"",

--- a/tests/assets/oracle/cisco_viptela.json
+++ b/tests/assets/oracle/cisco_viptela.json
@@ -19,6 +19,17 @@
     "output": null,
     "variants": []
   },
+  "paginate false": {
+    "exit": false,
+    "help": "disable paging",
+    "modes": [
+      "enable",
+      "user"
+    ],
+    "new_mode": null,
+    "output": null,
+    "variants": []
+  },
   "show arp": {
     "exit": false,
     "help": "execute the command \"show arp\"",

--- a/tests/assets/oracle/cisco_wlc_ssh.json
+++ b/tests/assets/oracle/cisco_wlc_ssh.json
@@ -9,6 +9,17 @@
     ],
     "variants": []
   },
+  "config paging disable": {
+    "exit": false,
+    "help": "disable paging",
+    "modes": [
+      "enable",
+      "user"
+    ],
+    "new_mode": null,
+    "output": null,
+    "variants": []
+  },
   "enable": {
     "exit": false,
     "help": "enter enable mode",

--- a/tests/assets/oracle/dlink_ds.json
+++ b/tests/assets/oracle/dlink_ds.json
@@ -15,6 +15,20 @@
     ],
     "variants": []
   },
+  "disable clipaging": {
+    "exit": false,
+    "help": "disable paging",
+    "modes": [
+      "user"
+    ],
+    "new_mode": null,
+    "output": [
+      "Command: disable clipaging",
+      "",
+      "Success."
+    ],
+    "variants": []
+  },
   "enable": {
     "exit": false,
     "help": "enter enable mode",
@@ -27,13 +41,13 @@
   },
   "enable clipaging": {
     "exit": false,
-    "help": "enters the mmi mode (machine-machine interface)",
+    "help": "enable paging",
     "modes": [
       "user"
     ],
-    "new_mode": "user",
+    "new_mode": null,
     "output": [
-      "Command: disable clipaging",
+      "Command: enable clipaging",
       "",
       "Success."
     ],

--- a/tests/assets/oracle/extreme_slxos.json
+++ b/tests/assets/oracle/extreme_slxos.json
@@ -57,5 +57,15 @@
       "Ve 734                 10.224.8.137         ABC-PUBLIC-LEGACY                             administratively down     down"
     ],
     "variants": []
+  },
+  "terminal length 0": {
+    "exit": false,
+    "help": "disable paging",
+    "modes": [
+      "user"
+    ],
+    "new_mode": null,
+    "output": null,
+    "variants": []
   }
 }

--- a/tests/assets/oracle/ruckus_fastiron.json
+++ b/tests/assets/oracle/ruckus_fastiron.json
@@ -1069,5 +1069,16 @@
       "     Monitoring: Disabled"
     ],
     "variants": []
+  },
+  "skip-page-display": {
+    "exit": false,
+    "help": "disable paging",
+    "modes": [
+      "enable",
+      "user"
+    ],
+    "new_mode": null,
+    "output": null,
+    "variants": []
   }
 }

--- a/tests/assets/oracle/zte_zxros.json
+++ b/tests/assets/oracle/zte_zxros.json
@@ -860,5 +860,16 @@
       "Uptime is N/A"
     ],
     "variants": []
+  },
+  "terminal length 0": {
+    "exit": false,
+    "help": "disable paging",
+    "modes": [
+      "enable",
+      "user"
+    ],
+    "new_mode": null,
+    "output": null,
+    "variants": []
   }
 }


### PR DESCRIPTION
🐙claude:

## 概要

#307 (P3-4 paging `--More--`、PR #308) の netmiko audit で見つかった **pre-existing gap** を解消する。netmiko driver が paging-disable コマンドを送るが A3 platform data に当該コマンドが存在しない **Category B = 8 NOS** に、#307 で確立した data-driven 方式 (`disables_paging: true` flag 付き command yaml) で 1 件ずつ追加する。

base = **v3**。`#309` は v3 が非デフォルトブランチのため自動 close されない → 参照のみ記載し、**#309 は v3→main 統合時に close**(epic #263 配下の運用に整合)。

## 追加した 8 コマンド

| NOS | command | mode | netmiko 裏取り |
|---|---|---|---|
| aruba_aoscx | `no page` | user, enable | OK (driver literal) |
| aruba_os | `no paging` | user, enable | OK (driver literal) |
| cisco_viptela | `paginate false` | user, enable | OK (driver literal) |
| cisco_wlc_ssh | `config paging disable` | user, enable | OK (driver literal) |
| dlink_ds | `disable clipaging` | user | OK (driver literal) |
| extreme_slxos | `terminal length 0` | user | OK (netmiko `extreme_slx` base default) |
| zte_zxros | `terminal length 0` | user, enable | OK (base default 継承) |
| ruckus_fastiron | `skip-page-display` | user, enable | OK (driver literal) |

- 全コマンド `type: simnos` / `disables_paging: true`。コマンド綴りは netmiko `CLASS_MAPPER` の driver source で **8/8 裏取り済**。
- 出力は基本 **NO_OUTPUT**(実機の disable コマンドは通常無出力、flag 済 34 NOS 中 31 が NO_OUTPUT)。
- mode は各 `platform.yaml` の実 modes に合わせ、enable mode が無い NOS (dlink_ds / extreme_slxos) は `user` へ縮退(paging disable は exec 操作のため config は全除外)。

## 副次修正 (dlink_ds clipaging ペアの pre-existing 不整合是正)

レビュー過程で dlink_ds の既存データに 2 件の pre-existing バグを発見、user 同意の上で本 PR で是正:

1. **echo swap**: `enable_clipaging.txt` が `Command: disable clipaging` を echo する copy-paste swap だった → 正しい `Command: enable clipaging` へ修正。disable 側の正しい出力は新規 `disable_clipaging.txt` へ移送(enable/disable ペアを対称化)。
2. **help/new_mode**: `enable_clipaging.yaml` の `help` を `enters the mmi mode...`(clipaging=CLI ページング制御で mmi mode と無関係)→ `enable paging` に是正、no-op の `new_mode: user` を撤去。

## migration oracle snapshot

新コマンド追加で A3 loader projection が変わるため `regen_oracle_snapshots.py` で 8 platform を再 baseline。diff は新コマンド純追加 + dlink 修正のみに限定(`disables_paging` は v2 等価 projection 対象外で snapshot 非出現)。

## cross-review (1st round)

🦊codex / 🐳gemini / 🐙claude 全員 **総合 SUGGESTION**(MUST/SHOULD ゼロ、全員マージ可)。綴り 8/8 一致・flag 方式・mode 縮退・oracle diff・dlink swap 対称性を実コードで裏取り。
- claude #6(dlink enable help/new_mode)→ **取り込み済**。
- codex #5(ファイル命名基準)→ worklog に明文化。
- gemini #1(aruba_os/ruckus を `[enable]` のみに絞る)→ **defer**(同一コマンド `skip-page-display` の既存 brocade_fastiron が `[user, enable]` 採用、絞ると新たな convention drift。fidelity-vs-convention で後者優先)。

## 検証

- full suite **1129 passed** / 7 skipped / 1 xfailed(docker 2 error = ローカル env iptables、無関係)
- ruff(check+format) / ty(0.0.55) / yamllint / lint-platform-data 全 green

## 参照

- 親: #307 (P3-4 paging) / PR #308 / P3 umbrella #303 / epic #263

🤖 Generated with [Claude Code](https://claude.com/claude-code)