### PR TITLE
feat: hot-reload watcher を per-shell snapshot + per-platform watch へ分離 (#281)

### DIFF
--- a/simnos/core/host.py
+++ b/simnos/core/host.py
@@ -7,6 +7,7 @@ It also validates the host object using pydantic.
 from dataclasses import dataclass
 import logging
 import os
+import threading
 from typing import TYPE_CHECKING
 
 from simnos.core.nos import Nos
@@ -147,6 +148,11 @@ class Host:
             # The async server plugins (AsyncSshServer + telnetlib3 TelnetServer)
             # reach the SimNOS-owned shared loop through this back reference.
             simnos=self.simnos,
+            # Per-host hot-reload lock (#281 / D6): one lock per host, threaded
+            # to every session's shell so concurrent dev hot-reloads (and a new
+            # connection's self-build) serialize on the host-shared `nos`. A
+            # no-op cost in production (env off = no reload, no self-build).
+            reload_lock=threading.Lock(),
             # Environment-wide pager page height (#307 / P3-4). sys_config always
             # materializes `paging.default_rows` (ModelPaging default 24), so the
             # `.get` chain is a defensive fallback only.

--- a/simnos/plugins/servers/async_server_base.py
+++ b/simnos/plugins/servers/async_server_base.py
@@ -82,6 +82,7 @@ class AsyncServerBase:
         render_config: "HostRenderConfig | None" = None,
         simnos: "SimNOS | None" = None,
         page_default_rows: int = 24,
+        reload_lock: "threading.Lock | None" = None,
     ) -> None:
         self.nos: Nos = nos
         self.nos_inventory_config: dict = nos_inventory_config
@@ -92,6 +93,10 @@ class AsyncServerBase:
         # `shell_configuration` (which is inventory-derived) so the environment-wide
         # sys_config value flows through a distinct, non-colliding path.
         self.page_default_rows: int = page_default_rows
+        # Per-host hot-reload lock (#281 / D6), threaded to every session's shell
+        # so concurrent dev hot-reloads serialize on the host-shared `nos`. None in
+        # direct/test construction -> each shell falls back to a private lock.
+        self._reload_lock: threading.Lock | None = reload_lock
         self._render_config: HostRenderConfig | None = render_config
         # Normalize the merged platform once at Host.start (per-host invariant,
         # surfaces malformed data at startup rather than on the first connection).
@@ -314,6 +319,7 @@ class AsyncServerBase:
             resolved_platform=self._shared_platform,
             render_config=self._render_config,
             page_default_rows=self.page_default_rows,
+            reload_lock=self._reload_lock,
             **self.shell_configuration,
         )
 

--- a/simnos/plugins/servers/ssh_server_asyncssh.py
+++ b/simnos/plugins/servers/ssh_server_asyncssh.py
@@ -212,6 +212,7 @@ class AsyncSshServer(AsyncServerBase):
         render_config: "HostRenderConfig | None" = None,
         simnos: "SimNOS | None" = None,
         page_default_rows: int = 24,
+        reload_lock: "threading.Lock | None" = None,
     ) -> None:
         super().__init__(
             shell,
@@ -227,6 +228,7 @@ class AsyncSshServer(AsyncServerBase):
             render_config=render_config,
             simnos=simnos,
             page_default_rows=page_default_rows,
+            reload_lock=reload_lock,
         )
         self.ssh_banner: str = ssh_banner
         self._authorized_keys = self._load_authorized_keys(authorized_keys)

--- a/simnos/plugins/servers/telnet_server.py
+++ b/simnos/plugins/servers/telnet_server.py
@@ -29,6 +29,7 @@ import contextlib
 import ipaddress
 import logging
 import socket
+import threading
 from typing import TYPE_CHECKING
 
 import telnetlib3
@@ -130,6 +131,7 @@ class TelnetServer(AsyncServerBase):
         render_config: "HostRenderConfig | None" = None,
         simnos: "SimNOS | None" = None,
         page_default_rows: int = 24,
+        reload_lock: "threading.Lock | None" = None,
     ) -> None:
         super().__init__(
             shell,
@@ -145,6 +147,7 @@ class TelnetServer(AsyncServerBase):
             render_config=render_config,
             simnos=simnos,
             page_default_rows=page_default_rows,
+            reload_lock=reload_lock,
         )
         self.banner: str = banner
         if not _is_loopback(address):

--- a/simnos/plugins/shell/cmd_shell.py
+++ b/simnos/plugins/shell/cmd_shell.py
@@ -265,7 +265,12 @@ class CMDShell:
         # hot-reload dev mode the shared snapshot is None (`build_shared_platform`
         # returns None), so every connection self-builds from the live shared
         # `nos` — done under the reload lock so a concurrent executor reload does
-        # not mutate `nos` mid-read (#281 / D6, gemini#1).
+        # not mutate `nos` mid-read (#281 / D6, gemini#1). `_build_shell` runs on
+        # the shared event-loop thread, so a new connection contending here with an
+        # in-flight reload briefly blocks the loop until the reload releases the
+        # lock — dev-only (production passes a non-None shared platform, skipping
+        # this branch entirely) and accepted as the cost of the no-mid-mutation
+        # guarantee (#281 / Risks, 1st code review claude#1).
         if resolved_platform is None:
             with self._reload_lock:
                 resolved_platform = build_resolved_platform(self.nos, self._inventory_commands, self._render_config)
@@ -532,12 +537,15 @@ class CMDShell:
 
     def precmd(self, line):
         """Method to return line before processing the command"""
-        if os.environ.get("SIMNOS_RELOAD_COMMANDS"):
-            # env on => `__init__` seeded the watcher state, so `_package_root` is
-            # non-None here (narrows the `str | None` for `get_files_changed`,
-            # 3rd round gemini#4). The diff runs against this shell's own snapshot
-            # (per-shell, #281 / D1), which is then swapped for the returned one.
-            assert self._package_root is not None  # noqa: S101 — env on guarantees __init__ seeded it
+        # Two-part gate (#281, 1st code review gemini#1/claude#2): the env var
+        # keeps the current "env off mid-session stops reloading" semantics, and
+        # `_package_root is not None` proves `__init__` actually seeded the watcher
+        # (env was on at construction). It also narrows `_package_root` to `str`
+        # for `get_files_changed` without an `assert` — so a late env toggle-on
+        # (no baseline seeded) or `python -O` degrades to a graceful no-op instead
+        # of a `TypeError` deep in `resolve_reload_targets`. The diff runs against
+        # this shell's own snapshot (per-shell, D1), then swaps in the returned one.
+        if os.environ.get("SIMNOS_RELOAD_COMMANDS") and self._package_root is not None:
             reload_targets, self._reload_snapshot = get_files_changed(
                 self._watch_roots, self._package_root, self._reload_snapshot
             )

--- a/simnos/plugins/shell/cmd_shell.py
+++ b/simnos/plugins/shell/cmd_shell.py
@@ -9,6 +9,7 @@ import logging
 import os
 import random
 import string
+import threading
 import traceback
 from typing import TYPE_CHECKING, cast
 
@@ -18,8 +19,18 @@ from simnos.core.nos import Nos
 from simnos.core.overlay_loader import resolve_overlay
 from simnos.core.platform_loader import load_platform_dir
 from simnos.core.resolved_command import ResolvedCommand, ResolvedOutput, ResolvedPlatform
