### PR TITLE
fix: get_host_commands が callable の動的遷移コマンドを sweep しないよう修正 (#115)

### DIFF
--- a/docs/changelog.ja.md
+++ b/docs/changelog.ja.md
@@ -1,0 +1,200 @@
+# 変更履歴 (Changelog)
+
+SIMNOS の主要な変更点をここに記録します。
+詳細は [GitHub Releases](https://github.com/Route-Reflector/simnos/releases) を参照してください。
+
+## Unreleased
+
+<!-- リリース時にこの見出しを `## v3.0.0 - YYYY-MM-DD` に差し替える。 -->
+
+SIMNOS v3 は SSH/Telnet コアとプラグインのデータレイアウトを clean rewrite した
+ものです。破壊的変更は以下の移行ガイドに集約しています。各行は後述の詳細エントリへ
+リンクしています。
+
+**v2 からの移行 (Migration from v2)**
+
+_v2 に留まる場合 (移行期間)_ — v2 は critical / security 修正のみの移行期間として
+保守されます。移行の準備が整うまでは、以下のいずれかで固定してください:
+
+- PyPI: `pip install "simnos<3"`
+- Docker: メジャータグ `simnos:2` を pin する (`:latest` は v3 を追うので使わない)
+- git: `v2.4.0` タグ、または `2.x` メンテナンスブランチを pin する
+
+_v3 へ上げる場合_ — 該当する変更をそれぞれ適用してください:
+
+| こういう場合… | こうする |
+|---|---|
+| インベントリで `platform:` を使っている | キーを `device_type:` に改名する — エイリアスは無く `platform:` はロード時に拒否されます (`sed -i 's/^\([[:space:]]*\)platform:/\1device_type:/' inventory.yaml`)。#266 参照 |
+| `ParamikoSshServer` プラグインを設定している | 削除する — `AsyncSshServer` が既定の SSH プラグインです。`ssh_key_file` / `ssh_banner` / `authorized_keys` はそのまま引き継がれます。#297 参照 |
+| `simnos -i inventory.yaml` (または素の `simnos`) で起動している | サブコマンド形式を使う: `simnos up -i inventory.yaml` (default inventory なら `simnos up`)。#267 参照 |
+| リッスンポート `6000` / `6001` / `6002` をハードコードしている | `start()` 後に `net.hosts[<name>].port` から実ポートを読む (CLI もログ出力します)。既定ポートは OS 割り当てになりました。#271 参照 |
+| シェルの `configuration` ブロックで `ruler` / `completekey` を設定している | 削除する — ロード時に拒否されます (`extra="forbid"`)。#303 参照 |
+| `paramiko` を推移的依存として当てにしている | ランタイム依存ではなくなりました — 自前コードで import していたなら明示的に依存を追加してください。#297 参照 |
+
+scraper (netmiko / scrapli / ansible) から見た wire 上の挙動は不変で、byte-parity
+golden で固定されています — コマンドを送って出力を読むだけの自動化ツールにクライアント
+側の変更は不要です。
+
+**破壊的変更**
+
+- インベントリのキー `platform` を `device_type` に改名 (v3, #266)。互換エイリアスはありません。`platform:` を使う v2 インベントリはロード時に拒否されます。移行はキーを書き換える (`sed -i 's/^\([[:space:]]*\)platform:/\1device_type:/' inventory.yaml`) か、v2 に固定する (`pip install "simnos<3"`、移行期間として保守) かのいずれかです。`device_type` にはプラットフォームの内部名 / `netmiko_device_type` / `ntc_platform` エイリアスのいずれも指定でき、データ駆動の逆引きインデックスを介してすべて同一プラットフォームに解決されます (#266)
+- SSH / Telnet サーバのトランスポートを、共有 asyncio イベントループ上の非同期バックエンドに置換: SSH は `asyncssh` (旧 paramiko)、Telnet は `telnetlib3` で動作し、いずれも単一の push-dispatch セッションループで駆動されます (#297)。`ParamikoSshServer` プラグインとその inventory 設定は削除されました — `AsyncSshServer` (既定の SSH プラグイン) を使ってください。既存の `ssh_key_file` / `ssh_banner` / `authorized_keys` オプションはそのまま引き継がれます。同梱の DH-GEX moduli ファイルと paramiko GEX ワークアラウンドは削除され (asyncssh が moduli を自前でネゴシエート)、`paramiko` はランタイム依存ではなくなりました (byte-parity / 相互運用テストのクライアント用に dev 依存として残置)
+- CLI をサブコマンド方式に再構成: `simnos up` でサーバを起動し、`simnos list-platforms` で対応プラットフォームを一覧します (#267)。v2 のフラット形式 (`simnos -i inventory.yaml`、または default inventory 用の素の `simnos`) はもうパースされません — サブコマンドが必須になりました (`simnos up -i inventory.yaml`、または default inventory 用の `simnos up`)。`up` にはアドホックな単一ホストモード (`-d/--device-type` に加えて任意で `-p/--port`、`-n/--host-name`、`-u/--username`、`-w/--password`) も追加され、インベントリファイルなしで単発のプラットフォームを起動できます。`-l/--log-level` と `-r/--reload-commands` は各サブコマンド共通のフラグとして引き継がれます
+- 既定のリッスンポートを、固定値 `6000` / `6001` / `6002` から OS 割り当て (ephemeral) に変更 (#271)。引数なしの `SimNOS()` (組み込み default inventory) と `port: 0` を指定したインベントリホストは、`bind()` 時に OS がアトミックに選んだポートにバインドします。実ポートは `start()` 後に `host.port` から読み戻してください (CLI は `host <name> listening on <addr>:<port>` をログ出力します)。これにより macOS CI で見られたワーカー間のポート衝突フレーク (`OSError: Errno 48`) が解消します。`6000` をハードコードしていた呼び出し側やテストは、代わりに `net.hosts[<name>].port` を読む必要があります。replicas リスト経路は依然として明示的な `ge=1` ポートを要求します — ephemeral は単一ホスト専用です
+- `ruler` / `completekey` シェル設定ノブを、それが属していた `cmd.Cmd` 基底クラスとともに削除 (#303)。これらを設定するインベントリ `configuration` ブロックはロード時に拒否されます (`extra="forbid"`) — キーを削除してください。scraper (netmiko / scrapli / ansible) から見た wire 上の挙動は不変で、byte-parity golden で固定されています
+
+**機能強化**
+
+- トポロジ inventory とは別の、最小限の環境設定ファイル `sys_config.yaml` (`data_dir`、`variants_policy`) を導入。`sys_config=` 引数、`SIMNOS_SYS_CONFIG` 環境変数、`./sys_config.yaml`、`~/.simnos/sys_config.yaml` の順で探索し、`SIMNOS_DATA_DIR` が `data_dir` を上書きします。設定の優先順位 `CLI > env > inventory(host > default) > sys_config > builtin` を確立します。両フィールドは予約 (no-op、ロード時に警告) で、#265 / #267 で実配線されます (#266)
+- インベントリフィールド `facts` / `overlay` / `variants_policy` を #265 のスキーマの器として予約。検証はされますがまだ誰も消費しません。設定されているが不活性な値は暗黙に無視せず `log.warning` で顕在化します (#266)
+- プラグインのプラットフォームレイアウトを A3 ディレクトリ形式に移行: 従来のモノリシックなプラットフォーム単位 YAML を、プラットフォーム単位の `platform.yaml` (modes + prompts) と、`commands/*.yaml` 配下のコマンド 1 個 1 ファイル (隣接する `.txt` / `.j2` 出力) に置換 (#264)。`command` フィールドが単一の真実の源 (SSoT) で、ビルド時 lint (`invoke lint-platform-data`) が encoding / 参照 / 拡張子の規約を強制します。任意の動的挙動は引き続き `platforms_py/<nos>.py` に置けます
+- データ駆動の facts レンダリングとコマンド単位の出力バリアントを追加 (#287)。コマンド出力は `.j2` テンプレート + 隣接するサイドカー `.json` (ビルド時に厳格検証) の facts として記述でき、コマンドは `variants_policy` (`int` / `random`、任意で seed) で選択される複数の `variants` を宣言できます。canonical 出力を共有し、二相のアトミック swap で書き出します
+- SSH セッションに対話的ラインエディタを追加: `?` の文脈ヘルプ (現在モードのコマンド一覧)、コマンドツリーに対する Tab 補完、`↑` / `↓` 履歴、`←` / `→` カーソル移動と backspace を、push-dispatch ループ上の軽量 readline レイヤとして実装 (#303)。編集シーケンスは対話的なキー入力時のみ出力されるため、scraper からのフルライン入力には影響せず byte-parity で同一を維持します
+- 実機式のコマンド省略マッチを追加: トークン単位で一意な prefix が完全なコマンドに解決され、曖昧なときは `% Ambiguous command`、部分一致のときは incomplete-command メッセージを返します (#305)。省略マッチは dispatch コア (既定 ON) と Tab 補完で共有されます
+- 長い出力向けにターミナルページング (`--More--`) を追加 (#307)。ページ高は PTY / Telnet NAWS の行数に従い (取得できなければ `sys_config.paging.default_rows`、既定 24 にフォールバック)、`terminal length 0` 系のコマンドはそのセッションのページングを無効化します (`disables_paging` データフラグ)。非対話クライアント (netmiko の `height=1000`、scraper) は byte-parity を保つ行数ゲートを通じてページャをバイパスします。`--More--` 文字列はプラットフォームデータです (`platform.yaml` の `paging.more_prompt`、Cisco 既定は `" --More-- "`)
+- コマンドの hot-reload ウォッチャ (`SIMNOS_RELOAD_COMMANDS`) を、per-shell スナップショット + プラットフォーム単位 watch にスコープし、共有 reload を host ロック下で直列化することで、並行セッションと競合しないようにしました (#281)
+
+## v2.3.1
+
+**バグ修正**
+
+- DH Group Exchange (DH-GEX) moduli ファイル (`simnos/plugins/servers/moduli`、2048 + 3072 ビット素数を連結) を同梱し、システム moduli が無いときのフォールバックとしてロード。Windows / macOS で `gex-sha256` の advertise を復活させ、`netmiko.fortinet.FortinetSSH` のような SHA-1 寄りのレガシー SSH クライアントが再び KEX を完了できるようにします — v2.3.0 の Known Issues に挙げた `pytest-full-matrix` の Win/macOS 決定的失敗を解消します。Linux の挙動は不変 (システムの `/etc/ssh/moduli` が引き続き優先)。既存の `_default_key_lock` パターンに倣った thread-safe な one-shot ロードキャッシュ用に `_moduli_lock` を追加し、同梱欠落 / 同梱破損の退行経路に `log.error` アラームを追加。4096 ビット素数は VM ホストでの ssh-keygen `-M screen` 実行時間の都合で将来の chore PR に先送り (#189)
+
+**ツール**
+
+- ローテーションポリシー (3 年ごと、logjam 級イベント時はアドホック) と `ssh-keygen` による再生成手順を記した `docs/development/regenerate_moduli.md` (+ `.ja.md` i18n) を追加 (#189)
+- リリース時の `unzip -l dist/*.whl | grep moduli` / `tar tzf dist/*.tar.gz | grep moduli` アサーションを `pypi-publish.yml` に追加し、同梱 moduli を落とすパッケージング退行を publish 前に検出 (#189)
+
+## v2.3.0
+
+**破壊的変更**
+
+- `hp_comware` プラットフォームを、従来の Cisco 風プロンプト (`>`/`#`/`(config)#`) ではなく実機の HP Comware CLI 規約 (`<HOST>` user view / `[HOST]` system view) に沿って書き直し。`enable` / `ex` コマンドを削除 (HP には存在しない) し、`system-view` / `return` / `quit` を追加。hp_comware の netmiko / scrapli / ansible 相互運用が追加設定なしで動作するようになりました。従来の `enable` コマンドをスクリプトで叩いていた直接 CLI ユーザは、`system-view` を使うようスクリプトを更新する必要があります (#173, closes #136)
+
+**新機能**
+
+- `cisco_ios` 向けに netmiko / scrapli / ansible 互換 CI ワークフロー (`workflow_dispatch`) を追加。`compatibility` pytest マーカーと `compatibility` オプション依存グループ (`scrapli`、`ansible-core`) でゲートした新しい `tests/compatibility/` テストスイート。各ライブラリは独立した CI ジョブとして実行されます。netmiko + scrapli 完全互換のため `terminal width 512` / `configure terminal` / `end` / `exit` を `cisco_ios.yaml` に追加 (#177, closes #125 Phase 1+2+3)
+- NTC Templates v9.1 コマンドを 10 プラットフォームに追加 — `mikrotik_routeros` (25)、`linux` (15)、`alcatel_aos` (12)、`alcatel_sros` (7)、`ciena_saos` (5)、`aruba_os` (4)、`extreme_exos` (2)、`hp_procurve` (2)、`paloalto_panos` (2)、`aruba_aoscx` (1): 合計 75 コマンド (#174)
+- NTC Templates v9.1 コマンドを `hp_comware` に追加 — `display bgp peer ipv4` / `display link-aggregation member-port`: 2 コマンド。`#128` NTC v9.1 エピックをクローズ (#175)
+
+**バグ修正**
+
+- `cmd_shell.default` が、yaml `output` に未認識の `str.format` プレースホルダを含む場合でもシェルセッションをクラッシュさせないように修正。`KeyError` / `ValueError` / `IndexError` を捕捉し、エラーをログ出力して raw output を返します。ランタイムは意図的に寛容ですが、ビルド時のドキュメント生成 (`tasks.render_template`) は同じ状況で引き続き `RuntimeError` を送出します (#170, closes #162)
+
+**ツール**
+
+- `invoke gen-docs-platform-commands` が、裏付けとなる yaml が削除された `docs/platforms/*.md` を孤児として掃除するようになりました。`index.md` / `index.ja.md` 用に `_PRESERVED_PLATFORM_DOCS` を含みます (#169, closes #159)
+
+**テスト**
+
+- `pytest-rerunfailures` を追加し、`test_send_command_returns_defined_output` を `@pytest.mark.flaky(reruns=2, reruns_delay=1)` でマークして、遅い CI ランナー (例: `broadcom_icos`) で断続的に観測された netmiko auto-enable レースを安定化 (#176)
+
+**依存関係**
+
+- `paramiko` 制約を `>=4.0,<5.0` から `>=4.0,<6.0` に引き上げ (paramiko 5.0 リリース)。既存の `_DISABLED_GEX_ALGORITHMS` ワークアラウンドは引き続き必要 (upstream の stale-snapshot バグが 5.0 でも未修正) (#168)
+- `urllib3` を 2.6.3 から 2.7.0 に更新 (#167)
+
+## v2.2.1
+
+**新機能**
+
+- Cisco ファミリに NTC Templates v9.1 コマンドを追加 — cisco_nxos / cisco_xr / cisco_asa: 合計 19 コマンド。`cisco_asa` の手動 netmiko init 互換 (`show curpriv` / `terminal pager 0` など) を含みます (#151)
+- 非 Cisco バッチに NTC Templates v9.1 コマンドを追加 — fortinet / juniper_junos / paloalto_panos / arista_eos: 合計 30 コマンド (#154)
+- Huawei ファミリに NTC Templates v9.1 コマンドを追加 — huawei_smartax / huawei_vrp: 合計 39 コマンド (#160)
+- Ansible 互換のため cisco_ios に `show privilege` を追加し、互換表で cisco_ios を Ansible 検証済みとしてマーク (#124)
+
+**バグ修正**
+
+- `gen_docs_platform_commands` invoke タスクを書き直し: `output` フィールドの無いコマンドを扱い、ランタイム意味論に合わせて `{base_prompt}` 置換に `str.format()` を使用、正しいレンダリングで全 50 プラットフォームのドキュメントを再生成 (#146)
+- ドキュメント生成器を `str.format()` に切り替えることで、エスケープされた波括弧リテラル (`{{ ... }}`) をプラットフォームドキュメントで正しくレンダリング (`cmd_shell.default` ランタイムと一致)。フィクスチャにリテラル波括弧を含む 10 プラットフォーム (huawei_smartax、juniper_junos、cisco_asa、cisco_ios、cisco_nxos、hp_comware、arista_eos、paloalto_panos、oneaccess_oneos、huawei_vrp) に影響 (#160)
+
+**ツール**
+
+- `sync_ntc_commands.py` を改善: canonical な raw フィクスチャを優先し、代替フィクスチャを `output_variants` として保持、兄弟フィクスチャのノイズをフィルタ (#147)
+- `sync_ntc_commands.py` 出力でリテラル `{xxx}` パターンを自動エスケープ (予防的エスケープ) し、任意の NTC フィクスチャ内容に対してランタイム `str.format()` が安全になるように (#156)
+
+**テスト**
+
+- `render_template` フォーマッタの意味論 (置換、escape/unescape、エラーコンテキスト) を固定する `tests/test_gen_docs_platform_commands.py` を追加し、波括弧レンダリングの将来の退行を防止 (#160)
+
+**CI/CD**
+
+- `pytest-xdist` の並列実行を既定で有効化 (`addopts = "-vv -n auto"`)。ローカル計測: 18:06 → 3:01 (6.0 倍高速化) (#164)
+- Docker 前提のタスク (`build` / `clean` / `rebuild` / `pytest` / `cli` / `tests`) と dead code を `tasks.py` から削除し、CI ワークフローから `INVOKE_LOCAL` を除去 (#145)
+
+## v2.2.0
+
+**新機能**
+
+- NTC Templates v9.0 から 9 個の新プラットフォームを追加: aruba_aoscx、cisco_apic、cisco_viptela、cisco_wlc_ssh、edgecore、extreme_slxos、oneaccess_oneos、watchguard_firebox、zte_zxros (#129)
+- NTC Templates v9.1 から cisco_ios に 28 個の新コマンドを追加 (SD-WAN、CTS、endpoint-tracker、license コマンドを含む) (#128)
+
+**テスト**
+
+- 全 YAML-only プラットフォームに netmiko 接続テストを追加 (#129)
+- フルプラットフォーム xfail の代わりに、粒度の細かい `skip_enable_platforms` でテスト skip ロジックを精緻化 (#129)
+
+**ドキュメント**
+
+- バイリンガル対応 (英語 / 日本語)、AI Transparency ポリシー、コントリビューションワークフローを含む `CONTRIBUTING.md` を追加 (#121)
+- GitHub Private Vulnerability Reporting を指すバイリンガル対応の `SECURITY.md` を追加 (#120)
+- プラットフォーム互換リストを、注記付きの詳細な互換表に変換 (#129)
+
+**CI/CD**
+
+- 50 以上の YAML プラットフォーム検証のため yamllint を CI に追加 (#137)
+
+**依存関係**
+
+- ntc-templates 9.0.0 → 9.1.0 (netmiko 経由の推移的依存)
+- cryptography 46.0.5 → 46.0.7
+- pytest 9.0.2 → 9.0.3
+- trivy-action 0.35.0 → 0.36.0
+- GitHub Actions Pages ワークフローを Node.js 24 互換バージョンに更新
+
+## v2.1.3
+
+**セキュリティ**
+
+- trivy-action のサプライチェーン侵害を修正: 0.34.1 → v0.35.0 に更新 (#117)
+
+**CI/CD**
+
+- GitHub Actions を Node.js 24 互換バージョンに更新 (#112, #118)
+- 週次自動更新のため Dependabot 設定を追加 (#116)
+
+## v2.1.2
+
+**パフォーマンス**
+
+- SSH/Telnet tap 関数のバイト単位 `time.sleep(0.01)` を除去 — テストスイートが約 20% 高速化 (#107)
+- 即時サーバシャットダウンのため `accept()` ポーリングを `selectors` + `socketpair` に置換 (#106)
+
+**セキュリティ**
+
+- 7 件の Dependabot アラートを修正するため依存関係をアップグレード: urllib3、filelock、virtualenv、pynacl (#111)
+
+## v2.1.1
+
+**バグ修正**
+
+- Docker Trivy スキャン失敗 (zlib CVE) を `apk upgrade --no-cache` で解消 (#102)
+- cisco_ios の macOS テストタイムアウトを 600 秒に延長 (#102)
+- Telnet 認証失敗時の BrokenPipeError を修正 (#102)
+
+**CI/CD**
+
+- 早すぎる publish を防ぐため、publish ワークフローのトリガをタグ push から release イベントに変更 (#103)
+
+## v2.1.0
+
+**新機能**
+
+- SSH / Telnet サーバの echo coalescing — netmiko `send_command()` で断続的に空出力になる問題を防止 (#87, #94)
+- RFC 854/857/858 準拠の Telnet サーバプラグイン
+- SSH / Telnet サーバで共有する thread-safe な TapIO I/O ブリッジ
+
+**バグ修正**
+
+- thread-unsafe な ChannelFile を直接 Channel API に置換 (#85)
+- SSH channel_to_shell_tap に CRLF 処理を追加 (#88)

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -5,15 +5,54 @@ For full details, see the [GitHub Releases](https://github.com/Route-Reflector/s
 
 ## Unreleased
 
+<!-- At release, rename this heading to `## v3.0.0 - YYYY-MM-DD`. -->
+
+SIMNOS v3 is a clean rewrite of the SSH/Telnet core and the plugin data
+layout. The breaking changes are consolidated in the migration guide below;
+each links to its detailed entry further down.
+
+**Migration from v2**
+
+_Staying on v2 (migration window)_ — v2 is maintained as a migration window for
+critical / security fixes only. Pin to it until you are ready to move:
+
+- PyPI: `pip install "simnos<3"`
+- Docker: pin the major tag `simnos:2` (do not use `:latest`, which now tracks v3)
+- git: pin the `v2.4.0` tag or the `2.x` maintenance branch
+
+_Upgrading to v3_ — apply each change that affects you:
+
+| If you… | Do this |
+|---|---|
+| use `platform:` in an inventory | Rename the key to `device_type:` — there is no alias, `platform:` is rejected at load (`sed -i 's/^\([[:space:]]*\)platform:/\1device_type:/' inventory.yaml`). See #266 |
+| configure the `ParamikoSshServer` plugin | Drop it — `AsyncSshServer` is the default SSH plugin; `ssh_key_file` / `ssh_banner` / `authorized_keys` carry over unchanged. See #297 |
+| run `simnos -i inventory.yaml` (or bare `simnos`) | Use the subcommand form: `simnos up -i inventory.yaml` (or `simnos up` for the default inventory). See #267 |
+| hardcode listen port `6000` / `6001` / `6002` | Read the real port from `net.hosts[<name>].port` after `start()` (the CLI logs it); default ports are now OS-assigned. See #271 |
+| set `ruler` / `completekey` in a shell `configuration` block | Remove them — they are rejected at load (`extra="forbid"`). See #303 |
+| rely on `paramiko` pulled in transitively | It is no longer a runtime dependency — depend on it explicitly if your own code imported it. See #297 |
+
+On-the-wire behaviour for scrapers (netmiko / scrapli / ansible) is unchanged
+and pinned by the byte-parity golden — no client-side changes are needed for
+automated tooling that only sends commands and reads output.
+
 **Breaking Changes**
 
 - Rename the inventory key `platform` to `device_type` (v3, #266). There is no compatibility alias: a v2 inventory using `platform:` is rejected at load. Migrate by rewriting the key (`sed -i 's/^\([[:space:]]*\)platform:/\1device_type:/' inventory.yaml`) or pin to v2 (`pip install "simnos<3"`, maintained as a migration window). A `device_type` accepts a platform's internal name, its `netmiko_device_type`, or its `ntc_platform` alias — all resolve to the same platform via the data-driven reverse index (#266)
 - Replace the SSH and Telnet server transports with asynchronous backends on a shared asyncio event loop: SSH now runs on `asyncssh` (was paramiko) and Telnet on `telnetlib3`, both driven by a single push-dispatch session loop (#297). The `ParamikoSshServer` plugin and its inventory configuration are removed — use `AsyncSshServer` (the default SSH plugin); existing `ssh_key_file` / `ssh_banner` / `authorized_keys` options carry over. The bundled DH-GEX moduli file and the paramiko GEX workaround are gone (asyncssh negotiates moduli itself), and `paramiko` is no longer a runtime dependency (retained as a dev dependency for the byte-parity / interop test clients)
+- Restructure the CLI around subcommands: `simnos up` starts server(s) and `simnos list-platforms` lists supported platforms (#267). The v2 flat form (`simnos -i inventory.yaml`, or a bare `simnos` for the default inventory) no longer parses — a subcommand is now required (`simnos up -i inventory.yaml`, or `simnos up` for the default inventory). `up` also gains an ad-hoc single-host mode (`-d/--device-type` with optional `-p/--port`, `-n/--host-name`, `-u/--username`, `-w/--password`) so a one-off platform launches without an inventory file. The `-l/--log-level` and `-r/--reload-commands` flags carry over as shared flags on every subcommand
+- Default listen ports are now OS-assigned (ephemeral) instead of the fixed `6000` / `6001` / `6002` (#271). A no-argument `SimNOS()` (the builtin default inventory) and any inventory host with `port: 0` bind a port chosen atomically by the OS at `bind()` time; read the real port back from `host.port` after `start()` (the CLI logs `host <name> listening on <addr>:<port>`). This removes the cross-worker port-collision flake seen on macOS CI (`OSError: Errno 48`). Callers and tests that hardcoded `6000` must read `net.hosts[<name>].port` instead. The replicas list path still requires explicit `ge=1` ports — ephemeral is single-host only
+- Remove the `ruler` and `completekey` shell-configuration knobs together with the `cmd.Cmd` base class they belonged to (#303). An inventory `configuration` block that still sets them is now rejected at load (`extra="forbid"`) — drop the keys. On-the-wire behaviour for scrapers (netmiko / scrapli / ansible) is unchanged and pinned by the byte-parity golden
 
 **Enhancements**
 
 - Introduce `sys_config.yaml`, a minimal environment-config file (`data_dir`, `variants_policy`) distinct from the topology inventory. Discovered via the `sys_config=` argument, the `SIMNOS_SYS_CONFIG` env var, `./sys_config.yaml`, or `~/.simnos/sys_config.yaml`; `SIMNOS_DATA_DIR` overrides `data_dir`. Establishes the setting precedence `CLI > env > inventory(host > default) > sys_config > builtin`. Both fields are reserved (no-op, warned at load) and wired up in #265 / #267 (#266)
 - Reserve the inventory fields `facts`, `overlay`, and `variants_policy` as the schema vessel for #265. They are validated but consumed by nobody yet; a set-but-inert value is surfaced with a `log.warning` rather than silently ignored (#266)
+- Migrate the plugin platform layout to the A3 directory format: a per-platform `platform.yaml` (modes + prompts) plus one file per command under `commands/*.yaml` with adjacent `.txt` / `.j2` output, replacing the monolithic per-platform YAML (#264). The `command` field is the single source of truth, and a build-time lint (`invoke lint-platform-data`) enforces the encoding / reference / extension conventions. Optional dynamic behaviour still lives in `platforms_py/<nos>.py`
+- Add data-driven facts rendering and per-command output variants (#287). A command's output can be authored as a `.j2` template with an adjacent sidecar `.json` of facts (validated loudly at build time), and a command may declare multiple `variants` selected by `variants_policy` (`int` / `random` with an optional seed), sharing a canonical output and written via a two-phase atomic swap
+- Add an interactive line editor to the SSH session: `?` context help (current-mode command list), Tab completion over the command tree, `↑` / `↓` history, `←` / `→` cursor movement and backspace, layered as a lightweight readline over the push-dispatch loop (#303). Editing sequences are emitted only on interactive keypress, so full-line input from scrapers is untouched and stays byte-parity-identical
+- Add real-device-style command abbreviation: a unique per-token prefix resolves to the full command, with `% Ambiguous command` on a tie and an incomplete-command message on a partial match (#305). Abbreviation is shared by the dispatch core (default-on) and by Tab completion
+- Add terminal paging (`--More--`) for long command output (#307). The page height follows the PTY / Telnet NAWS rows (falling back to `sys_config.paging.default_rows`, default 24); a `terminal length 0`-class command disables paging for the session (the `disables_paging` data flag), and non-interactive clients (netmiko at `height=1000`, scrapers) bypass the pager through a line-count gate that preserves byte parity. The `--More--` string is platform data (`platform.yaml` `paging.more_prompt`, Cisco default `" --More-- "`)
+- Scope the command hot-reload watcher (`SIMNOS_RELOAD_COMMANDS`) to per-shell snapshots and per-platform watches, serialising a shared reload under the host lock so it no longer races concurrent sessions (#281)
 
 ## v2.3.1
 

--- a/simnos/core/pydantic_models.py
+++ b/simnos/core/pydantic_models.py
@@ -74,6 +74,13 @@ class ModelNosCommand(BaseModel):
     # so `extra="forbid"` keeps accepting the existing data while still
     # rejecting typos.
     output_variants: list[StrictStr] | None = None
+    # Test-facing marker for a callable-output command whose transition
+    # (`new_mode`/`exit`) is decided at dispatch time and so cannot be read
+    # from this static schema. The netmiko sweep (`tests/utils.get_host_commands`)
+    # skips such commands instead of running them into a ReadTimeout (#115).
+    # Not consumed by the runtime; declared so `extra="forbid"` accepts it.
+    # #317 supersedes it once A3 authors handlers with a static new_mode.
+    changes_prompt: StrictBool | None = None
 
 
 class ModelNosAttributes(BaseModel):

--- a/simnos/plugins/nos/platforms_py/huawei_smartax.py
+++ b/simnos/plugins/nos/platforms_py/huawei_smartax.py
@@ -99,6 +99,11 @@ commands = {
         "output": HuaweiSmartAX._return,
         "help": "return to user prompt",
         "prompt": ENABLE_PROMPT,
+        # The handler decides `new_mode` at dispatch time (conditional on
+        # current_mode), so the static command dict carries no `new_prompt`.
+        # Flag the transition statically so the netmiko sweep skips it (#115);
+        # #317 supersedes this once A3 authors handlers with a static new_mode.
+        "changes_prompt": True,
     },
     "scroll": {
         "output": None,
@@ -109,6 +114,9 @@ commands = {
         "output": HuaweiSmartAX.disable,
         "help": "exit exec prompt",
         "prompt": [INITIAL_PROMPT, ENABLE_PROMPT],
+        # Handler-decided transition (see `return` above) — flag it so the
+        # netmiko sweep skips it (#115).
+        "changes_prompt": True,
     },
     "display board": {
         "output": HuaweiSmartAX.make_display_board,

--- a/tests/_platform_quirks.py
+++ b/tests/_platform_quirks.py
@@ -45,10 +45,7 @@ SKIP_ENABLE: dict[str, Quirk] = {
 }
 
 # Python-plugin platforms whose "all commands" sweep is xfailed.
-XFAIL_PY_ALL_COMMANDS: dict[str, Quirk] = {
-    "huawei_smartax": Quirk(
-        "callable commands (return/disable) dynamically change the prompt, causing netmiko ReadTimeout",
-        None,
-        "2026-06-08",
-    ),
-}
+# huawei_smartax was xfailed here until #115: its callable `return`/`disable`
+# now carry a static `changes_prompt` flag so the netmiko sweep skips them
+# instead of running them into a ReadTimeout. No platform is currently quirked.
+XFAIL_PY_ALL_COMMANDS: dict[str, Quirk] = {}

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -4,6 +4,7 @@ from types import SimpleNamespace
 from typing import cast
 
 from simnos.core.host import Host
+from simnos.plugins.nos.platforms_py import huawei_smartax
 from tests.utils import get_host_commands
 
 
@@ -14,9 +15,9 @@ class TestGetHostCommandsChangesPrompt:
     transition (`new_mode`/`exit`) is decided at dispatch time, so it is invisible
     to the static legacy-dict read the sweep does. Without the `changes_prompt`
     skip the sweep would run them and hit a netmiko ReadTimeout. Previously this
-    was only pinned indirectly by the slow huawei integration sweep; this test
-    pins the filter directly. #317 removes the need once A3 authors handlers with
-    a static new_mode.
+    was only pinned indirectly by the slow huawei integration sweep; these tests
+    pin the filter and the real authoring data directly. #317 removes the need
+    once A3 authors handlers with a static new_mode.
     """
 
     @staticmethod
@@ -32,14 +33,30 @@ class TestGetHostCommandsChangesPrompt:
         )
         return cast(Host, SimpleNamespace(nos=nos))
 
-    def test_changes_prompt_command_is_skipped(self):
-        """A `changes_prompt` command is excluded from every bucket; a sibling isn't."""
+    def test_changes_prompt_is_the_sole_reason_the_command_is_skipped(self):
+        """A `changes_prompt` command is excluded from every bucket; a plain sibling isn't.
+
+        The flagged command uses a neutral name (`widget reset`) that is not in the
+        exit-name set and carries no `new_prompt`/`alias`/`exit`, so `changes_prompt`
+        is the *only* condition that can drive its exclusion — the test cannot pass
+        falsely via a different filter branch (1st round codex/claude).
+        """
         host = self._legacy_host(
             {
-                "show version": {"output": "v", "prompt": "R1>"},
-                "return": {"output": "x", "prompt": "R1>", "changes_prompt": True},
+                "show widget": {"output": "v", "prompt": "R1>"},
+                "widget reset": {"output": "x", "prompt": "R1>", "changes_prompt": True},
             }
         )
         initial, enable, config = get_host_commands(host)
-        assert "show version" in initial
-        assert "return" not in initial + enable + config
+        assert "show widget" in initial  # plain sibling is swept
+        assert "widget reset" not in initial + enable + config  # flagged command is skipped
+
+    def test_huawei_transition_commands_carry_the_marker(self):
+        """The real huawei_smartax authoring data flags its callable transitions (#115).
+
+        Pins the actual `commands` dict (not a synthetic one) so a marker dropped
+        from `return` / `disable` is caught here directly, instead of only by the
+        slow netmiko sweep (1st round codex/claude).
+        """
+        for name in ("return", "disable"):
+            assert huawei_smartax.commands[name]["changes_prompt"] is True

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,0 +1,45 @@
+"""Unit tests for the test helpers in ``tests/utils.py``."""
+
+from types import SimpleNamespace
+from typing import cast
+
+from simnos.core.host import Host
+from tests.utils import get_host_commands
+
+
+class TestGetHostCommandsChangesPrompt:
+    """Regression pin for the `changes_prompt` filter in `get_host_commands` (#115).
+
+    huawei_smartax's `return` / `disable` are callable-output commands whose
+    transition (`new_mode`/`exit`) is decided at dispatch time, so it is invisible
+    to the static legacy-dict read the sweep does. Without the `changes_prompt`
+    skip the sweep would run them and hit a netmiko ReadTimeout. Previously this
+    was only pinned indirectly by the slow huawei integration sweep; this test
+    pins the filter directly. #317 removes the need once A3 authors handlers with
+    a static new_mode.
+    """
+
+    @staticmethod
+    def _legacy_host(commands: dict) -> Host:
+        """A minimal duck-typed host exposing a legacy (no-A3) nos to the sweep."""
+        nos = SimpleNamespace(
+            name="t",
+            initial_prompt="R1>",
+            enable_prompt=None,
+            config_prompt=None,
+            resolved_platform=None,
+            commands=commands,
+        )
+        return cast(Host, SimpleNamespace(nos=nos))
+
+    def test_changes_prompt_command_is_skipped(self):
+        """A `changes_prompt` command is excluded from every bucket; a sibling isn't."""
+        host = self._legacy_host(
+            {
+                "show version": {"output": "v", "prompt": "R1>"},
+                "return": {"output": "x", "prompt": "R1>", "changes_prompt": True},
+            }
+        )
+        initial, enable, config = get_host_commands(host)
+        assert "show version" in initial
+        assert "return" not in initial + enable + config

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -156,7 +156,18 @@ def get_host_commands(host: Host) -> tuple[list[str], list[str], list[str]]:
             continue
         prompts = options["prompt"]
         new_prompt = options.get("new_prompt")
-        if new_prompt or "alias" in options or options.get("exit") or command in {"exit", "quit", "logout"}:
+        # `changes_prompt` flags a callable-output command whose transition
+        # (`new_mode`/`exit`) is decided at dispatch time and so is invisible to
+        # this static dict read — without it the sweep would run e.g. huawei's
+        # `return`/`disable` and hit a netmiko ReadTimeout (#115; #317 removes the
+        # need once A3 authors handlers with a static new_mode).
+        if (
+            new_prompt
+            or options.get("changes_prompt")
+            or "alias" in options
+            or options.get("exit")
+            or command in {"exit", "quit", "logout"}
+        ):
             continue
         if isinstance(prompts, str):
             prompts = [prompts]


### PR DESCRIPTION
🐙claude:

## 概要

`tests/utils.get_host_commands`（netmiko sweep helper）の legacy dict 側フィルタが、**callable-output コマンドが dispatch 時に返す遷移**（`new_mode`/`exit`）を静的キー判定（`new_prompt`/`exit`）ですり抜け、huawei_smartax の `return`/`disable` を sweep が実行 → netmiko ReadTimeout → **platform 全面 xfail** になっていた問題（#115）の**戦術修正（案A）**。

## 根本原因

A3 側は `ResolvedCommand.new_mode`/`exit` を静的フィールドで持ち `rc.new_mode or rc.exit` で除外できる。一方 legacy dict 側は静的キーしか見ず、callable が**戻り値**で返す遷移（`huawei_smartax.py` の `_return`/`disable` が `{"new_mode": ...}` を返す）を検出できない。すり抜けるのは `return`/`disable` の2件（`quit`=名前 `{exit,quit,logout}` 除外 / `enable`=静的 `new_prompt` 除外は既存挙動、arista `make_exit`=command 名 `exit` で既存除外）。

## 変更内容

- `simnos/core/pydantic_models.py`: `ModelNosCommand` に `changes_prompt` を宣言（`extra="forbid"` 受理用、runtime 非消費。`output_variants` と同じ data-only パターン）
- `simnos/plugins/nos/platforms_py/huawei_smartax.py`: `return`/`disable` に `changes_prompt: True`
- `tests/utils.py`: `get_host_commands` の legacy フィルタに `options.get("changes_prompt")` 節を追加
- `tests/_platform_quirks.py`: `XFAIL_PY_ALL_COMMANDS` から huawei_smartax を除去（空 dict 化）
- `tests/test_utils.py`（新規）: フィルタを netmiko 非依存で直接 pin する unit test（marker 一択で除外されること + 実 huawei データが marker を持つこと）

A3 側が静的除外できているのと同じ「静的シグナル」を legacy 側に与える発想。結果 `test_platforms_py_all_commands_are_running[huawei_smartax]` が xfail→PASS。

## レビュー

- **cross-review 1st round = 総合 SUGGESTION（codex/gemini/claude 3者一致、MUST/SHOULD 0）**。最重要観点「marker 抜け漏れ」は3者とも 3 py platform 全数を実コード確認し「過不足なし」。
- 取り込み: 実 huawei データ pin 追加（codex#4+claude#3 収束）/ synthetic cmd を中立名化（claude#3）/ #317 に受け入れ条件追記（claude#2）。
- 見送り: `Mock(spec=Host)` 化（gemini#1）— duck-type+cast は ty クリーン・#317 で削除されるコード、実データ pin が上位の安全網。

## 位置づけ

これは戦術的な絆創膏。根本原因（A3 が動的 handler を authoring できない）は **#317**（レガシー command authoring 面の A3 単一化）が構造的に supersede し、その完了時に本 marker は撤去される（#317 受け入れ条件に明記）。

## 検証

- `invoke ruff`（check --diff + format --diff）green / `ty check` All passed
- `pytest -n auto` = **1144 passed, 7 skipped**（fail 0）。asyncio teardown 警告 1 件は `-n auto` 並列 teardown の既存 intermittent（huawei sweep 単独を `-W error` で PASS 確認＝本 PR 非起因）

Closes #115

🤖 Generated with [Claude Code](https://claude.com/claude-code)
