### PR TITLE
fix: py dict が A3 の disables_paging を shadow する live bug を修正 (#320)

### DIFF
--- a/docs/platforms/arista_eos.md
+++ b/docs/platforms/arista_eos.md
@@ -2490,7 +2490,7 @@ Maximum number of vrfs allowed: 1023
 
 **Output:**
 ```
-Pagination disabled
+Pagination disabled.
 ```
 
 **Help:** It disables the pagination
@@ -2503,10 +2503,36 @@ Pagination disabled
 
 **Output:**
 ```
-Width set to 511
+Width set to 511 columns.
 ```
 
 **Help:** set the terminal width to maximum
+
+**Prompt:**
+- arista_eos>
+- arista_eos#
+
+### term length 0
+
+**Output:**
+```
+Pagination disabled.
+```
+
+**Help:** 
+
+**Prompt:**
+- arista_eos>
+- arista_eos#
+
+### term width 0
+
+**Output:**
+```
+Width set to 511 columns.
+```
+
+**Help:** 
 
 **Prompt:**
 - arista_eos>

--- a/simnos/plugins/nos/platforms/arista_eos/commands/term_length_0.yaml
+++ b/simnos/plugins/nos/platforms/arista_eos/commands/term_length_0.yaml
@@ -1,0 +1,2 @@
+command: term length 0
+alias: terminal length 0

--- a/simnos/plugins/nos/platforms/arista_eos/commands/term_width_0.yaml
+++ b/simnos/plugins/nos/platforms/arista_eos/commands/term_width_0.yaml
@@ -1,0 +1,2 @@
+command: term width 0
+alias: terminal width 511

--- a/simnos/plugins/nos/platforms/arista_eos/commands/terminal_length_0.txt
+++ b/simnos/plugins/nos/platforms/arista_eos/commands/terminal_length_0.txt
@@ -1,1 +1,1 @@
-Pagination disabled
+Pagination disabled.

--- a/simnos/plugins/nos/platforms/arista_eos/commands/terminal_width_511.txt
+++ b/simnos/plugins/nos/platforms/arista_eos/commands/terminal_width_511.txt
@@ -1,1 +1,1 @@
-Width set to 511
+Width set to 511 columns.

--- a/simnos/plugins/nos/platforms_py/arista_eos.py
+++ b/simnos/plugins/nos/platforms_py/arista_eos.py
@@ -69,20 +69,15 @@ commands = {
         "help": "Output to print for unknown commands",
         "prompt": [ENABLE_PROMPT, INITIAL_PROMPT],
     },
-    "terminal width 511": {
-        "output": "Width set to 511 columns.",
-        "help": "Configure the terminal width to 511",
-        "prompt": [ENABLE_PROMPT, INITIAL_PROMPT],
-    },
-    "term width 0": {
-        "alias": "terminal width 511",
-    },
-    "terminal length 0": {
-        "output": "Pagination disabled.",
-        "help": "Configure the pagination length to 0",
-        "prompt": [ENABLE_PROMPT, INITIAL_PROMPT],
-    },
-    "term length 0": {"alias": "terminal length 0"},
+    # `terminal length 0` / `terminal width 511` (+ their `term …` aliases) are
+    # served by the A3 commands (commands/terminal_length_0.yaml /
+    # terminal_width_511.yaml + term_length_0.yaml / term_width_0.yaml), whose
+    # `.txt` bodies match these strings byte-for-byte. They were dropped from
+    # this py module so the A3 `terminal length 0` (carrying `disables_paging:
+    # true`, #307 / P3-4) is no longer shadowed by the py inflow (which overrides
+    # A3 in build_resolved_platform and cannot carry the flag). The aliases moved
+    # too: an alias resolves only within its own inflow, so leaving them here
+    # would dangle once the target is A3-only. See #320 / #308.
     "show ip int brief": {
         "output": AristaEOS.make_show_ip_int_br,
         "help": "Condensed output",

--- a/simnos/plugins/nos/platforms_py/huawei_smartax.py
+++ b/simnos/plugins/nos/platforms_py/huawei_smartax.py
@@ -105,11 +105,11 @@ commands = {
         # #317 supersedes this once A3 authors handlers with a static new_mode.
         "changes_prompt": True,
     },
-    "scroll": {
-        "output": None,
-        "help": "set scroll",
-        "prompt": [INITIAL_PROMPT, ENABLE_PROMPT],
-    },
+    # `scroll` is served by the A3 command (commands/scroll.yaml), byte-identical
+    # to this empty-output stub. It was dropped from this py module so the A3
+    # `scroll` (carrying `disables_paging: true`, #307 / P3-4) is no longer
+    # shadowed by the py inflow (which overrides A3 in build_resolved_platform and
+    # cannot carry the flag — py-plugin paging is out of scope). See #320 / #308.
     "disable": {
         "output": HuaweiSmartAX.disable,
         "help": "exit exec prompt",

--- a/tests/assets/oracle/arista_eos.json
+++ b/tests/assets/oracle/arista_eos.json
@@ -2656,6 +2656,32 @@
     ],
     "variants": []
   },
+  "term length 0": {
+    "exit": false,
+    "help": "",
+    "modes": [
+      "enable",
+      "user"
+    ],
+    "new_mode": null,
+    "output": [
+      "Pagination disabled."
+    ],
+    "variants": []
+  },
+  "term width 0": {
+    "exit": false,
+    "help": "",
+    "modes": [
+      "enable",
+      "user"
+    ],
+    "new_mode": null,
+    "output": [
+      "Width set to 511 columns."
+    ],
+    "variants": []
+  },
   "terminal length 0": {
     "exit": false,
     "help": "It disables the pagination",
@@ -2665,7 +2691,7 @@
     ],
     "new_mode": null,
     "output": [
-      "Pagination disabled"
+      "Pagination disabled."
     ],
     "variants": []
   },