-from simnos.plugins import nos
-from simnos.plugins.shell.utils import get_files_changed
+
+# `nos_pkg` is the package module (for `__path__`); the `__init__` arg `nos` is a
+# `Nos` instance that would shadow a plain `from simnos.plugins import nos`, so the
+# module is bound under a distinct name (#281 / D5, 2nd round gemini#1/claude#1).
+import simnos.plugins.nos as nos_pkg
+from simnos.plugins.nos import nos_plugins
+from simnos.plugins.shell.utils import (
+    get_files_changed,
+    get_files_lasttime_changed,
+    get_files_under_roots,
+    platform_watch_roots,
+)
 
 if TYPE_CHECKING:
     from simnos.core.host import HostRenderConfig
@@ -196,14 +207,9 @@ class CMDShell:
         resolved_platform=None,
         render_config=None,
         page_default_rows=24,
+        reload_lock=None,
     ):
         self.nos: Nos = nos
-        # Platform name captured at build time for the hot-reload ownership filter
-        # (#274 / D6). A later foreign py reload can overwrite live `nos.name`
-        # (`_from_module` commit phase), so the filter must compare against this
-        # frozen value, not `self.nos.name`, or a hijacked name would permanently
-        # skip this session's own A3 platform reload.
-        self._platform_name: str = nos.name
         self.intro = intro
         self.base_prompt = base_prompt
         self.newline = newline
@@ -242,15 +248,44 @@ class CMDShell:
         # connection (true non-determinism, the realism opt-in; D6). Seeded
         # selection uses `_stable_hash` instead, not this RNG.
         self._connection_rng = random.Random()  # noqa: S311 — variant pick, not cryptographic
+        # Per-host shared reload lock (#281 / D6): serializes the executor-thread
+        # `reload_commands` against both a concurrent reload (another session of
+        # this host) and this `__init__`'s self-build read below, all of which
+        # touch the host-shared `self.nos`. The server injects one lock per host
+        # (`Host.start` -> server kwarg); a direct construction / test gets a
+        # private fallback. Established BEFORE the self-build so the read is
+        # already protected.
+        self._reload_lock: threading.Lock = reload_lock or threading.Lock()
         # The merged platform is per-host invariant (base_prompt is the host name,
         # nos/inventory are shared), so the server normalizes it once at
         # Host.start and passes it to every connection's shell (#264 / Impact —
         # normalize once, fail at startup). When not supplied (tests / direct
         # construction) the shell builds its own. A malformed prompt template
-        # fails loudly here (the #172 lenient fallback is gone, #264 / D5).
+        # fails loudly here (the #172 lenient fallback is gone, #264 / D5). In
+        # hot-reload dev mode the shared snapshot is None (`build_shared_platform`
+        # returns None), so every connection self-builds from the live shared
+        # `nos` — done under the reload lock so a concurrent executor reload does
+        # not mutate `nos` mid-read (#281 / D6, gemini#1).
         if resolved_platform is None:
-            resolved_platform = build_resolved_platform(self.nos, self._inventory_commands, self._render_config)
+            with self._reload_lock:
+                resolved_platform = build_resolved_platform(self.nos, self._inventory_commands, self._render_config)
         self._apply_platform(resolved_platform)
+        # Hot-reload watcher state (#281 / D1, D2, D5). Built ONLY in dev hot-reload
+        # mode so production (env off) does no walk and holds no snapshot — the
+        # per-shell baseline replaces the #274 process-global consume-once snapshot.
+        # `_watch_roots` is this platform's own subtree (per-platform watch, D2/D4),
+        # derived from the registry; `.get` degrades gracefully for a platform with
+        # no registry sources (e.g. a runtime-registered custom plugin). The baseline
+        # snapshot is seeded here so the first command can already reflect an edit.
+        self._watch_roots: list[str] = []
+        self._reload_snapshot: dict[str, float] = {}
+        self._package_root: str | None = None
+        if os.environ.get("SIMNOS_RELOAD_COMMANDS"):
+            self._package_root = nos_pkg.__path__[0]  # rollup root; module ref avoids the `nos` arg shadowing (D5)
+            self._watch_roots = platform_watch_roots(nos_plugins.get(self.nos.name, []))
+            self._reload_snapshot = get_files_lasttime_changed(get_files_under_roots(self._watch_roots))
+            if not self._watch_roots:
+                log.debug("hot-reload: no watch roots for platform %r (registry 未登録?)", self.nos.name)
 
     @staticmethod
     def build_shared_platform(
@@ -459,39 +494,53 @@ class CMDShell:
         (#264 / D6 cache bypass). No-op for legacy yaml/py reloads.
 
         `reload_targets` are reload units (A3 platform dirs / `.py` modules), not
-        raw changed files (#274 / D1). A dir target for a *different* platform is
-        skipped (#274 / D6 ownership filter): the watcher sees the whole
-        `plugins/nos` tree, so without this a sibling platform's edit — or a
-        `git checkout` touching many platforms — would `_from_platform_dir`-replace
-        this session's `resolved_platform` and hijack it onto another NOS.
+        raw changed files (#274 / D1). Per-platform watch (#281 / D2) means a
+        session only ever sees its own platform's subtree, so `reload_targets`
+        cannot contain a sibling platform — the #274 ownership filter is gone as
+        unreachable dead code (#281 / D7).
+
+        Serialized by the per-host `_reload_lock` (#281 / D6): `self.nos` is shared
+        by every session of this host, and dispatch runs on a bounded executor, so
+        two sessions could otherwise reload concurrently and corrupt the shared
+        `nos` (or race this method against a new connection's self-build read in
+        `__init__`). The whole body — including `load_platform_dir.cache_clear()` —
+        is under the lock: clearing the cache outside it would let session B drop
+        the cache while session A is still populating from it, re-opening the stale
+        parse window the cache bypass closes (#281 / D6, claude#2/codex#2).
         """
-        load_platform_dir.cache_clear()
-        for target in reload_targets:
-            if os.path.isdir(target) and os.path.basename(target) != self._platform_name:
-                # Foreign A3 platform dir — not this session's platform. Skipping
-                # keeps a sibling edit / git checkout from hijacking the session.
-                continue
-            snapshot_commands = dict(self.nos.commands)
-            snapshot_attrs = {attr: getattr(self.nos, attr) for attr in self._NOS_RELOAD_ATTRS}
-            try:
-                self.nos.from_file(target)
-                self._rebuild()
-            except Exception:
-                # Broad except, like the dispatch core's handler guard: any
-                # plugin error must not crash the session. Roll back the partial
-                # nos mutation so the broken file does not poison subsequent
-                # reloads, then log the traceback so a genuine plugin bug stays
-                # diagnosable.
-                self.nos.commands = snapshot_commands
-                for attr, value in snapshot_attrs.items():
-                    setattr(self.nos, attr, value)
-                log.error("shell '%s' failed to hot-reload %r\n%s", self.base_prompt, target, traceback.format_exc())
-                continue
+        with self._reload_lock:
+            load_platform_dir.cache_clear()
+            for target in reload_targets:
+                snapshot_commands = dict(self.nos.commands)
+                snapshot_attrs = {attr: getattr(self.nos, attr) for attr in self._NOS_RELOAD_ATTRS}
+                try:
+                    self.nos.from_file(target)
+                    self._rebuild()
+                except Exception:
+                    # Broad except, like the dispatch core's handler guard: any
+                    # plugin error must not crash the session. Roll back the partial
+                    # nos mutation so the broken file does not poison subsequent
+                    # reloads, then log the traceback so a genuine plugin bug stays
+                    # diagnosable.
+                    self.nos.commands = snapshot_commands
+                    for attr, value in snapshot_attrs.items():
+                        setattr(self.nos, attr, value)
+                    log.error(
+                        "shell '%s' failed to hot-reload %r\n%s", self.base_prompt, target, traceback.format_exc()
+                    )
+                    continue
 
     def precmd(self, line):
         """Method to return line before processing the command"""
         if os.environ.get("SIMNOS_RELOAD_COMMANDS"):
-            reload_targets = get_files_changed(nos.__path__[0])
+            # env on => `__init__` seeded the watcher state, so `_package_root` is
+            # non-None here (narrows the `str | None` for `get_files_changed`,
+            # 3rd round gemini#4). The diff runs against this shell's own snapshot
+            # (per-shell, #281 / D1), which is then swapped for the returned one.
+            assert self._package_root is not None  # noqa: S101 — env on guarantees __init__ seeded it
+            reload_targets, self._reload_snapshot = get_files_changed(
+                self._watch_roots, self._package_root, self._reload_snapshot
+            )
             if reload_targets:
                 log.debug("Reloading... Reload targets: %s", reload_targets)
                 self.reload_commands(reload_targets)

--- a/simnos/plugins/shell/cmd_shell.py
+++ b/simnos/plugins/shell/cmd_shell.py
@@ -285,7 +285,7 @@ class CMDShell:
             self._watch_roots = platform_watch_roots(nos_plugins.get(self.nos.name, []))
             self._reload_snapshot = get_files_lasttime_changed(get_files_under_roots(self._watch_roots))
             if not self._watch_roots:
-                log.debug("hot-reload: no watch roots for platform %r (registry 未登録?)", self.nos.name)
+                log.debug("hot-reload: no watch roots for platform %r (not in the registry?)", self.nos.name)
 
     @staticmethod
     def build_shared_platform(

--- a/simnos/plugins/shell/utils.py
+++ b/simnos/plugins/shell/utils.py
@@ -28,6 +28,54 @@ def get_files_under_directory(directory):
     return files
 
 
+def platform_watch_roots(sources: list[str]) -> list[str]:
+    """Walk targets for one platform's `nos_plugins` source list (#281 / D4).
+
+    `sources` is the registry entry `nos_plugins[<platform>]`: an A3 platform dir
+    and/or a legacy `platforms_py/<name>.py` module. Each maps to its watch
+    target(s):
+
+    - an A3 dir            -> the dir itself (recursively walked)
+    - a legacy `<name>.py` -> the `.py` plus its jinja inputs
+      (`configurations/<name>.yaml.j2`, `templates/<name>/`), mirroring the
+      `_legacy_jinja_to_py` reverse map so editing a template reloads the module.
+
+    A dual-source platform (e.g. cisco_ios = A3 dir + py module) yields both,
+    preserving the prior whole-tree watcher's coverage. Existence is NOT checked
+    here — a jinja input does not exist for every legacy platform;
+    `get_files_under_roots` skips non-existent roots at walk time (#281 / Risks).
+    """
+    roots: list[str] = []
+    for source in sources:
+        if source.endswith(".py"):
+            base = os.path.dirname(source)
+            name = os.path.basename(source)[: -len(".py")]
+            roots.append(source)
+            roots.append(os.path.join(base, "configurations", f"{name}.yaml.j2"))
+            roots.append(os.path.join(base, "templates", name))
+        else:
+            roots.append(source)
+    return roots
+
+
+def get_files_under_roots(roots: list[str]) -> list[str]:
+    """Collect watched files across `roots` (dir walked / file as-is / missing skipped).
+
+    A root is a directory (recursively walked with `get_files_under_directory`'s
+    extension filter) or an individual file (a legacy py module / jinja input,
+    taken as-is when it exists). A non-existent root is silently skipped — the
+    dev watcher's normal state, since `platform_watch_roots` emits jinja paths
+    that only some platforms ship (#281 / D4, Risks).
+    """
+    files: list[str] = []
+    for root in roots:
+        if os.path.isdir(root):
+            files += get_files_under_directory(root)
+        elif os.path.isfile(root):
+            files.append(root)
+    return files
+
+
 def _get_mtime(file: str) -> float | None:
     """Return the file's st_mtime, or None if the file vanished.
 
@@ -150,50 +198,32 @@ def resolve_reload_targets(files: list[str], root: str) -> list[str]:
     return sorted(targets)
 
 
-# Module-level cache for get_files_changed. Previously stored as a
-# function attribute (get_files_changed.files_lasttime_changed_old),
-# which defeats static type analysis. Moved to module scope so ty can
-# track the type properly. `_watch_root` pairs the snapshot with the directory
-# it was taken under so a changed watch root re-seeds instead of reporting every
-# prior-root path as a deletion (#274 / D7).
-_files_lasttime_changed_old: dict[str, float] = {}
-_watch_root: str | None = None
+def get_files_changed(
+    watch_roots: list[str], package_root: str, snapshot: dict[str, float]
+) -> tuple[list[str], dict[str, float]]:
+    """Diff the watched files against `snapshot`; return (reload targets, new snapshot).
 
-
-def get_files_changed(directory: str) -> list[str]:
-    """Return the reload targets for files changed under `directory` (#274 / D1, D7).
-
-    First observation of a (new) watch root only seeds the snapshot and returns
-    no targets — a diff needs a prior baseline. Subsequent polls report new,
-    modified, and deleted paths, rolled up to reload targets by
-    `resolve_reload_targets`. Deletion matters for A3 (a removed `commands/*`
-    file is a command removal); the platform dir is still healthy so the rollup
+    Pure function (#281 / D3): no module-global state and no in-place mutation of
+    `snapshot`. The caller — the per-shell `precmd` — owns the snapshot dict and
+    swaps in the returned one, so each shell tracks its own platform subtree
+    independently (no consume-once sharing, the #281 fix). New, modified, and
+    deleted paths are rolled up to reload units by `resolve_reload_targets`
+    against `package_root` (the `plugins/nos` tree, so an A3 file still folds to
+    its platform dir, D8). Deletion matters for A3 (a removed `commands/*` file
+    is a command removal); the platform dir is still healthy so the rollup
     reloads it and the removal propagates.
 
-    Known dev-mode limitation: the snapshot is consume-once and shared by every
-    shell in the process. The first session to poll consumes a change, and the
-    ownership filter (#274 / D6) may then discard it — on a multi-host reload
-    server another platform's edit can be consumed-and-dropped before any
-    session of that platform observes it. Per-shell snapshots are the future
-    fix (pre-existing single-host assumption, 1st code review claude #2).
+    Unlike the #274 module-global watcher, there is no first-poll re-seed branch:
+    the per-shell baseline is seeded once at connection time (`__init__`, D5), so
+    every `precmd` poll diffs against that baseline and the first command can
+    already reflect an edit.
     """
-    global _files_lasttime_changed_old, _watch_root
-    files_under_directory = get_files_under_directory(directory)
-    # Re-seed (no diff) on the first poll of a watch root, so a stale
-    # prior-root snapshot does not surface every old path as a deletion. The
-    # root is the only seed key: an empty snapshot is a legitimate baseline
-    # (a root with no watched files yet), and treating it as "unseeded" would
-    # swallow the first file ever added to it (1st code review codex #2).
-    if _watch_root != directory:
-        _watch_root = directory
-        _files_lasttime_changed_old = get_files_lasttime_changed(files_under_directory)
-        return []
-    files_changed: list[str] = []
-    files_changed += get_new_files(list(_files_lasttime_changed_old.keys()), files_under_directory)
-    files_changed += get_files_recently_modified(files_under_directory, _files_lasttime_changed_old)
-    # Deletion (D7): paths in the prior snapshot that are gone from this walk.
-    current = set(files_under_directory)
-    files_changed += [path for path in _files_lasttime_changed_old if path not in current]
-    targets = resolve_reload_targets(files_changed, directory)
-    _files_lasttime_changed_old = get_files_lasttime_changed(files_under_directory)
-    return targets
+    files = get_files_under_roots(watch_roots)
+    current = set(files)
+    changed: list[str] = []
+    changed += get_new_files(list(snapshot), files)
+    changed += get_files_recently_modified(files, snapshot)
+    # Deletion: paths in the prior snapshot that are gone from this walk.
+    changed += [path for path in snapshot if path not in current]
+    targets = resolve_reload_targets(changed, package_root)
+    return targets, get_files_lasttime_changed(files)

--- a/tests/plugins/test_cmd_shell.py
+++ b/tests/plugins/test_cmd_shell.py
@@ -752,7 +752,8 @@ class HotReloadTest(TestCase):
     @patch("simnos.plugins.shell.cmd_shell.get_files_changed")
     def test_hot_reload_activated_does_enter(self, mock_get_files_changed):
         """Test that if there are no changed files, nothing happens."""
-        mock_get_files_changed.return_value = []
+        # #281: get_files_changed is now pure, returning (targets, new_snapshot).
+        mock_get_files_changed.return_value = ([], {})
         shell = CMDShell(**self.arguments)
         shell.precmd("show clock")
         mock_get_files_changed.assert_called_once()
@@ -766,7 +767,8 @@ class HotReloadTest(TestCase):
         and the commands are updated correctly.
         """
         changed_module = "simnos.plugins.nos.platforms_py.cisco_ios"
-        mock_get_files_changed.return_value = [changed_module.replace(".", "/") + ".py"]
+        # #281: get_files_changed is now pure, returning (targets, new_snapshot).
+        mock_get_files_changed.return_value = ([changed_module.replace(".", "/") + ".py"], {})
         shell = CMDShell(**self.arguments)
         shell.precmd("show clock")
         module = importlib.import_module(changed_module)

--- a/tests/plugins/test_cmd_shell_a3.py
+++ b/tests/plugins/test_cmd_shell_a3.py
@@ -15,6 +15,7 @@ tree is never mutated, so no xdist serialization is needed).
 import os
 import threading
 import time
+from unittest.mock import Mock
 
 import pytest
 
@@ -457,13 +458,22 @@ class TestA3HotReload:
 
         Pins the "本番無変更" core claim and guards against the env-gate / shadowing
         regression (2nd round claude#3): with `SIMNOS_RELOAD_COMMANDS` unset the
-        shell holds empty watch roots / snapshot and a None package root.
+        shell holds empty watch roots / snapshot and a None package root, AND the
+        watcher-build helpers are never called — so a future refactor that walks
+        unconditionally (then discards) is caught, not just the resulting state
+        (1st code review codex#4).
         """
         monkeypatch.delenv("SIMNOS_RELOAD_COMMANDS", raising=False)
+        watch_roots_spy = Mock(wraps=cmd_shell_module.platform_watch_roots)
+        under_roots_spy = Mock(wraps=cmd_shell_module.get_files_under_roots)
+        monkeypatch.setattr(cmd_shell_module, "platform_watch_roots", watch_roots_spy)
+        monkeypatch.setattr(cmd_shell_module, "get_files_under_roots", under_roots_spy)
         shell = _shell_for(Nos(filename=str(_a3_platform(tmp_path))))
         assert shell._watch_roots == []
         assert shell._reload_snapshot == {}
         assert shell._package_root is None
+        watch_roots_spy.assert_not_called()  # no walk derivation in production
+        under_roots_spy.assert_not_called()
 
     def test_post_commit_rebuild_failure_rolls_back_resolved_platform(self, tmp_path, caplog):
         """A reload that loads but fails `_rebuild` restores `resolved_platform` (D3).

--- a/tests/plugins/test_cmd_shell_a3.py
+++ b/tests/plugins/test_cmd_shell_a3.py
@@ -5,23 +5,22 @@ PR-1 covered the legacy adapter end of `_rebuild`; these pin the new A3 branch:
 shell merges the still-legacy inflows (BASIC, py-module commands, inventory)
 over the A3 statics with the right precedence and the A3 modes.
 
-`TestA3HotReload` pins the #274 dev hot-reload path on top: watcher rollup to a
-platform-dir target, the ownership filter, the `resolved_platform` rollback,
-and the mode-degrade contract — all against tmp platforms (the real tree is
-never mutated, so no xdist serialization is needed).
+`TestA3HotReload` pins the #274/#281 dev hot-reload path on top: per-platform
+watch rollup to a platform-dir target, per-shell snapshot isolation (multi-host /
+multi-session), the per-host reload lock (#281 / D6), the `resolved_platform`
+rollback, and the mode-degrade contract — all against tmp platforms (the real
+tree is never mutated, so no xdist serialization is needed).
 """
 
 import os
 import threading
 import time
-from types import SimpleNamespace
 
 import pytest
 
 from simnos.core.host import HostRenderConfig
 from simnos.core.nos import Nos
 from simnos.plugins.shell import cmd_shell as cmd_shell_module
-from simnos.plugins.shell import utils as shell_utils
 from simnos.plugins.shell.cmd_shell import CMDShell, build_resolved_platform
 
 
@@ -261,43 +260,60 @@ def _touch_future(path):
     os.utime(path, (future, future))
 
 
-class TestA3HotReload:
-    """Dev hot-reload over A3 platforms (#274).
+def _arista_platform(parent):
+    """A second minimal A3 platform (arista_eos) for the multi-host watch tests."""
+    root = parent / "arista_eos"
+    _write(root / "platform.yaml", 'modes:\n  user:\n    prompt: "{{ base_prompt }}>"\ninitial_mode: user\n')
+    _write(
+        root / "commands" / "show_version.yaml",
+        "command: show version\ntype: ntc\nmode: [user]\noutput: show_version.txt\n",
+    )
+    _write(root / "commands" / "show_version.txt", "Arista EOS\n")
+    return root
 
-    Covers the four designed behaviors: an A3 edit propagating through the real
-    `precmd` watch path (D1/D2), the post-commit `_rebuild` failure rolling back
-    `resolved_platform` (D3), the ownership filter with its build-time anchor
-    (D6), and the current-mode degrade on a reload that dropped the mode.
+
+def _enable_per_platform_watch(monkeypatch, watch_root, registry):
+    """Turn on hot-reload with a tmp-scoped per-platform watch (#281 / D2, D4).
+
+    Sets the env gate and points the two registry lookups `__init__` reads at the
+    tmp tree: `nos_plugins` (per-platform source list -> watch roots) and the
+    package `__path__` (the rollup `package_root`). Must run BEFORE the shell is
+    built, since #281 seeds the watcher baseline at `__init__` (D5).
     """
+    monkeypatch.setenv("SIMNOS_RELOAD_COMMANDS", "1")
+    monkeypatch.setattr(cmd_shell_module, "nos_plugins", registry)
+    monkeypatch.setattr(cmd_shell_module.nos_pkg, "__path__", [str(watch_root)])
 
-    @pytest.fixture(autouse=True)
-    def _reset_watcher(self):
-        # The watcher snapshot is module-global; reset around each test so a
-        # prior test's (or the real tree's) snapshot never leaks phantom
-        # changes/deletions into these tmp-root polls (#274 / D7).
-        shell_utils._files_lasttime_changed_old.clear()
-        shell_utils._watch_root = None
-        yield
-        shell_utils._files_lasttime_changed_old.clear()
-        shell_utils._watch_root = None
+
+class TestA3HotReload:
+    """Dev hot-reload over A3 platforms (#274 / #281).
+
+    Covers: an A3 edit / new-file propagating through the real `precmd` watch path
+    (per-platform watch, D1/D2), per-shell snapshot isolation across hosts and
+    sessions (#281 / D1), the per-host reload lock serializing concurrent reloads
+    and the `__init__` self-build read (#281 / D6), the env-off no-walk regression
+    (#281 / D2/D5), the post-commit `_rebuild` rollback (D3), and the current-mode
+    degrade on a reload that dropped the mode.
+
+    No watcher-reset fixture is needed: the snapshot is per-shell since #281, so a
+    tmp-root poll cannot leak into another test.
+    """
 
     def test_a3_edit_propagates_via_precmd(self, tmp_path, monkeypatch):
         """E2E: editing an A3 output file reaches the session through `precmd`.
 
-        Drives the real watch path (seed poll -> edit -> second poll), with the
-        watch root swapped to the tmp tree by replacing the `nos` module binding
-        in cmd_shell (safer than mutating the live package's `__path__`).
+        The watcher baseline is seeded at `__init__` (env on before construction),
+        so the first poll already detects the edit (#281 / D5 — no seed-only poll).
+        The watch root is the platform's own subtree via a tmp-scoped registry.
         """
         watch_root = tmp_path / "nos"
         platform_dir = _a3_platform(watch_root / "platforms")
+        _enable_per_platform_watch(monkeypatch, watch_root, {"cisco_ios": [str(platform_dir)]})
         shell = _shell_for(Nos(filename=str(platform_dir)))
-        monkeypatch.setenv("SIMNOS_RELOAD_COMMANDS", "1")
-        monkeypatch.setattr(cmd_shell_module, "nos", SimpleNamespace(__path__=[str(watch_root)]))
-        shell.precmd("show clock")  # first poll: seed only
         target_txt = platform_dir / "commands" / "show_version.txt"
         _write(target_txt, "Cisco IOS Software, Version 16.0\n")
         _touch_future(target_txt)
-        shell.precmd("show clock")  # second poll: detects the edit, reloads the dir
+        shell.precmd("show clock")  # poll: detects the edit against the __init__ baseline, reloads the dir
         assert shell.commands["show version"].output.render("R1") == "Cisco IOS Software, Version 16.0\n"
 
     def test_a3_new_command_file_appears_via_precmd(self, tmp_path, monkeypatch):
@@ -309,18 +325,145 @@ class TestA3HotReload:
         """
         watch_root = tmp_path / "nos"
         platform_dir = _a3_platform(watch_root / "platforms")
+        _enable_per_platform_watch(monkeypatch, watch_root, {"cisco_ios": [str(platform_dir)]})
         shell = _shell_for(Nos(filename=str(platform_dir)))
-        monkeypatch.setenv("SIMNOS_RELOAD_COMMANDS", "1")
-        monkeypatch.setattr(cmd_shell_module, "nos", SimpleNamespace(__path__=[str(watch_root)]))
-        shell.precmd("show clock")  # first poll: seed only
         assert "show clock" not in shell.commands
         _write(
             platform_dir / "commands" / "show_clock.yaml",
             "command: show clock\ntype: simnos\nmode: [user]\noutput: show_clock.txt\n",
         )
         _write(platform_dir / "commands" / "show_clock.txt", "12:00:00 UTC\n")
-        shell.precmd("show clock")  # second poll: new files detected, dir reloaded
+        shell.precmd("show clock")  # poll: new files detected, dir reloaded
         assert shell.commands["show clock"].output.render("R1") == "12:00:00 UTC\n"
+
+    def test_multi_host_edit_only_reloads_owning_shell(self, tmp_path, monkeypatch):
+        """Per-platform watch: an edit is observed by its own shell, not consumed by another (#281 / D1, D2).
+
+        The #281 core fix. Two shells of different platforms share the tree; the
+        non-owning shell polls FIRST. With the old process-global consume-once
+        snapshot it would consume cisco's edit and the cisco shell would then see
+        nothing (cross-host discard). With per-platform watch + per-shell snapshot,
+        the arista shell never walks cisco's subtree, so the cisco shell still
+        observes the edit on its own poll.
+        """
+        watch_root = tmp_path / "nos"
+        cisco_dir = _a3_platform(watch_root / "platforms")
+        arista_dir = _arista_platform(watch_root / "platforms")
+        _enable_per_platform_watch(
+            monkeypatch, watch_root, {"cisco_ios": [str(cisco_dir)], "arista_eos": [str(arista_dir)]}
+        )
+        cisco_shell = _shell_for(Nos(filename=str(cisco_dir)))
+        arista_shell = _shell_for(Nos(filename=str(arista_dir)))
+        cisco_txt = cisco_dir / "commands" / "show_version.txt"
+        _write(cisco_txt, "Cisco IOS 99\n")
+        _touch_future(cisco_txt)
+        arista_shell.precmd("show clock")  # polls first; watches only its own subtree -> does not consume cisco's edit
+        assert arista_shell.commands["show version"].output.render("R1") == "Arista EOS\n"
+        cisco_shell.precmd("show clock")  # still observes the edit (not discarded by arista)
+        assert cisco_shell.commands["show version"].output.render("R1") == "Cisco IOS 99\n"
+
+    def test_multi_session_same_host_both_reload(self, tmp_path, monkeypatch):
+        """Two sessions of one host each reflect an edit independently (#281 / D1).
+
+        They share one `Nos` (as in production), but each shell owns its snapshot,
+        so the second session is not starved by the first consuming the change —
+        the multi-session staleness the old consume-once snapshot caused.
+        """
+        watch_root = tmp_path / "nos"
+        platform_dir = _a3_platform(watch_root / "platforms")
+        _enable_per_platform_watch(monkeypatch, watch_root, {"cisco_ios": [str(platform_dir)]})
+        nos_obj = Nos(filename=str(platform_dir))
+        shell1 = _shell_for(nos_obj)
+        shell2 = _shell_for(nos_obj)
+        txt = platform_dir / "commands" / "show_version.txt"
+        _write(txt, "Shared V2\n")
+        _touch_future(txt)
+        shell1.precmd("show clock")
+        assert shell1.commands["show version"].output.render("R1") == "Shared V2\n"
+        shell2.precmd("show clock")  # independent snapshot -> also reflects the edit
+        assert shell2.commands["show version"].output.render("R1") == "Shared V2\n"
+
+    def test_concurrent_reload_same_lock_no_corruption(self, tmp_path):
+        """Two sessions reloading concurrently under the shared host lock stay consistent (#281 / D6).
+
+        Injects ONE lock into both shells (as `Host.start` does per host) and
+        fires `reload_commands` from two threads at a barrier. Per-shell fallback
+        locks would not serialize the shared-`nos` mutation, so the explicit
+        single lock is what this pins; both shells must end consistent and the
+        shared nos uncorrupted.
+        """
+        platform_dir = _a3_platform(tmp_path)
+        nos_obj = Nos(filename=str(platform_dir))
+        lock = threading.Lock()
+        common = {"nos_inventory_config": {}, "base_prompt": "R1"}
+        shell1 = CMDShell(nos=nos_obj, is_running=threading.Event(), reload_lock=lock, **common)
+        shell2 = CMDShell(nos=nos_obj, is_running=threading.Event(), reload_lock=lock, **common)
+        _write(platform_dir / "commands" / "show_version.txt", "Concurrent\n")
+        barrier = threading.Barrier(2)
+        errors: list[BaseException] = []
+
+        def _reload(sh):
+            barrier.wait()
+            try:
+                sh.reload_commands([str(platform_dir)])
+            except BaseException as exc:  # surface any thread failure to the assert
+                errors.append(exc)
+
+        threads = [threading.Thread(target=_reload, args=(sh,)) for sh in (shell1, shell2)]
+        for t in threads:
+            t.start()
+        for t in threads:
+            t.join()
+        assert not errors
+        assert shell1.commands["show version"].output.render("R1") == "Concurrent\n"
+        assert shell2.commands["show version"].output.render("R1") == "Concurrent\n"
+        assert nos_obj.name == "cisco_ios"  # shared nos not corrupted by the concurrent reloads
+
+    def test_init_self_build_acquires_reload_lock(self, tmp_path):
+        """A new connection's self-build runs under the reload lock (#281 / D6, gemini#1).
+
+        When `resolved_platform` is None (hot-reload mode) the `__init__` builds
+        from the shared `nos`; that read must hold the per-host lock so a
+        concurrent executor reload cannot mutate `nos` mid-read. Holding the lock
+        in the main thread must therefore block a shell construction until release.
+        """
+        platform_dir = _a3_platform(tmp_path)
+        nos_obj = Nos(filename=str(platform_dir))
+        lock = threading.Lock()
+        built: list[CMDShell] = []
+
+        def _build():
+            built.append(
+                CMDShell(
+                    nos=nos_obj,
+                    nos_inventory_config={},
+                    base_prompt="R1",
+                    is_running=threading.Event(),
+                    reload_lock=lock,
+                )
+            )
+
+        with lock:
+            t = threading.Thread(target=_build)
+            t.start()
+            t.join(timeout=0.3)
+            blocked = not built  # self-build is waiting on the held lock
+        t.join(timeout=2)
+        assert blocked
+        assert built  # proceeds once the lock is released
+
+    def test_env_off_builds_no_watcher_state(self, tmp_path, monkeypatch):
+        """Production (env off): `__init__` builds no watcher state and does no walk (#281 / D2, D5).
+
+        Pins the "本番無変更" core claim and guards against the env-gate / shadowing
+        regression (2nd round claude#3): with `SIMNOS_RELOAD_COMMANDS` unset the
+        shell holds empty watch roots / snapshot and a None package root.
+        """
+        monkeypatch.delenv("SIMNOS_RELOAD_COMMANDS", raising=False)
+        shell = _shell_for(Nos(filename=str(_a3_platform(tmp_path))))
+        assert shell._watch_roots == []
+        assert shell._reload_snapshot == {}
+        assert shell._package_root is None
 
     def test_post_commit_rebuild_failure_rolls_back_resolved_platform(self, tmp_path, caplog):
         """A reload that loads but fails `_rebuild` restores `resolved_platform` (D3).
@@ -351,36 +494,6 @@ class TestA3HotReload:
         assert len(caplog.records) == 1
         assert nos_obj.resolved_platform is old_platform  # rolled back, not the modeless parse
         assert shell.commands is old_commands  # live session untouched
-
-    def test_foreign_platform_dir_is_skipped(self, tmp_path):
-        """The ownership filter keeps a sibling platform's reload out (D6)."""
-        watch_root = tmp_path / "nos"
-        own_dir = _a3_platform(watch_root / "platforms")
-        foreign_dir = watch_root / "platforms" / "arista_eos"
-        _write(foreign_dir / "platform.yaml", 'modes:\n  user:\n    prompt: "{{ base_prompt }}%"\ninitial_mode: user\n')
-        _write(foreign_dir / "commands" / "default.yaml", "command: _default_\ntype: simnos\n")
-        nos_obj = Nos(filename=str(own_dir))
-        shell = _shell_for(nos_obj)
-        old_platform = nos_obj.resolved_platform
-        shell.reload_commands([str(foreign_dir)])
-        assert nos_obj.name == "cisco_ios"  # not hijacked
-        assert nos_obj.resolved_platform is old_platform
-
-    def test_ownership_anchor_survives_live_name_overwrite(self, tmp_path):
-        """The filter compares against the build-time anchor, not live `nos.name` (D6).
-
-        A foreign py reload can overwrite live `nos.name` (its commit phase sets
-        the module's NAME); if the filter read `nos.name` it would then skip
-        this session's own platform forever. The captured `_platform_name` is
-        immune to that overwrite.
-        """
-        platform_dir = _a3_platform(tmp_path)
-        nos_obj = Nos(filename=str(platform_dir))
-        shell = _shell_for(nos_obj)
-        nos_obj.name = "arista_eos"  # simulate the foreign-py NAME overwrite
-        _write(platform_dir / "commands" / "show_version.txt", "Reloaded fine\n")
-        shell.reload_commands([str(platform_dir)])
-        assert shell.commands["show version"].output.render("R1") == "Reloaded fine\n"  # not skipped
 
     def test_removed_mode_degrades_to_initial(self, tmp_path):
         """A reload that drops the current mode resets the session to initial_mode."""

--- a/tests/plugins/test_shell_utils.py
+++ b/tests/plugins/test_shell_utils.py
@@ -8,6 +8,7 @@ import time
 from unittest import TestCase
 from unittest.mock import patch
 
+from simnos.plugins.nos import nos_plugins
 from simnos.plugins.shell.utils import (
     get_files_changed,
     get_files_lasttime_changed,
@@ -308,6 +309,22 @@ def test_platform_watch_roots_dual_source():
 def test_platform_watch_roots_unregistered_empty():
     """An unregistered platform (empty sources) yields no watch roots (graceful, #281 / D4)."""
     assert platform_watch_roots([]) == []
+
+
+def test_platform_watch_roots_real_tree_legacy_jinja_coverage():
+    """Smoke: the real huawei_smartax legacy jinja inputs stay covered (#281 / D4, codex#5).
+
+    huawei_smartax is the one shipped platform using the legacy
+    `configurations/<name>.yaml.j2` layout (plus `templates/<name>/`). Driving the
+    real registry entry through `platform_watch_roots` -> `get_files_under_roots`
+    catches a legacy-layout move the synthetic-path tests above would miss, since
+    those build paths rather than walk the tree.
+    """
+    files = set(get_files_under_roots(platform_watch_roots(nos_plugins["huawei_smartax"])))
+    assert any(os.path.basename(f) == "huawei_smartax.yaml.j2" for f in files)  # configurations/<name>.yaml.j2
+    assert any(
+        f.endswith(".j2") and os.path.basename(os.path.dirname(f)) == "huawei_smartax" for f in files
+    )  # templates/huawei_smartax/*.j2
 
 
 def test_get_files_under_roots_mixes_dir_file_and_skips_missing(tmp_path):

--- a/tests/plugins/test_shell_utils.py
+++ b/tests/plugins/test_shell_utils.py
@@ -8,15 +8,14 @@ import time
 from unittest import TestCase
 from unittest.mock import patch
 
-import pytest
-
-from simnos.plugins.shell import utils as shell_utils
 from simnos.plugins.shell.utils import (
     get_files_changed,
     get_files_lasttime_changed,
     get_files_recently_modified,
     get_files_under_directory,
+    get_files_under_roots,
     get_new_files,
+    platform_watch_roots,
     resolve_reload_targets,
 )
 
@@ -54,35 +53,12 @@ original_os_stat = os.stat
 
 
 class ShellUtilsTest(TestCase):
+    """Test class for the shell utils.
+
+    `get_files_changed` is a pure function since #281 (no module-global snapshot),
+    so these tests need no reset fixture: each call diffs an explicit caller-owned
+    snapshot against the current walk.
     """
-    Test class for the shell utils
-    """
-
-    def setUp(self):
-        """Reset the stateful get_files_changed cache before each test.
-
-        Other tests in the same pytest-xdist worker (e.g. the hot-reload
-        integration tests, which exercise `get_files_changed` via `precmd`
-        with the absolute `nos.__path__[0]`) may have primed the
-        module-level `_files_lasttime_changed_old` snapshot; without a
-        reset, the relative-path calls below would treat every file as
-        "new" and the first-call-returns-empty contract breaks. `_watch_root`
-        is reset too so the next call re-seeds rather than diffing against a
-        prior root's snapshot (#274 / D7).
-        """
-        shell_utils._files_lasttime_changed_old.clear()
-        shell_utils._watch_root = None
-
-    def tearDown(self):
-        """Avoid leaking the stateful cache to other tests.
-
-        Note: the previous implementation deleted the function attribute
-        `get_files_changed.files_lasttime_changed_old`, which silently
-        became a no-op when the cache moved to the module-level
-        `_files_lasttime_changed_old` (ty adoption, M-9).
-        """
-        shell_utils._files_lasttime_changed_old.clear()
-        shell_utils._watch_root = None
 
     def test_get_files_under_directory(self):
         """
@@ -157,27 +133,26 @@ class ShellUtilsTest(TestCase):
         self.assertNotIn(vanished, modified)
 
     def test_get_files_changed(self):
-        """
-        Test to check if we get the reload targets for files that changed.
+        """A changed file rolls up to its reload target against a caller snapshot.
 
-        `get_files_changed` now returns reload targets, not raw changed files
-        (#274 / D1): a changed A3 command file is rolled up to its platform dir,
-        a `.py` module stays itself. The first call only seeds the snapshot.
+        `get_files_changed` returns (reload targets, new snapshot) (#281 / D3): a
+        changed A3 command file is rolled up to its platform dir, a `.py` module
+        stays itself. The caller owns the baseline snapshot (seeded at connection
+        time), so the test seeds it explicitly, then diffs with RANDOM_FILE bumped.
         """
-        targets = get_files_changed("simnos/plugins/nos")
-        self.assertFalse(targets)  # first call: seed only, no diff
+        roots = ["simnos/plugins/nos"]
+        package_root = "simnos/plugins/nos"
+        snapshot = get_files_lasttime_changed(get_files_under_roots(roots))  # baseline (real mtimes)
         with patch("os.stat", side_effect=mock_os_stat):
-            targets = get_files_changed("simnos/plugins/nos")
+            targets, _new_snapshot = get_files_changed(roots, package_root, snapshot)
         # RANDOM_FILE is the only change, so the result is exactly its rollup target.
-        self.assertEqual(targets, resolve_reload_targets([RANDOM_FILE], "simnos/plugins/nos"))
+        self.assertEqual(targets, resolve_reload_targets([RANDOM_FILE], package_root))
 
     def test_get_files_changed_null(self):
-        """
-        Test to check if we don't get the files that have been changed
-        """
-        targets = get_files_changed("simnos/plugins/nos")
-        self.assertFalse(targets)
-        targets = get_files_changed("simnos/plugins/nos")
+        """No change against a freshly-seeded snapshot yields no reload targets."""
+        roots = ["simnos/plugins/nos"]
+        snapshot = get_files_lasttime_changed(get_files_under_roots(roots))
+        targets, _new_snapshot = get_files_changed(roots, "simnos/plugins/nos", snapshot)
         self.assertFalse(targets)
 
 
@@ -297,49 +272,82 @@ def test_resolve_targets_drops_deleted_platform_dir(tmp_path):
     assert resolve_reload_targets([ghost_yaml, ghost_j2], str(root)) == []
 
 
-@pytest.fixture
-def _clean_watcher():
-    """Reset the module-global watcher snapshot around a test (#274 / D7).
-
-    Same contract as `ShellUtilsTest.setUp/tearDown` and the autouse fixture in
-    `test_cmd_shell_a3.TestA3HotReload` — without it, another test's snapshot
-    (possibly for a different root) leaks phantom changes into this one.
-    """
-    shell_utils._files_lasttime_changed_old.clear()
-    shell_utils._watch_root = None
-    yield
-    shell_utils._files_lasttime_changed_old.clear()
-    shell_utils._watch_root = None
+# --- platform_watch_roots / get_files_under_roots (#281 / D4) ----------------
 
 
-def test_get_files_changed_root_change_reseeds(tmp_path, _clean_watcher):
-    """A changed watch root re-seeds instead of reporting all prior paths (#274 / D7)."""
-    root_a = _make_nos_tree(tmp_path / "a")
-    root_b = _make_nos_tree(tmp_path / "b")
-    assert get_files_changed(str(root_a)) == []  # seed A
-    assert get_files_changed(str(root_b)) == []  # root change -> re-seed, no phantom diff
+def test_platform_watch_roots_a3_dir():
+    """An A3 dir source maps to the dir itself (recursively walked)."""
+    a3_dir = os.path.join("x", "platforms", "cisco_ios")
+    assert platform_watch_roots([a3_dir]) == [a3_dir]
 
 
-def test_get_files_changed_detects_deletion(tmp_path, _clean_watcher):
-    """Deleting a command file rolls up to the (healthy) platform dir (#274 / D7)."""
+def test_platform_watch_roots_legacy_py():
+    """A legacy `<name>.py` maps to the `.py` plus its jinja inputs."""
+    py = os.path.join("x", "platforms_py", "foo.py")
+    base = os.path.join("x", "platforms_py")
+    assert platform_watch_roots([py]) == [
+        py,
+        os.path.join(base, "configurations", "foo.yaml.j2"),
+        os.path.join(base, "templates", "foo"),
+    ]
+
+
+def test_platform_watch_roots_dual_source():
+    """A dual-source platform (A3 dir + py) yields both, the py expanded to its jinja."""
+    a3_dir = os.path.join("x", "platforms", "cisco_ios")
+    py = os.path.join("x", "platforms_py", "cisco_ios.py")
+    base = os.path.join("x", "platforms_py")
+    assert platform_watch_roots([a3_dir, py]) == [
+        a3_dir,
+        py,
+        os.path.join(base, "configurations", "cisco_ios.yaml.j2"),
+        os.path.join(base, "templates", "cisco_ios"),
+    ]
+
+
+def test_platform_watch_roots_unregistered_empty():
+    """An unregistered platform (empty sources) yields no watch roots (graceful, #281 / D4)."""
+    assert platform_watch_roots([]) == []
+
+
+def test_get_files_under_roots_mixes_dir_file_and_skips_missing(tmp_path):
+    """A dir root is walked, a file root is taken as-is, a missing root is skipped (#281 / D4)."""
+    d = tmp_path / "dir"
+    d.mkdir()
+    (d / "a.yaml").write_text("x", encoding="utf-8")
+    mod = tmp_path / "mod.py"
+    mod.write_text("x", encoding="utf-8")
+    missing = str(tmp_path / "nope" / "x.yaml.j2")
+    files = set(get_files_under_roots([str(d), str(mod), missing]))
+    assert files == {str(d / "a.yaml"), str(mod)}
+
+
+# --- get_files_changed pure-function diffs (#281 / D3) -----------------------
+
+
+def test_get_files_changed_detects_deletion(tmp_path):
+    """Deleting a command file rolls up to the (healthy) platform dir (#281 / D3)."""
     root = _make_nos_tree(tmp_path)
     platform_dir = str(root / "platforms" / "cisco_ios")
-    assert get_files_changed(str(root)) == []  # seed
+    roots = [platform_dir]  # per-platform watch root (D2)
+    snapshot = get_files_lasttime_changed(get_files_under_roots(roots))  # baseline
     (root / "platforms" / "cisco_ios" / "commands" / "show.yaml").unlink()
-    assert get_files_changed(str(root)) == [platform_dir]
+    targets, _new_snapshot = get_files_changed(roots, str(root), snapshot)
+    assert targets == [platform_dir]
 
 
-def test_get_files_changed_empty_root_first_file_detected(tmp_path, _clean_watcher):
-    """A file added to an initially-empty root is detected, not swallowed by re-seed.
+def test_get_files_changed_new_file_detected(tmp_path):
+    """A file added after the baseline seed is detected as a new reload target (#281 / D3).
 
-    The seed condition keys on the watch root only: an empty snapshot is a
-    legitimate baseline (a root with no watched files yet). Keying on snapshot
-    emptiness would re-seed on the next poll and swallow the first file ever
-    added (1st code review codex #2, taken in at final-refactor).
+    Mirrors the connection-time seed (an initially-empty snapshot) followed by a
+    new `.py` plugin appearing — the per-shell baseline diffs it as new.
     """
     root = tmp_path / "nos"
-    (root / "platforms_py").mkdir(parents=True)
-    assert get_files_changed(str(root)) == []  # seed: empty but valid baseline
-    newplugin = root / "platforms_py" / "newplugin.py"
+    pyroot = root / "platforms_py"
+    pyroot.mkdir(parents=True)
+    roots = [str(pyroot)]
+    snapshot = get_files_lasttime_changed(get_files_under_roots(roots))  # empty but valid baseline
+    newplugin = pyroot / "newplugin.py"
     newplugin.write_text("NAME = 'x'\n", encoding="utf-8")
-    assert get_files_changed(str(root)) == [str(newplugin)]
+    targets, _new_snapshot = get_files_changed(roots, str(root), snapshot)
+    assert targets == [str(newplugin)]


### PR DESCRIPTION
🐙claude:

## 概要
Issue #281（epic #263 / v3、#274 由来）。dev hot-reload の変更検知 watcher が **module-global な consume-once snapshot をプロセス内の全 shell で共有** していた問題を構造的に解消する。

### 問題
`get_files_changed` が module-global snapshot（`_files_lasttime_changed_old` / `_watch_root`）を全 shell で共有する consume-once 方式だったため:
- **マルチ host（重大）**: 先に poll した別 platform の shell が変更を消費 → ownership filter で reload skip → 編集した platform の shell が「変更なし」になる cross-host discard
- **同一 host マルチ session（軽微）**: 1 session が消費・reload 後、他 session が stale

## 変更内容（採用案B）
- **D1/D3**: `get_files_changed(watch_roots, package_root, snapshot) -> (targets, new_snapshot)` を純粋関数化。module-global を廃止し、各 shell が自分の snapshot を保持
- **D2/D4**: `platform_watch_roots` / `get_files_under_roots` を新設し、各 shell が `nos_plugins.get(self.nos.name, [])` 由来の **自 platform subtree のみ** 監視（30+ NOS ツリー walk → 1 NOS 分に縮小）
- **D5**: watcher 状態は `SIMNOS_RELOAD_COMMANDS` 有効時のみ `__init__` で構築・seed。本番（env off）は walk もロック取得もしない
- **D6**: 共有 `Nos` の reload/read を host 単位 `threading.Lock` で直列化（`reload_commands` 本体全体 + hot-reload mode の `__init__` self-build read）。lock は `Host.start → server kwarg`（concrete SSH/Telnet + base の 3 `__init__`）経由で注入、`HostRenderConfig` は不変
- **D7**: per-platform watch で foreign target が構造上出ないため、ownership filter（#274/D6）と `_platform_name` capture を撤去（到達不能 dead code）

## テスト
- `tests/plugins/test_shell_utils.py`: 純粋関数 API へ移行、reset fixture 廃止、`platform_watch_roots` / `get_files_under_roots` の導出 test 追加（A3 / legacy / dual-source / 未登録 / 実 tree legacy jinja smoke）
- `tests/plugins/test_cmd_shell_a3.py`: ownership filter test 2 本撤去、precmd E2E 2 本を per-platform watch + env-at-init へ移行、マルチ host / マルチ session / 並行 reload（同一 lock 注入）/ self-build lock / env-off no-walk の統合 test 追加
- full suite（`-n auto`、integration 含む）= **1139 passed, 7 skipped, 1 xfailed**、ruff + ruff format + ty 全 green

## レビュー
設計 cross-review 3 round 収束 + final-refactor 通過。コード cross-review 1st round = codex/gemini/claude 全員 **SUGGESTION**（MUST/SHOULD なし）→ 4 件取り込み（precmd ゲート堅牢化＋assert 撤去 / event-loop stall コメント / no-walk test 強化 / 実 tree legacy jinja smoke test）→ final-refactor 両 phase クリーン。

🤖 Generated with [Claude Code](https://claude.com/claude-code)