@@ -2678,7 +2704,7 @@
     ],
     "new_mode": null,
     "output": [
-      "Width set to 511"
+      "Width set to 511 columns."
     ],
     "variants": []
   }

--- a/tests/plugins/test_cmd_shell.py
+++ b/tests/plugins/test_cmd_shell.py
@@ -19,8 +19,9 @@ import yaml
 
 from simnos.core.nos import Nos
 from simnos.core.simnos import SimNOS, simnos
+from simnos.plugins.nos import nos_plugins
 from simnos.plugins.shell.cmd_shell import HANDLER_ERROR_OUTPUT, CMDShell, build_resolved_platform
-from tests.utils import build_inventory, set_attr
+from tests.utils import set_attr
 
 
 def _nos_from_yaml_asset(path: str = "tests/assets/yaml_nos.yaml") -> Nos:
@@ -145,45 +146,45 @@ def test_no_do_shell_keeps_bang_fall_through():
 
 
 def _merged_platform(platform: str):
-    """Build the merged (BASIC < A3 < py) `ResolvedPlatform` for a registered platform.
+    """Build the merged (BASIC < A3 < py) `ResolvedPlatform` for a packaged platform.
 
-    Mirrors what `Host.start` does (Nos over the registered plugin ->
-    `build_resolved_platform`) but without starting a server, so a data-level
-    merge assertion stays fast. No overlay / inventory layer (empty commands).
+    Runs the same `Nos -> build_resolved_platform` path a connection takes, but
+    over the packaged registry entry (`nos_plugins[...]`) and without a server,
+    so a data-level merge assertion stays fast. No overlay / inventory layer.
     """
-    net = SimNOS(inventory=build_inventory(platform))
-    plugin = net.nos_plugins.get(platform)
-    nos = plugin if isinstance(plugin, Nos) else Nos(filename=plugin)
-    return build_resolved_platform(nos, {})
+    return build_resolved_platform(Nos(filename=nos_plugins[platform]), {})
 
 
 @pytest.mark.parametrize(
-    ("platform", "command", "paging", "body_lines"),
+    ("platform", "command", "paging", "modes", "body_lines"),
     [
         # huawei `scroll` / arista `terminal length 0` carry `disables_paging:
         # true` only in their A3 command; the empty legacy py stubs used to
         # shadow them (py wins the merge and cannot carry the flag), so the P3-4
         # pager never disabled at runtime. #320 dropped the stubs so A3 wins.
-        ("huawei_smartax", "scroll", True, None),
-        ("arista_eos", "terminal length 0", True, ["Pagination disabled."]),
-        # The `term …` alias inherits the target's flag + body via the loader.
-        ("arista_eos", "term length 0", True, ["Pagination disabled."]),
+        ("huawei_smartax", "scroll", True, {"user", "enable"}, None),
+        ("arista_eos", "terminal length 0", True, {"user", "enable"}, ["Pagination disabled."]),
+        # The `term …` alias inherits the target's flag + modes + body via the loader.
+        ("arista_eos", "term length 0", True, {"user", "enable"}, ["Pagination disabled."]),
         # `terminal width 511` moved to A3 in the same sweep (its alias `term
         # width 0` would otherwise dangle); it carries no flag, so pin False to
         # guard against an over-broad disable.
-        ("arista_eos", "terminal width 511", False, ["Width set to 511 columns."]),
-        ("arista_eos", "term width 0", False, ["Width set to 511 columns."]),
+        ("arista_eos", "terminal width 511", False, {"user", "enable"}, ["Width set to 511 columns."]),
+        ("arista_eos", "term width 0", False, {"user", "enable"}, ["Width set to 511 columns."]),
     ],
 )
-def test_a3_paging_flag_and_output_survive_py_inflow_merge(platform, command, paging, body_lines):
-    """A3 `disables_paging` + output reach the merged runtime, unshadowed by the py inflow (#320).
+def test_a3_paging_flag_and_output_survive_py_inflow_merge(platform, command, paging, modes, body_lines):
+    """A3 `disables_paging` + modes + output reach the merged runtime, unshadowed by the py inflow (#320).
 
     `_render_response` joins body lines with the newline and absorbs trailing
     newlines (via `splitlines()`), so the projected `body_lines` are the wire
     lines a client sees — pinning the `.txt` bytes the py stubs used to serve.
+    The `modes` assert pins the mode constraint the py `prompt: [...]` used to
+    carry, so an A3 `mode:` narrowing (e.g. dropping `user`) fails here.
     """
     rc = _merged_platform(platform).commands[command]
     assert rc.disables_paging is paging
+    assert rc.modes == modes
     rendered = rc.output.render("x")
     assert (rendered.splitlines() if rendered is not None else None) == body_lines
 

--- a/tests/plugins/test_cmd_shell.py
+++ b/tests/plugins/test_cmd_shell.py
@@ -19,8 +19,8 @@ import yaml
 
 from simnos.core.nos import Nos
 from simnos.core.simnos import SimNOS, simnos
-from simnos.plugins.shell.cmd_shell import HANDLER_ERROR_OUTPUT, CMDShell
-from tests.utils import set_attr
+from simnos.plugins.shell.cmd_shell import HANDLER_ERROR_OUTPUT, CMDShell, build_resolved_platform
+from tests.utils import build_inventory, set_attr
 
 
 def _nos_from_yaml_asset(path: str = "tests/assets/yaml_nos.yaml") -> Nos:
@@ -142,6 +142,50 @@ def test_no_do_shell_keeps_bang_fall_through():
     CMDShell would silently change the `!` wire without failing it.
     """
     assert not hasattr(CMDShell, "do_shell")
+
+
+def _merged_platform(platform: str):
+    """Build the merged (BASIC < A3 < py) `ResolvedPlatform` for a registered platform.
+
+    Mirrors what `Host.start` does (Nos over the registered plugin ->
+    `build_resolved_platform`) but without starting a server, so a data-level
+    merge assertion stays fast. No overlay / inventory layer (empty commands).
+    """
+    net = SimNOS(inventory=build_inventory(platform))
+    plugin = net.nos_plugins.get(platform)
+    nos = plugin if isinstance(plugin, Nos) else Nos(filename=plugin)
+    return build_resolved_platform(nos, {})
+
+
+@pytest.mark.parametrize(
+    ("platform", "command", "paging", "body_lines"),
+    [
+        # huawei `scroll` / arista `terminal length 0` carry `disables_paging:
+        # true` only in their A3 command; the empty legacy py stubs used to
+        # shadow them (py wins the merge and cannot carry the flag), so the P3-4
+        # pager never disabled at runtime. #320 dropped the stubs so A3 wins.
+        ("huawei_smartax", "scroll", True, None),
+        ("arista_eos", "terminal length 0", True, ["Pagination disabled."]),
+        # The `term …` alias inherits the target's flag + body via the loader.
+        ("arista_eos", "term length 0", True, ["Pagination disabled."]),
+        # `terminal width 511` moved to A3 in the same sweep (its alias `term
+        # width 0` would otherwise dangle); it carries no flag, so pin False to
+        # guard against an over-broad disable.
+        ("arista_eos", "terminal width 511", False, ["Width set to 511 columns."]),
+        ("arista_eos", "term width 0", False, ["Width set to 511 columns."]),
+    ],
+)
+def test_a3_paging_flag_and_output_survive_py_inflow_merge(platform, command, paging, body_lines):
+    """A3 `disables_paging` + output reach the merged runtime, unshadowed by the py inflow (#320).
+
+    `_render_response` joins body lines with the newline and absorbs trailing
+    newlines (via `splitlines()`), so the projected `body_lines` are the wire
+    lines a client sees — pinning the `.txt` bytes the py stubs used to serve.
+    """
+    rc = _merged_platform(platform).commands[command]
+    assert rc.disables_paging is paging
+    rendered = rc.output.render("x")
+    assert (rendered.splitlines() if rendered is not None else None) == body_lines
 
 
 # pylint: disable=too-many-public-methods


### PR DESCRIPTION
🐙claude:

## 概要
`build_resolved_platform` の merge 順 (BASIC < A3 < py) では、レガシー py `commands` dict が同名 A3 コマンドを shadow する。`disables_paging` フィールドは **A3 スキーマにしか無い**ため、py の空出力 stub (huawei `scroll` / arista `terminal length 0`) が A3 を shadow すると、P3-4 (#307) の per-session ページング無効化フラグが実行時に立たない **live bug**。

cisco_ios が #308 (P3-4) で実施した「py stub 削除 → A3 を勝たせる」前例を踏襲した最小修正。#317 (構造 umbrella) が py 静的コマンド全量移送で本問題のクラスを構造解消するが、本 PR はその先行最小修正。

## 変更
- **huawei**: py `scroll` stub 削除 (A3 `scroll.yaml` が有効化、出力空で byte 不変)。
- **arista**: py `terminal length 0` / `terminal width 511` (+ `term …` alias 2 件) 削除。alias は自 inflow 内でしか解決しないため 4 件セットで移送し、alias 2 件を A3 alias yaml (`term_length_0.yaml` / `term_width_0.yaml`) として追加。
- arista A3 `.txt` を現行 serve バイトに一致 (`terminal_length_0.txt` に末尾ピリオド / `terminal_width_511.txt` に " columns.")。
- oracle snapshot (`arista_eos.json`) 再生成 + `docs/platforms/arista_eos.md` 再生成。
- regression pin test 追加 (`test_a3_paging_flag_and_output_survive_py_inflow_merge`) — merged runtime の `disables_paging` + modes + 出力 byte を pin。

## wire 不変の担保
- `_render_response` は `str(body).splitlines()` で行化するため `.txt` 末尾改行は吸収され、旧 py 文字列と wire byte 完全一致。
- `?` 対話 help は **A3 authored を維持** (py に揃えない)。byte-parity golden は cisco/alcatel のみで arista/huawei 非対象、scraper は `?` を送らないため scraper wire・CI golden は不変。

## 検証
- cross-review 1st round: codex / gemini / claude いずれも **SUGGESTION** (blocking なし)。test 強化 2 件 (modes assert / helper 縮約) を取り込み済み。
- full suite: **1147 passed, 7 skipped** (byte_parity 含む)。ruff / yamllint / lint-platform-data / ty 全 pass。

Closes は付けず (v3 issue は v3→main merge まで OPEN 維持の運用)。#320 参照。

🤖 Generated with [Claude Code](https://claude.com/claude-code)