### PR TITLE
feat: A3 authoring に handler channel + transitions map を追加 (#317 P-1)

### DIFF
--- a/simnos/core/nos.py
+++ b/simnos/core/nos.py
@@ -4,13 +4,18 @@ Network Operating Systems (NOS). Base class to build NOS plugins instances to us
 
 import copy
 import importlib.util
+import inspect
 import logging
 import os
 import types
+from typing import TYPE_CHECKING
 
 from simnos.core.platform_loader import load_platform_dir
 from simnos.core.pydantic_models import ModelNosAttributes
 from simnos.core.resolved_command import ResolvedPlatform
+
+if TYPE_CHECKING:
+    from simnos.core.command_contract import CommandHandler
 
 log = logging.getLogger(__name__)
 
@@ -48,6 +53,66 @@ def _find_device_classes(module: types.ModuleType) -> list[type]:
             and obj.__module__ == module.__name__
         )
     )
+
+
+def _build_handler_namespace(module: types.ModuleType, device_classes: list[type]) -> dict[str, "CommandHandler"]:
+    """Collect the A3 ``handler:`` name -> callable namespace from a py module (#317 / P-1, 案D).
+
+    An A3 command's ``handler: <name>`` is resolved against this namespace at
+    merge time. Two channels:
+
+    - **device-class methods**: walk the device class MRO, skipping ``BaseDevice``
+      / ``object`` (so base utilities like ``render`` are never handlers), and
+      take each non-``_`` name defined on that class. A more-derived class's
+      override wins (normal Python method resolution — an MRO same-name is NOT a
+      collision). A ``classmethod`` is rejected loudly: its first arg binds to
+      ``cls``, which breaks the `CommandHandler` contract (the shell passes the
+      device as the first positional). Only a plain method or a ``staticmethod``
+      is a valid handler; a non-callable class attribute (constant / property) is
+      skipped, not misregistered.
+    - **module-level functions**: locally defined (``__module__ == module.__name__``,
+      the `_find_device_classes` criterion) non-``_`` functions — `inspect.isfunction`
+      excludes imported callables, classes and callable instances.
+
+    A name appearing in BOTH channels is a load-time error (no implicit
+    precedence — fail at startup). The caller assigns the result as a fresh dict
+    (rollback-safe under hot reload).
+    """
+    from simnos.plugins.nos.platforms_py._templates.base_template import BaseDevice
+
+    class_ns: dict[str, CommandHandler] = {}
+    for device_cls in device_classes:
+        for cls in device_cls.__mro__:
+            if cls in (BaseDevice, object):
+                continue
+            for name, raw in vars(cls).items():
+                # A more-derived class earlier in the MRO already claimed this
+                # name (override) — skip the base definition.
+                if name.startswith("_") or name in class_ns:
+                    continue
+                if isinstance(raw, classmethod):
+                    raise ValueError(
+                        f"handler {name!r} on {cls.__name__} is a classmethod; a command handler must take the "
+                        "device as its first argument (a plain method or staticmethod), not `cls`"
+                    )
+                if isinstance(raw, staticmethod) or inspect.isfunction(raw):
+                    # `getattr` on the leaf class resolves the descriptor (a
+                    # staticmethod unwraps to its plain function, a method to the
+                    # underlying function that takes the device as the first arg).
+                    class_ns[name] = getattr(device_cls, name)
+                # else: a non-callable class attribute is not a handler — skip it.
+    module_ns: dict[str, CommandHandler] = {
+        name: obj
+        for name, obj in vars(module).items()
+        if not name.startswith("_") and inspect.isfunction(obj) and obj.__module__ == module.__name__
+    }
+    collision = class_ns.keys() & module_ns.keys()
+    if collision:
+        raise ValueError(
+            f"handler name(s) {sorted(collision)} are defined both as a device-class method and a module-level "
+            "function; a handler name must be unambiguous (rename one)"
+        )
+    return {**class_ns, **module_ns}
 
 
 class Nos:
@@ -96,6 +161,11 @@ class Nos:
         self.enable_prompt: str | None = None
         self.config_prompt: str | None = None
         self.device = None
+        # A3 ``handler:`` namespace (#317 / P-1): name -> callable, populated by
+        # `_from_module` from the py plugin's device class + module-level
+        # functions. `build_resolved_platform` binds A3 handler refs against it.
+        # Rebuilt (fresh dict) on hot reload, so it is a `_NOS_RELOAD_ATTRS` member.
+        self.handlers: dict[str, CommandHandler] = {}
         self.configuration_file = configuration_file
         # A3 form (#264 / PR-2): an A3 platform dir loads straight into a
         # `ResolvedPlatform` (modes + resolved commands) here, instead of the
@@ -225,7 +295,11 @@ class Nos:
         is auto-detected as the module's single locally-defined `BaseDevice`
         subclass, if any (see `_find_device_classes` — the legacy
         ``DEVICE_NAME`` constant is ignored with a warning since #241).
-        See :mod:`simnos.plugins.nos.platforms_py.cisco_ios` for a live example.
+        The A3 ``handler:`` namespace (`self.handlers`) is also built here from
+        the device class methods + module-level functions (see
+        `_build_handler_namespace`) so an A3 platform's `handler:` refs bind at
+        merge time (#317 / P-1). See
+        :mod:`simnos.plugins.nos.platforms_py.cisco_ios` for a live example.
 
         :param filename: OS path string to Python .py file
         """
@@ -273,6 +347,11 @@ class Nos:
                 f"Module '{filename}' defines multiple BaseDevice subclasses "
                 f"({', '.join(sorted(c.__name__ for c in device_classes))}); expected exactly one"
             )
+        # Build the A3 handler namespace before mutating self (#317 / P-1): a
+        # classmethod handler / a class-vs-module name collision raises here, so
+        # a broken plugin never leaves partial state (same no-partial contract as
+        # the device-class / commands validation above).
+        new_handlers = _build_handler_namespace(module, device_classes)
         if hasattr(module, "DEVICE_NAME"):
             # G4 (#241) removed the DEVICE_NAME indirection; the device class
             # is auto-detected now. Nudge plugin authors to drop the leftover.
@@ -302,6 +381,11 @@ class Nos:
                 sorted(overridden),
             )
         self.commands.update(candidate_commands)
+        # Fresh dict (never in-place `.update`): `_NOS_RELOAD_ATTRS` snapshots
+        # `handlers` by reference for hot-reload rollback, so a mutable in-place
+        # update could not be rolled back. Cumulative later-wins across a
+        # multi-file load, mirroring `self.commands` (#317 / P-1, 案D).
+        self.handlers = {**self.handlers, **new_handlers}
         if self.name == "SimNOS":
             log.warning(
                 "Module '%s' does not define NAME; falling back to default 'SimNOS' "

--- a/simnos/core/nos.py
+++ b/simnos/core/nos.py
@@ -59,7 +59,10 @@ def _build_handler_namespace(module: types.ModuleType, device_classes: list[type
     """Collect the A3 ``handler:`` name -> callable namespace from a py module (#317 / P-1, 案D).
 
     An A3 command's ``handler: <name>`` is resolved against this namespace at
-    merge time. Two channels:
+    merge time. `device_classes` is the caller's already-validated list (0 or 1
+    entries — `_from_module` rejects >1 local `BaseDevice` subclass before
+    calling this), so the per-class loop is effectively single-class; it is
+    written as a loop only to no-op cleanly on the no-device case. Two channels:
 
     - **device-class methods**: walk the device class MRO, skipping ``BaseDevice``
       / ``object`` (so base utilities like ``render`` are never handlers), and
@@ -68,8 +71,9 @@ def _build_handler_namespace(module: types.ModuleType, device_classes: list[type
       collision). A ``classmethod`` is rejected loudly: its first arg binds to
       ``cls``, which breaks the `CommandHandler` contract (the shell passes the
       device as the first positional). Only a plain method or a ``staticmethod``
-      is a valid handler; a non-callable class attribute (constant / property) is
-      skipped, not misregistered.
+      is a valid handler; anything else on the class (a constant, a ``property``,
+      or a callable *instance* / functor) is skipped, not misregistered — only a
+      real function / staticmethod is a handler (gemini#1).
     - **module-level functions**: locally defined (``__module__ == module.__name__``,
       the `_find_device_classes` criterion) non-``_`` functions — `inspect.isfunction`
       excludes imported callables, classes and callable instances.

--- a/simnos/core/platform_loader.py
+++ b/simnos/core/platform_loader.py
@@ -30,6 +30,7 @@ from simnos.core.resolved_command import (
     ResolvedCommand,
     ResolvedOutput,
     ResolvedPlatform,
+    Transition,
     compile_template,
 )
 from simnos.core.values_loader import load_values, validate_render_values
@@ -139,7 +140,28 @@ def _resolve_commands(
             # An alias carries the target's dispatch fields but keeps its own
             # help (usually blank) — same as the legacy adapter and v2 do_help
             # (#264 / D6, Decision 6).
-            resolved[name] = replace(target, name=model.command, help=model.help or "")
+            aliased = replace(target, name=model.command, help=model.help or "")
+            # A `mode:` override lets an alias run in a different mode set than
+            # its target (e.g. arista `do show ip int brief`: target is
+            # user/enable, the alias is config-only) — the one dispatch field an
+            # alias may re-author (#317 / P-1). Validate the names and re-check
+            # any inherited `transitions` against the narrowed modes.
+            if model.mode is not None:
+                unknown = [m for m in model.mode if m not in mode_names]
+                if unknown:
+                    raise ValueError(
+                        f"command {model.command!r}: mode(s) {unknown} not in platform modes {sorted(mode_names)}"
+                    )
+                new_modes = frozenset(model.mode)
+                if aliased.transitions is not None:
+                    stray = sorted(k for k in aliased.transitions if k not in new_modes)
+                    if stray:
+                        raise ValueError(
+                            f"command {model.command!r}: alias `mode:` override to {sorted(new_modes)} drops "
+                            f"transition mode(s) {stray} inherited from target {model.alias!r} (dead entry)"
+                        )
+                aliased = replace(aliased, modes=new_modes)
+            resolved[name] = aliased
     return resolved
 
 
@@ -219,6 +241,12 @@ def _resolve_command(
             command_name=model.command,
         )
         variants = ()
+    elif model.handler is not None:
+        # The handler callable is bound at merge time from the platform's py
+        # handler namespace (#317 / P-1, 案D); the loader stays pure and only
+        # records the reference name (schema-validated as an identifier).
+        output = ResolvedOutput(kind="handler", handler_ref=model.handler)
+        variants = ()
     else:
         output = NO_OUTPUT
         variants = ()
@@ -235,7 +263,41 @@ def _resolve_command(
         type=model.type or "simnos",
         source=model.source,
         disables_paging=bool(model.disables_paging),
+        transitions=_resolve_transitions(model, cmd_modes, mode_names),
     )
+
+
+def _resolve_transitions(
+    model: ModelCommandAuthoring, cmd_modes: frozenset[str], mode_names: frozenset[str]
+) -> dict[str, Transition] | None:
+    """Validate + build a command's mode-conditional transition map (#317 / P-1).
+
+    Each key must be one of the command's own modes (`cmd_modes`, or every
+    platform mode when `mode` was omitted) — a key outside them would never fire
+    (dead entry, an authoring error). Each `new_mode` value must be a real
+    platform mode, the same loud boundary the static `new_mode` uses. Returns
+    None when the command authored no `transitions` (the common case).
+    """
+    if model.transitions is None:
+        return None
+    # Empty `cmd_modes` means "all modes" (mode omitted / `_default_`); the schema
+    # already forbids `transitions` on `_default_`, so a command reaching here with
+    # empty modes is a genuine all-modes command whose keys may be any platform mode.
+    effective_modes = cmd_modes or mode_names
+    resolved: dict[str, Transition] = {}
+    for key, mt in model.transitions.items():
+        if key not in effective_modes:
+            raise ValueError(
+                f"command {model.command!r}: transitions key {key!r} is not one of the command's modes "
+                f"{sorted(effective_modes)} — it would never fire (dead entry)"
+            )
+        if mt.new_mode is not None and mt.new_mode not in mode_names:
+            raise ValueError(
+                f"command {model.command!r}: transitions[{key!r}].new_mode {mt.new_mode!r} "
+                f"not in platform modes {sorted(mode_names)}"
+            )
+        resolved[key] = Transition(new_mode=mt.new_mode, exit=bool(mt.exit))
+    return resolved
 
 
 def _resolve_output_file(

--- a/simnos/core/pydantic_models.py
+++ b/simnos/core/pydantic_models.py
@@ -2,6 +2,7 @@
 File to contain pydantic models for plugins input/output data validation
 """
 
+import keyword
 import os
 from typing import Annotated, Literal
 
@@ -240,7 +241,10 @@ class ModelCommandAuthoring(BaseModel):
         # A handler is a py identifier resolved against the platform's handler
         # namespace at merge time; reject a non-identifier here so a path /
         # dotted / spaced value fails at the authoring boundary, not at bind.
-        if value is not None and not value.isidentifier():
+        # A keyword (`class` / `def`) passes `isidentifier()` but can never name a
+        # real py function, so reject it here for a clear boundary error rather
+        # than a confusing "not found in namespace" at bind (1st round codex#5).
+        if value is not None and (not value.isidentifier() or keyword.iskeyword(value)):
             raise ValueError(f"handler {value!r} must be a valid Python identifier")
         return value
 

--- a/simnos/core/pydantic_models.py
+++ b/simnos/core/pydantic_models.py
@@ -159,16 +159,45 @@ class ModelCommandVariant(BaseModel):
         return value
 
 
+class ModelTransition(BaseModel):
+    """One mode's entry in a command's `transitions` map (#317 / P-1).
+
+    Exactly one of `new_mode` / `exit` must be set: ``exit: true`` terminates the
+    session, ``new_mode: <mode>`` switches mode after the command runs. Both-set,
+    neither-set and ``exit: false`` are all rejected — an empty or ambiguous entry
+    is an authoring error, not a silent no-op. The mode name(s) (the map keys) and
+    each `new_mode` value are validated against the platform modes by the loader.
+    """
+
+    model_config = ConfigDict(extra="forbid")
+
+    new_mode: StrictStr | None = None
+    exit: StrictBool | None = None
+
+    @model_validator(mode="after")
+    def _exactly_one(self) -> "ModelTransition":
+        if self.exit is not None and not self.exit:
+            raise ValueError("transition `exit` must be true — omit it entirely for a `new_mode` transition")
+        if (self.new_mode is not None) == bool(self.exit):
+            raise ValueError("a transition entry must set exactly one of `new_mode` or `exit: true`")
+        return self
+
+
 class ModelCommandAuthoring(BaseModel):
     """A3 per-command authoring schema (#264 / D3).
 
     One file = one command; `command` is the SSoT key (Decision 1), the
     filename is non-semantic. Exactly one output channel may be set
-    (`output` / `output_template` / `variants`, and `variants` may not be the
-    empty list); all absent = no output. An `alias` is a pure reference: it may
-    carry only `command` + `help` (Decision 6). `_default_` is the unconditional
-    fallback, so authoring a `mode` / `new_mode` / `alias` on it is rejected — it
-    must stay mode-agnostic and must not inherit a target's modes (Decision 7).
+    (`output` / `output_template` / `variants` / `handler`, and `variants` may
+    not be the empty list); all absent = no output. `handler` names a py-defined
+    callable resolved at merge time (#317 / P-1). Transitions are either the
+    simple static `new_mode` / `exit`, or the mode-conditional `transitions` map
+    (exclusive with them). An `alias` is a reference: it may carry only
+    `command` + `help` + a `mode:` override (#317 / P-1); all other dispatch
+    fields are inherited from the target, not re-authored. `_default_` is the
+    unconditional fallback, so authoring a `mode` / `new_mode` / `transitions` /
+    `alias` on it is rejected — it must stay mode-agnostic and must not inherit a
+    target's modes (Decision 7).
     """
 
     model_config = ConfigDict(extra="forbid")
@@ -183,6 +212,14 @@ class ModelCommandAuthoring(BaseModel):
     output: StrictStr | None = None
     output_template: StrictStr | None = None
     variants: list[ModelCommandVariant] | None = None
+    # Fourth (dynamic) output channel: the name of a py-defined handler callable
+    # (#317 / P-1). The loader records it as a `handler_ref`; the merge binds the
+    # actual callable from the platform's py handler namespace.
+    handler: StrictStr | None = None
+    # Mode-conditional transition map (#317 / P-1), exclusive with `new_mode` /
+    # `exit`. Keys are mode names the command is valid in; each entry decides the
+    # transition for that mode (see `ModelTransition`).
+    transitions: dict[StrictStr, ModelTransition] | None = None
     exit: StrictBool | None = None
     alias: StrictStr | None = None
     # Session-level "disable paging" flag (#307 / P3-4). Set on the real command
@@ -196,6 +233,16 @@ class ModelCommandAuthoring(BaseModel):
     @classmethod
     def _safe_output(cls, value: str | None) -> str | None:
         return _reject_unsafe_output_ref(value)
+
+    @field_validator("handler")
+    @classmethod
+    def _valid_handler(cls, value: str | None) -> str | None:
+        # A handler is a py identifier resolved against the platform's handler
+        # namespace at merge time; reject a non-identifier here so a path /
+        # dotted / spaced value fails at the authoring boundary, not at bind.
+        if value is not None and not value.isidentifier():
+            raise ValueError(f"handler {value!r} must be a valid Python identifier")
+        return value
 
     @field_validator("mode")
     @classmethod
@@ -227,22 +274,26 @@ class ModelCommandAuthoring(BaseModel):
     @model_validator(mode="after")
     def _check_combination(self) -> "ModelCommandAuthoring":
         if self.alias is not None:
+            # An alias inherits every dispatch field from its target; it may
+            # re-author only `mode` (a mode-set override, #317 / P-1) alongside
+            # `command` + `help`. Everything else is forbidden.
             forbidden = {
                 "type": self.type,
                 "source": self.source,
-                "mode": self.mode,
                 "new_mode": self.new_mode,
                 "output": self.output,
                 "output_template": self.output_template,
                 "variants": self.variants,
+                "handler": self.handler,
+                "transitions": self.transitions,
                 "exit": self.exit,
                 "disables_paging": self.disables_paging,
             }
             present = sorted(k for k, v in forbidden.items() if v is not None)
             if present:
                 raise ValueError(
-                    f"command {self.command!r}: alias is a pure reference and cannot also set {present} "
-                    "(only `command` and `help` are allowed alongside `alias`) (#264 / Decision 6)"
+                    f"command {self.command!r}: alias cannot also set {present} "
+                    "(only `command`, `help` and a `mode:` override are allowed alongside `alias`) (#317 / P-1)"
                 )
         else:
             if self.type is None:
@@ -253,6 +304,7 @@ class ModelCommandAuthoring(BaseModel):
                     ("output", self.output),
                     ("output_template", self.output_template),
                     ("variants", self.variants),
+                    ("handler", self.handler),
                 )
                 if v is not None
             )
@@ -260,11 +312,23 @@ class ModelCommandAuthoring(BaseModel):
                 raise ValueError(
                     f"command {self.command!r}: at most one output channel allowed, got {channels} (#264 / Decision 6)"
                 )
+            # `transitions` is the mode-conditional alternative to the simple
+            # static `new_mode` / `exit`; setting both is ambiguous (#317 / P-1).
+            if self.transitions is not None:
+                conflict = sorted(
+                    name for name, v in (("new_mode", self.new_mode), ("exit", self.exit)) if v is not None
+                )
+                if conflict:
+                    raise ValueError(
+                        f"command {self.command!r}: `transitions` is exclusive with {conflict} (#317 / P-1)"
+                    )
+                if not self.transitions:
+                    raise ValueError(f"command {self.command!r}: `transitions: {{}}` is empty — omit it (#317 / P-1)")
         if self.command == "_default_":
-            if self.mode is not None or self.new_mode is not None:
+            if self.mode is not None or self.new_mode is not None or self.transitions is not None:
                 raise ValueError(
-                    "command '_default_': `mode` / `new_mode` are rejected — the fallback is mode-agnostic "
-                    "(runtime never matches its mode, would be dead data) (#264 / Decision 7)"
+                    "command '_default_': `mode` / `new_mode` / `transitions` are rejected — the fallback is "
+                    "mode-agnostic (runtime never matches its mode, would be dead data) (#264 / Decision 7)"
                 )
             # An aliased `_default_` would inherit the target's modes/new_mode via
             # the loader's `replace(target, ...)`, splitting `_default_` semantics

--- a/simnos/core/resolved_command.py
+++ b/simnos/core/resolved_command.py
@@ -181,6 +181,13 @@ class ResolvedOutput:
     text: str | None = None
     template: Template | None = None
     handler: "CommandHandler | None" = None
+    # For an A3-authored ``handler:`` command, the referenced handler name (an
+    # identifier). The loader records it here with ``handler=None``; the merge
+    # (`build_resolved_platform`) binds the actual callable from the platform's
+    # py handler namespace, so an unresolved ref fails loudly at start rather
+    # than being a silent no-output command (#317 / P-1, 案D). The legacy adapter
+    # sets ``handler`` directly and leaves this None.
+    handler_ref: str | None = None
     required_vars: frozenset[str] = frozenset()
     values: Mapping[str, Any] = field(default_factory=dict)
 
@@ -226,6 +233,22 @@ NO_OUTPUT = ResolvedOutput(kind="none")
 
 
 @dataclass(frozen=True)
+class Transition:
+    """One mode's transition decision in a command's `transitions` map (#317 / P-1).
+
+    Exactly one is meaningful (the A3 loader / schema enforce it): `exit` True
+    terminates the session; otherwise the command switches to `new_mode` (a
+    validated mode name), or stays put when `new_mode` is None. An `exit`
+    transition always carries ``new_mode=None``. This is the static, per-mode
+    successor to a handler deciding its own transition at dispatch time (#115):
+    the shell reads it from the schema instead of running the command.
+    """
+
+    new_mode: str | None = None
+    exit: bool = False
+
+
+@dataclass(frozen=True)
 class ResolvedCommand:
     """Normalized command, independent of the authoring form (#264 / D4).
 
@@ -262,12 +285,23 @@ class ResolvedCommand:
     type: str
     source: dict | None = None
     canonical_name: str = ""
+    # Mode-conditional transition map (#317 / P-1): mode name -> `Transition`.
+    # None (the common case) means the command uses the simple static
+    # `new_mode` / `exit` above. When set, `_dispatch_general` looks up the
+    # current mode and applies that entry's transition, falling back to
+    # `exit` / `new_mode` only for a mode absent from the map. The loader
+    # validates every key against the command's modes and every `new_mode`
+    # value against the platform modes, and the schema keeps it exclusive with
+    # the top-level `new_mode` / `exit`, so it never conflicts at runtime. An
+    # A3 alias built via ``dataclasses.replace`` inherits the target's map (the
+    # `mode:`-override alias path re-validates the inherited keys, #317 / P-1).
     # `disables_paging` marks a session-level "turn paging off" command (e.g.
     # `terminal length 0`, #307 / P3-4). The shell sets a sticky session flag when
     # such a command runs in-mode; the push driver then renders without the
     # `--More--` pager. An A3 alias built via ``dataclasses.replace(target, ...)``
     # inherits the target's value for free (alias authoring rows cannot set it).
     disables_paging: bool = False
+    transitions: Mapping[str, Transition] | None = None
 
     def __post_init__(self) -> None:
         # Backfill canonical_name to the command's own name when unset (empty

--- a/simnos/plugins/shell/cmd_shell.py
+++ b/simnos/plugins/shell/cmd_shell.py
@@ -3,7 +3,7 @@ Custom shell class to interact with NOS.
 """
 
 import copy
-from dataclasses import dataclass
+from dataclasses import dataclass, replace
 import hashlib
 import logging
 import os
@@ -145,6 +145,10 @@ def build_resolved_platform(
         log.debug("overlay overrides %d command(s): %s", len(overlay_commands), sorted(overlay_commands))
         commands.update(overlay_commands)
     commands.update(adapt_commands(copy.deepcopy(inventory_commands), reverse_map))
+    # Bind any A3 `handler:` refs to the platform's py handler namespace now that
+    # every inflow is merged (an overlay/inventory override may have replaced a
+    # handler command with a literal, so bind the final state) (#317 / P-1).
+    _bind_handler_refs(commands, nos.handlers)
     # Carry `auth` so the merged platform mirrors the A3 source — auth is consumed
     # via `nos.auth`, but dropping it would re-introduce the silent-dead-end
     # asymmetry the auth wiring fixed (2nd round codex/claude #3).
@@ -158,6 +162,34 @@ def build_resolved_platform(
         # when the platform authored its own (#307 / P3-4).
         more_prompt=a3.more_prompt,
     )
+
+
+def _bind_handler_refs(commands: dict[str, ResolvedCommand], handlers: dict[str, CommandHandler]) -> None:
+    """Bind A3 ``handler:`` refs to callables from the py handler namespace (#317 / P-1).
+
+    An A3-authored handler command carries ``output.kind == "handler"`` with
+    ``handler=None`` and a ``handler_ref`` name; the py module that ships the
+    platform's device class exposes the actual callables (`nos.handlers`). Resolve
+    each ref here — at the merge boundary, once — and replace the command with a
+    bound copy. In-place on the fresh merge dict: each `ResolvedCommand` is frozen,
+    so binding means ``replace`` on the command and its output.
+
+    An unresolved ref is loud (a `ValueError` surfacing at ``Host.start`` /
+    ``build_shared_platform``): "fail at startup", never a silent no-output
+    command. The legacy adapter sets ``handler`` directly (no ``handler_ref``), so
+    those commands are already bound and skipped.
+    """
+    for name, cmd in commands.items():
+        out = cmd.output
+        if out.kind == "handler" and out.handler is None and out.handler_ref is not None:
+            handler = handlers.get(out.handler_ref)
+            if handler is None:
+                raise ValueError(
+                    f"command {name!r}: handler {out.handler_ref!r} is not defined in the platform's py handler "
+                    f"namespace (available: {sorted(handlers)}) — a `handler:` command needs a py module that "
+                    "defines it (#317 / P-1)"
+                )
+            commands[name] = replace(cmd, output=replace(out, handler=handler))
 
 
 @dataclass(frozen=True)
@@ -475,6 +507,9 @@ class CMDShell:
         "auth",
         "device",
         "resolved_platform",
+        # `_from_module` rebuilds `handlers` as a fresh dict, so snapshotting the
+        # reference here rolls back a failed hot reload cleanly (#317 / P-1).
+        "handlers",
     )
 
     def reload_commands(self, reload_targets: list):
@@ -796,8 +831,20 @@ class CMDShell:
                     cmd = special
                     abbrev_input = line  # set only when the special was actually swapped in
         if cmd is not None and self._in_current_mode(cmd):
-            if cmd.exit:
+            # Transition decision (#317 / P-1): the mode-conditional `transitions`
+            # map wins for the current mode, else the simple static `exit` /
+            # `new_mode`. An `exit` (from either channel) suppresses the body, so
+            # decide it before rendering. `transitions` is None for every command
+            # that uses the simple form, so this is a no-op for them.
+            eff = cmd.transitions.get(self.current_mode) if cmd.transitions else None
+            if eff is not None:
+                if eff.exit:
+                    return None, True
+                transition = eff.new_mode
+            elif cmd.exit:
                 return None, True
+            else:
+                transition = cmd.new_mode
             # Sticky paging disable (#307 / P3-4): set only here — abbreviation is
             # already resolved (so `term len 0` works too) and the `_in_current_mode`
             # gate has passed (so a mode-mismatched command that falls through to
@@ -816,7 +863,6 @@ class CMDShell:
             # reaching a sibling's variant output. `cmd.name` (dispatch identity)
             # keys the lookup so a legacy alias returns its own output.
             output = self._variant_outputs.get(cmd.name, cmd.output) if cmd.variants else cmd.output
-            transition = cmd.new_mode
         else:
             if cmd is not None:
                 log.warning(

--- a/tests/core/test_nos.py
+++ b/tests/core/test_nos.py
@@ -6,6 +6,7 @@ This module can be found at simnos/core/nos.py
 import copy
 import logging
 import os
+import types
 
 from pydantic import ValidationError
 import pytest
@@ -547,6 +548,100 @@ def test_from_module_override_logs_debug(caplog):
     assert any("overrides 1 already-loaded command(s)" in msg and "show clock" in msg for msg in debug_msgs)
     # Full replacement: the module's callable output wins over the yaml str.
     assert callable(nos.commands["show clock"]["output"])
+
+
+class TestHandlerNamespace:
+    """`Nos._from_module` builds the A3 `handler:` namespace (#317 / P-1, 案D)."""
+
+    def test_collects_methods_and_module_functions(self, tmp_path):
+        py = _write_tmp_file(
+            tmp_path,
+            "handlers_plugin.py",
+            "from simnos.plugins.nos.platforms_py._templates.base_template import BaseDevice\n"
+            'NAME = "h1"\n'
+            'INITIAL_PROMPT = "{base_prompt}>"\n'
+            "class Dev(BaseDevice):\n"
+            "    def make_a(self, device=None, **kw):\n"
+            '        return "a"\n'
+            "    @staticmethod\n"
+            "    def make_b(device=None, **kw):\n"
+            '        return "b"\n'
+            "    def _private(self):\n"  # underscore -> excluded
+            '        return "x"\n'
+            "def make_c(device=None, **kw):\n"  # module-level function
+            '    return "c"\n'
+            "commands = {}\n",
+        )
+        nos = Nos()
+        nos.from_file(py)
+        # method + staticmethod + module-level function collected; `_private` excluded.
+        assert set(nos.handlers) == {"make_a", "make_b", "make_c"}
+
+    def test_rejects_classmethod_handler(self, tmp_path):
+        py = _write_tmp_file(
+            tmp_path,
+            "classmethod_plugin.py",
+            "from simnos.plugins.nos.platforms_py._templates.base_template import BaseDevice\n"
+            'NAME = "hc"\n'
+            'INITIAL_PROMPT = "{base_prompt}>"\n'
+            "class Dev(BaseDevice):\n"
+            "    @classmethod\n"
+            "    def make_a(cls, device=None, **kw):\n"
+            '        return "a"\n'
+            "commands = {}\n",
+        )
+        nos = Nos()
+        with pytest.raises(ValueError, match="classmethod"):
+            nos.from_file(py)
+
+    def test_rejects_class_module_name_collision(self, tmp_path):
+        py = _write_tmp_file(
+            tmp_path,
+            "collision_plugin.py",
+            "from simnos.plugins.nos.platforms_py._templates.base_template import BaseDevice\n"
+            'NAME = "hx"\n'
+            'INITIAL_PROMPT = "{base_prompt}>"\n'
+            "class Dev(BaseDevice):\n"
+            "    def make_a(self, device=None, **kw):\n"
+            '        return "method"\n'
+            "def make_a(device=None, **kw):\n"  # same name at module level -> loud
+            '    return "func"\n'
+            "commands = {}\n",
+        )
+        nos = Nos()
+        with pytest.raises(ValueError, match="unambiguous"):
+            nos.from_file(py)
+
+    def test_mro_override_and_inherited_base(self):
+        # The MRO walk (#317 / P-1) tested directly on `_build_handler_namespace`:
+        # `_from_module` allows only ONE local BaseDevice subclass, so a custom
+        # intermediate base is realistically an *imported* class (different
+        # `__module__`); here we build the class hierarchy in-process and hand it
+        # to the namespace builder. A derived override wins (normal method
+        # resolution, not a collision, 3rd round codex#3); a handler defined only
+        # on the intermediate base is still collected (gemini#1).
+        from simnos.core.nos import _build_handler_namespace
+        from simnos.plugins.nos.platforms_py._templates.base_template import BaseDevice
+
+        class Mid(BaseDevice):
+            def make_shared(self, device=None, **kw):
+                return "shared"
+
+            def make_a(self, device=None, **kw):
+                return "base"
+
+        class Dev(Mid):
+            def make_own(self, device=None, **kw):
+                return "own"
+
+            def make_a(self, device=None, **kw):  # override
+                return "derived"
+
+        module = types.ModuleType("m")  # no module-level functions
+        ns = _build_handler_namespace(module, [Dev])
+        assert {"make_shared", "make_a", "make_own"} == set(ns)
+        # Derived version wins (getattr on the leaf class resolves the override).
+        assert ns["make_a"](None, base_prompt="R1", current_mode="user", current_prompt="R1>", command="x") == "derived"
 
 
 def test_register_nos_plugin_directly():

--- a/tests/core/test_platform_loader.py
+++ b/tests/core/test_platform_loader.py
@@ -164,6 +164,120 @@ class TestLoadHappyPath:
         assert platform.commands["show version"].canonical_name == "show version"
 
 
+class TestHandlerChannel:
+    """A3 `handler:` channel (#317 / P-1): loader records a `handler_ref`, no bind."""
+
+    def test_handler_channel_records_ref_unbound(self, tmp_path):
+        root, commands = _platform(tmp_path)
+        _cmd(commands, "clock.yaml", "command: show clock\ntype: simnos\nmode: [enable]\nhandler: make_show_clock\n")
+        cmd = load_platform_dir(str(root)).commands["show clock"]
+        assert cmd.output.kind == "handler"
+        assert cmd.output.handler is None  # loader stays pure; bind is at merge time
+        assert cmd.output.handler_ref == "make_show_clock"
+        assert cmd.modes == frozenset({"enable"})
+
+
+class TestTransitions:
+    """A3 `transitions:` mode-conditional map (#317 / P-1)."""
+
+    def test_transitions_build_per_mode(self, tmp_path):
+        root, commands = _platform(tmp_path, modes={"user": "{{ base_prompt }}>", "enable": "{{ base_prompt }}#"})
+        _cmd(
+            commands,
+            "exit.yaml",
+            "command: exit\ntype: simnos\nmode: [user, enable]\ntransitions:\n"
+            "  user: {exit: true}\n  enable: {new_mode: user}\n",
+        )
+        cmd = load_platform_dir(str(root)).commands["exit"]
+        assert cmd.transitions is not None
+        assert cmd.transitions["user"].exit is True
+        assert cmd.transitions["user"].new_mode is None
+        assert cmd.transitions["enable"].exit is False
+        assert cmd.transitions["enable"].new_mode == "user"
+
+    def test_no_transitions_is_none(self, tmp_path):
+        root, commands = _platform(tmp_path)
+        _cmd(commands, "a.yaml", "command: x\ntype: ntc\n")
+        assert load_platform_dir(str(root)).commands["x"].transitions is None
+
+    def test_transitions_key_outside_command_modes_rejected(self, tmp_path):
+        # A key for a mode the command does not run in would never fire (dead entry).
+        root, commands = _platform(tmp_path, modes={"user": "{{ base_prompt }}>", "enable": "{{ base_prompt }}#"})
+        _cmd(
+            commands,
+            "a.yaml",
+            "command: x\ntype: simnos\nmode: [user]\ntransitions:\n  enable: {exit: true}\n",
+        )
+        with pytest.raises(ValueError, match="never fire"):
+            load_platform_dir(str(root))
+
+    def test_transitions_unknown_new_mode_rejected(self, tmp_path):
+        root, commands = _platform(tmp_path)
+        _cmd(
+            commands,
+            "a.yaml",
+            "command: x\ntype: simnos\nmode: [user]\ntransitions:\n  user: {new_mode: bogus}\n",
+        )
+        with pytest.raises(ValueError, match="not in platform modes"):
+            load_platform_dir(str(root))
+
+    def test_transitions_all_modes_command_allows_any_platform_mode_key(self, tmp_path):
+        # `mode` omitted = all modes; a key for any platform mode is then valid.
+        root, commands = _platform(tmp_path, modes={"user": "{{ base_prompt }}>", "enable": "{{ base_prompt }}#"})
+        _cmd(commands, "a.yaml", "command: x\ntype: simnos\ntransitions:\n  enable: {exit: true}\n")
+        cmd = load_platform_dir(str(root)).commands["x"]
+        assert cmd.modes == frozenset()  # all modes
+        assert cmd.transitions is not None
+        assert cmd.transitions["enable"].exit is True
+
+
+class TestAliasModeOverride:
+    """A3 alias `mode:` override (#317 / P-1)."""
+
+    def test_alias_mode_override_narrows_modes(self, tmp_path):
+        root, commands = _platform(
+            tmp_path,
+            modes={
+                "user": "{{ base_prompt }}>",
+                "enable": "{{ base_prompt }}#",
+                "config": "{{ base_prompt }}(config)#",
+            },
+        )
+        _cmd(
+            commands,
+            "show.yaml",
+            "command: show ip\ntype: ntc\nmode: [user, enable]\noutput: s.txt\n",
+            output_files={"s.txt": "IP\n"},
+        )
+        # `do show ip` runs only in config (arista `do show ip int brief` shape).
+        _cmd(commands, "do.yaml", "command: do show ip\nalias: show ip\nmode: [config]\n")
+        alias = load_platform_dir(str(root)).commands["do show ip"]
+        assert alias.modes == frozenset({"config"})  # overridden, not the target's user/enable
+        assert alias.output.render("R1") == "IP\n"  # dispatch still inherited
+        assert alias.canonical_name == "show ip"
+
+    def test_alias_mode_override_unknown_mode_rejected(self, tmp_path):
+        root, commands = _platform(tmp_path)
+        _cmd(commands, "s.yaml", "command: show ip\ntype: ntc\noutput: s.txt\n", output_files={"s.txt": "IP\n"})
+        _cmd(commands, "do.yaml", "command: do show ip\nalias: show ip\nmode: [bogus]\n")
+        with pytest.raises(ValueError, match="not in platform modes"):
+            load_platform_dir(str(root))
+
+    def test_alias_mode_override_drops_inherited_transition_key_rejected(self, tmp_path):
+        # A `mode:` override that narrows away a mode the inherited `transitions`
+        # map keys on would leave a dead transition entry — loud (#317 / P-1).
+        root, commands = _platform(tmp_path, modes={"user": "{{ base_prompt }}>", "enable": "{{ base_prompt }}#"})
+        _cmd(
+            commands,
+            "t.yaml",
+            "command: toggle\ntype: simnos\nmode: [user, enable]\ntransitions:\n"
+            "  user: {exit: true}\n  enable: {new_mode: user}\n",
+        )
+        _cmd(commands, "alias.yaml", "command: tog\nalias: toggle\nmode: [user]\n")
+        with pytest.raises(ValueError, match="drops.*transition mode"):
+            load_platform_dir(str(root))
+
+
 class TestLoadRejections:
     def test_duplicate_command(self, tmp_path):
         root, commands = _platform(tmp_path)

--- a/tests/core/test_pydantic_models.py
+++ b/tests/core/test_pydantic_models.py
@@ -206,6 +206,12 @@ class TestModelCommandAuthoring:
         with pytest.raises(ValidationError, match="valid Python identifier"):
             ModelCommandAuthoring(command="x", type="simnos", handler="make.show clock")
 
+    def test_rejects_keyword_handler(self):
+        # A keyword passes `str.isidentifier()` but can never name a real py
+        # function, so it is rejected at the authoring boundary (#317 P-1, codex#5).
+        with pytest.raises(ValidationError, match="valid Python identifier"):
+            ModelCommandAuthoring(command="x", type="simnos", handler="class")
+
     def test_rejects_handler_with_other_output_channel(self):
         with pytest.raises(ValidationError, match="at most one output channel"):
             ModelCommandAuthoring(command="x", type="simnos", handler="h", output="a.txt")

--- a/tests/core/test_pydantic_models.py
+++ b/tests/core/test_pydantic_models.py
@@ -14,6 +14,7 @@ from simnos.core.pydantic_models import (
     ModelHost,
     ModelNosCommand,
     ModelPlatformMeta,
+    ModelTransition,
 )
 
 
@@ -116,12 +117,29 @@ class TestModelCommandAuthoring:
             ModelCommandAuthoring(command="x", output="a.txt")
 
     def test_rejects_alias_with_dispatch_fields(self):
-        with pytest.raises(ValidationError, match="pure reference"):
+        with pytest.raises(ValidationError, match="alias cannot also set"):
             ModelCommandAuthoring(command="x", alias="y", output="a.txt")
 
     def test_rejects_alias_with_type(self):
-        with pytest.raises(ValidationError, match="pure reference"):
+        with pytest.raises(ValidationError, match="alias cannot also set"):
             ModelCommandAuthoring(command="x", alias="y", type="ntc")
+
+    def test_accepts_alias_with_mode_override(self):
+        # #317 / P-1: `mode:` is the one dispatch field an alias may re-author —
+        # a mode-set override (e.g. arista `do show ip int brief`, config-only).
+        model = ModelCommandAuthoring(command="do show x", alias="show x", mode=["config"])
+        assert model.alias == "show x"
+        assert model.mode == ["config"]
+
+    def test_rejects_alias_with_handler(self):
+        with pytest.raises(ValidationError, match="alias cannot also set"):
+            ModelCommandAuthoring(command="x", alias="y", handler="make_x")
+
+    def test_rejects_alias_with_transitions(self):
+        with pytest.raises(ValidationError, match="alias cannot also set"):
+            # pydantic coerces the nested dict into ModelTransition at runtime; ty
+            # only sees the dict literal (same pattern as the variants test above).
+            ModelCommandAuthoring(command="x", alias="y", transitions={"user": {"exit": True}})  # ty: ignore[invalid-argument-type]
 
     def test_accepts_disables_paging_on_real_command(self):
         # #307 / P3-4: a session-disable command flags itself; the loader carries
@@ -130,9 +148,9 @@ class TestModelCommandAuthoring:
         assert model.disables_paging is True
 
     def test_rejects_alias_with_disables_paging(self):
-        # An alias is a pure reference and inherits the target's disables_paging via
-        # the loader's `replace`; authoring it on the alias row is rejected (#307).
-        with pytest.raises(ValidationError, match="pure reference"):
+        # An alias inherits the target's disables_paging via the loader's `replace`;
+        # authoring it on the alias row is rejected (#307).
+        with pytest.raises(ValidationError, match="alias cannot also set"):
             ModelCommandAuthoring(command="term len 0", alias="terminal length 0", disables_paging=True)
 
     def test_rejects_default_with_mode(self):
@@ -177,6 +195,85 @@ class TestModelCommandAuthoring:
     def test_rejects_bad_type_literal(self):
         with pytest.raises(ValidationError):
             ModelCommandAuthoring(command="x", type="bogus")  # ty: ignore[invalid-argument-type]
+
+    # --- handler channel (#317 / P-1) ---
+
+    def test_accepts_handler_channel(self):
+        model = ModelCommandAuthoring(command="show clock", type="simnos", handler="make_show_clock")
+        assert model.handler == "make_show_clock"
+
+    def test_rejects_non_identifier_handler(self):
+        with pytest.raises(ValidationError, match="valid Python identifier"):
+            ModelCommandAuthoring(command="x", type="simnos", handler="make.show clock")
+
+    def test_rejects_handler_with_other_output_channel(self):
+        with pytest.raises(ValidationError, match="at most one output channel"):
+            ModelCommandAuthoring(command="x", type="simnos", handler="h", output="a.txt")
+
+    # --- transitions map (#317 / P-1) ---
+
+    def test_accepts_transitions_map(self):
+        model = ModelCommandAuthoring(
+            command="exit",
+            type="simnos",
+            mode=["user", "config"],
+            transitions={"user": {"exit": True}, "config": {"new_mode": "enable"}},  # ty: ignore[invalid-argument-type]
+        )
+        assert model.transitions is not None
+        assert model.transitions["user"].exit is True
+        assert model.transitions["config"].new_mode == "enable"
+
+    def test_rejects_transitions_with_static_new_mode(self):
+        with pytest.raises(ValidationError, match="`transitions` is exclusive"):
+            ModelCommandAuthoring(
+                command="x",
+                type="simnos",
+                new_mode="enable",
+                transitions={"user": {"exit": True}},  # ty: ignore[invalid-argument-type]
+            )
+
+    def test_rejects_transitions_with_static_exit(self):
+        with pytest.raises(ValidationError, match="`transitions` is exclusive"):
+            ModelCommandAuthoring(
+                command="x",
+                type="simnos",
+                exit=True,
+                transitions={"user": {"new_mode": "enable"}},  # ty: ignore[invalid-argument-type]
+            )
+
+    def test_rejects_empty_transitions(self):
+        with pytest.raises(ValidationError, match="is empty"):
+            ModelCommandAuthoring(command="x", type="simnos", transitions={})
+
+    def test_rejects_default_with_transitions(self):
+        with pytest.raises(ValidationError, match="mode-agnostic"):
+            ModelCommandAuthoring(
+                command="_default_",
+                type="simnos",
+                transitions={"user": {"exit": True}},  # ty: ignore[invalid-argument-type]
+            )
+
+
+class TestModelTransition:
+    """One `transitions` map entry — exactly one of new_mode / exit (#317 / P-1)."""
+
+    def test_accepts_exit(self):
+        assert ModelTransition(exit=True).exit is True
+
+    def test_accepts_new_mode(self):
+        assert ModelTransition(new_mode="enable").new_mode == "enable"
+
+    def test_rejects_both(self):
+        with pytest.raises(ValidationError, match="exactly one"):
+            ModelTransition(new_mode="enable", exit=True)
+
+    def test_rejects_neither(self):
+        with pytest.raises(ValidationError, match="exactly one"):
+            ModelTransition()
+
+    def test_rejects_exit_false(self):
+        with pytest.raises(ValidationError, match="`exit` must be true"):
+            ModelTransition(exit=False)
 
 
 class TestModelPlatformMeta:

--- a/tests/plugins/test_cmd_shell.py
+++ b/tests/plugins/test_cmd_shell.py
@@ -189,6 +189,108 @@ def test_a3_paging_flag_and_output_survive_py_inflow_merge(platform, command, pa
     assert (rendered.splitlines() if rendered is not None else None) == body_lines
 
 
+# --- #317 P-1: A3 handler channel + transitions (synthetic asset e2e) ---
+
+
+def _synthetic_a3_handler_platform(tmp_path, *, handler_ref="make_greeting"):
+    """Build a synthetic A3 dir + handler py exercising the P-1 channels (#317).
+
+    The A3 platform authors a `handler:` command (dynamic output), a `transitions:`
+    command (mode-conditional exit / new_mode), and an alias with a `mode:`
+    override; the py module ships the device class + the referenced handler. Returns
+    ``(a3_dir, py_file)`` for ``Nos(filename=[...])``.
+    """
+    root = tmp_path / "synplat"
+    (root / "commands").mkdir(parents=True)
+    (root / "platform.yaml").write_text(
+        "modes:\n"
+        '  user: {prompt: "{{ base_prompt }}>"}\n'
+        '  enable: {prompt: "{{ base_prompt }}#"}\n'
+        '  config: {prompt: "{{ base_prompt }}(config)#"}\n'
+        "initial_mode: user\n",
+        encoding="utf-8",
+    )
+    cmds = root / "commands"
+    cmds.joinpath("greet.yaml").write_text(
+        f"command: greet\ntype: simnos\nmode: [user, enable]\nhandler: {handler_ref}\n", encoding="utf-8"
+    )
+    cmds.joinpath("leave.yaml").write_text(
+        "command: leave\ntype: simnos\nmode: [user, enable, config]\ntransitions:\n"
+        "  user: {exit: true}\n  enable: {exit: true}\n  config: {new_mode: enable}\n",
+        encoding="utf-8",
+    )
+    cmds.joinpath("goto.yaml").write_text(
+        "command: goto enable\ntype: simnos\nmode: [user]\nnew_mode: enable\n", encoding="utf-8"
+    )
+    py = tmp_path / "synplat_handlers.py"
+    py.write_text(
+        "from simnos.plugins.nos.platforms_py._templates.base_template import BaseDevice\n"
+        "class SynDev(BaseDevice):\n"
+        "    def make_greeting(self, device=None, *, base_prompt, current_mode, current_prompt, command):\n"
+        '        return f"hello from {current_mode}"\n'
+        "commands = {}\n",
+        encoding="utf-8",
+    )
+    return str(root), str(py)
+
+
+def test_p1_handler_ref_binds_at_merge(tmp_path):
+    """An A3 `handler:` ref is bound to the py callable at `build_resolved_platform` (#317 P-1)."""
+    a3_dir, py = _synthetic_a3_handler_platform(tmp_path)
+    nos = Nos(filename=[a3_dir, py])
+    platform = build_resolved_platform(nos, {})
+    greet = platform.commands["greet"]
+    assert greet.output.kind == "handler"
+    assert greet.output.handler is not None  # bound
+    assert greet.output.handler_ref == "make_greeting"
+
+
+def test_p1_unresolved_handler_ref_is_loud(tmp_path):
+    """A `handler:` ref with no matching py callable fails loudly at merge (#317 P-1)."""
+    a3_dir, py = _synthetic_a3_handler_platform(tmp_path, handler_ref="does_not_exist")
+    nos = Nos(filename=[a3_dir, py])
+    with pytest.raises(ValueError, match="not defined in the platform's py handler namespace"):
+        build_resolved_platform(nos, {})
+
+
+def _synthetic_shell(tmp_path):
+    a3_dir, py = _synthetic_a3_handler_platform(tmp_path)
+    nos = Nos(filename=[a3_dir, py])
+    running = threading.Event()
+    running.set()  # unset would make `_dispatch_general` treat every line as a shutdown close
+    return CMDShell(nos=nos, nos_inventory_config={}, base_prompt="R1", is_running=running)
+
+
+def test_p1_bound_handler_dispatches(tmp_path):
+    """The merge-bound handler produces dynamic output through `_dispatch_general` (#317 P-1)."""
+    shell = _synthetic_shell(tmp_path)  # starts in `user`
+    body, close = shell._dispatch_general("greet")
+    assert body == "hello from user"
+    assert close is False
+
+
+def test_p1_transitions_exit_and_new_mode(tmp_path):
+    """A `transitions` map drives a per-mode exit / new_mode in dispatch (#317 P-1)."""
+    shell = _synthetic_shell(tmp_path)
+    # user mode: transitions[user] = exit -> session closes, no body.
+    body, close = shell._dispatch_general("leave")
+    assert close is True
+    assert body is None
+    # config mode: transitions[config] = new_mode enable (no exit).
+    shell.current_mode = "config"
+    body, close = shell._dispatch_general("leave")
+    assert close is False
+    assert shell.current_mode == "enable"
+
+
+def test_p1_alias_mode_override_dispatch(tmp_path):
+    """The `goto enable` static new_mode still transitions (baseline, unchanged wire, #317 P-1)."""
+    shell = _synthetic_shell(tmp_path)
+    body, close = shell._dispatch_general("goto enable")
+    assert close is False
+    assert shell.current_mode == "enable"
+
+
 # pylint: disable=too-many-public-methods
 class TestCmdShell(TestCase):
     """Test the CmdShell class."""

--- a/tests/plugins/test_cmd_shell.py
+++ b/tests/plugins/test_cmd_shell.py
@@ -222,6 +222,18 @@ def _synthetic_a3_handler_platform(tmp_path, *, handler_ref="make_greeting"):
     cmds.joinpath("goto.yaml").write_text(
         "command: goto enable\ntype: simnos\nmode: [user]\nnew_mode: enable\n", encoding="utf-8"
     )
+    # A partial `transitions` map: valid in user+enable but keyed on enable only,
+    # so in user mode `eff` is None and the command stays put (#317 P-1, claude#3).
+    cmds.joinpath("partial.yaml").write_text(
+        "command: partial\ntype: simnos\nmode: [user, enable]\ntransitions:\n  enable: {new_mode: user}\n",
+        encoding="utf-8",
+    )
+    # A command carrying BOTH a dynamic `handler:` output and a `transitions:`
+    # transition — the two channels are orthogonal (#317 P-1, claude#2).
+    cmds.joinpath("dyn.yaml").write_text(
+        f"command: dyn\ntype: simnos\nmode: [enable]\nhandler: {handler_ref}\ntransitions:\n  enable: {{new_mode: user}}\n",
+        encoding="utf-8",
+    )
     py = tmp_path / "synplat_handlers.py"
     py.write_text(
         "from simnos.plugins.nos.platforms_py._templates.base_template import BaseDevice\n"
@@ -283,12 +295,36 @@ def test_p1_transitions_exit_and_new_mode(tmp_path):
     assert shell.current_mode == "enable"
 
 
-def test_p1_alias_mode_override_dispatch(tmp_path):
-    """The `goto enable` static new_mode still transitions (baseline, unchanged wire, #317 P-1)."""
+def test_p1_static_new_mode_dispatch(tmp_path):
+    """A plain static `new_mode` still transitions unchanged (baseline byte-parity, #317 P-1)."""
     shell = _synthetic_shell(tmp_path)
     body, close = shell._dispatch_general("goto enable")
     assert close is False
     assert shell.current_mode == "enable"
+
+
+def test_p1_partial_transitions_map_stays_when_mode_absent(tmp_path):
+    """A `transitions` map missing the current mode = no transition (#317 P-1, claude#3)."""
+    shell = _synthetic_shell(tmp_path)  # user mode; `partial` keys enable only
+    body, close = shell._dispatch_general("partial")
+    assert close is False
+    assert shell.current_mode == "user"  # stayed — no entry for user
+    # And in enable mode its one entry fires.
+    shell.current_mode = "enable"
+    shell.prompt = "R1#"
+    shell._dispatch_general("partial")
+    assert shell.current_mode == "user"
+
+
+def test_p1_handler_and_transitions_are_orthogonal(tmp_path):
+    """A command with both `handler:` and `transitions:` renders handler output AND transitions (#317 P-1, claude#2)."""
+    shell = _synthetic_shell(tmp_path)
+    shell.current_mode = "enable"  # `dyn` is enable-only
+    shell.prompt = "R1#"
+    body, close = shell._dispatch_general("dyn")
+    assert body == "hello from enable"  # handler output rendered
+    assert close is False
+    assert shell.current_mode == "user"  # transitions[enable] = new_mode user applied
 
 
 # pylint: disable=too-many-public-methods

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -4,6 +4,14 @@ from types import SimpleNamespace
 from typing import cast
 
 from simnos.core.host import Host
+from simnos.core.resolved_command import (
+    NO_OUTPUT,
+    ModeDef,
+    ResolvedCommand,
+    ResolvedPlatform,
+    Transition,
+    compile_template,
+)
 from simnos.plugins.nos.platforms_py import huawei_smartax
 from tests.utils import get_host_commands
 
@@ -60,3 +68,54 @@ class TestGetHostCommandsChangesPrompt:
         """
         for name in ("return", "disable"):
             assert huawei_smartax.commands[name]["changes_prompt"] is True
+
+
+class TestGetHostCommandsA3Transitions:
+    """The A3 sweep skips `transitions` commands like static `new_mode`/`exit` (#317 P-1).
+
+    A `transitions` command changes mode / closes the session at dispatch time, so
+    running it in the flat netmiko sweep would trip a mode change / ReadTimeout —
+    the same reason `new_mode` / `exit` are skipped. Pins the `rc.transitions`
+    branch added to `get_host_commands`.
+    """
+
+    @staticmethod
+    def _a3_host(commands: dict[str, ResolvedCommand]) -> Host:
+        template, _ = compile_template("{{ base_prompt }}>")
+        platform = ResolvedPlatform(
+            modes={"user": ModeDef(name="user", prompt_template=template)},
+            initial_mode="user",
+            commands=commands,
+        )
+        # `get_host_commands` walks the legacy `nos.commands` dict first, then the
+        # A3 `resolved_platform`; give the fake nos an empty legacy dict so only
+        # the A3 branch contributes.
+        nos = SimpleNamespace(name="t", commands={}, resolved_platform=platform)
+        return cast(Host, SimpleNamespace(nos=nos))
+
+    def test_transitions_command_is_skipped(self):
+        plain = ResolvedCommand(
+            name="show widget",
+            modes=frozenset({"user"}),
+            new_mode=None,
+            output=NO_OUTPUT,
+            variants=(),
+            help="",
+            exit=False,
+            type="simnos",
+        )
+        transitioning = ResolvedCommand(
+            name="toggle",
+            modes=frozenset({"user"}),
+            new_mode=None,
+            output=NO_OUTPUT,
+            variants=(),
+            help="",
+            exit=False,
+            type="simnos",
+            transitions={"user": Transition(exit=True)},
+        )
+        host = self._a3_host({"show widget": plain, "toggle": transitioning})
+        initial, enable, config = get_host_commands(host)
+        assert "show widget" in initial  # plain command is swept
+        assert "toggle" not in initial + enable + config  # transitions command is skipped

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -185,7 +185,12 @@ def get_host_commands(host: Host) -> tuple[list[str], list[str], list[str]]:
         for command, rc in resolved.commands.items():
             if command.startswith("_") and command.endswith("_"):
                 continue
-            if rc.new_mode or rc.exit or command in {"exit", "quit", "logout"}:
+            # `transitions` is the mode-conditional successor to `new_mode` /
+            # `exit` (#317 / P-1): a transitions command changes mode or closes
+            # the session at dispatch time just like the static forms, so the
+            # flat sweep must skip it too (else a future shipped A3 `transitions`
+            # command would be run into a mode change / ReadTimeout).
+            if rc.new_mode or rc.exit or rc.transitions or command in {"exit", "quit", "logout"}:
                 continue
             # Empty `modes` = valid in every mode (legacy prompt-omission
             # successor); a flat sweep reaches it from the initial mode.


### PR DESCRIPTION
🐙claude:

## 概要
#317(v3 レガシー command authoring 撤去 / A3 単一化)の **P-1**。A3 authoring の表現力を拡張する**純追加** PR。**shipped データ・client wire は完全不変**(byte-parity golden / paging golden / migration oracle / netmiko sweep 全 green)。epic #263 配下、design `20260702_053246_claude_issue-317-legacy-authoring-removal.md` の P-1 節。

## 変更点
- **`handler: <識別子>`** = 第4の排他 output channel。loader は `handler_ref` 参照のみ保持し pure/cache を維持、実 callable の bind は `build_resolved_platform`(`_bind_handler_refs`、未解決 ref は Host.start で loud)。
- **`transitions:`** = モード条件付き遷移 map(`ModelTransition` = `new_mode` XOR `exit`)。トップレベル `new_mode`/`exit` と排他、空 map reject、`_default_` は reject。loader が key ⊆ コマンドの有効モード / `new_mode` ∈ platform modes を検証(dead entry loud)。
- **`_dispatch_general`** の遷移決定を `transitions[current_mode]` → `exit` → `new_mode` に集約。`transitions=None` の既存コマンドは従来挙動と完全一致。
- **alias `mode:` 上書き**解禁(arista `do show ip int brief` 用)。継承した `transitions` の key が上書き後モード集合から外れる場合は load-time loud reject。
- **handler namespace 構築**(`Nos._from_module` / `_build_handler_namespace`): device class MRO walk(`BaseDevice`/`object` 除外、派生 override 優先)+ module-level 関数。`classmethod` reject、`function`/`staticmethod` 限定、class×module 名衝突 loud、fresh dict 置換 + `_NOS_RELOAD_ATTRS` に `handlers` 追加(hot-reload rollback)。
- handler 名 validator に `keyword.iskeyword` reject 追加。

## スコープ外(P-2 以降)
- handler 戻り値契約の `str | None` 縮小(`CommandResult` 削除等)は **P-2**。P-1 で先行すると legacy adapter 経由 dict-return handler が CI 非検知で壊れる regression 窓ができるため(design Decision 1)。
- 3 py module の A3 移送 / `#115` marker 撤去は P-2。

## テスト
- 新規 unit: schema(handler channel / `ModelTransition` / transitions 排他・空・`_default_` reject / keyword reject)、loader(handler channel resolve / transitions build+dead-key/unknown-new_mode reject / alias mode 上書き+継承 transitions 再検証)、handler namespace(収集 / classmethod reject / channel 衝突 / MRO override・継承基底)。
- 新規 e2e(synthetic A3 + handler py): merge-time bind / 未解決 loud / handler dispatch / transitions exit・new_mode / 部分 map fallback / handler×transitions 直交性。
- `get_host_commands` の A3 sweep filter に `rc.transitions` skip 追加(将来 shipped A3 の transitions が flat sweep に混入する regression を予防)+ pin。
- **full suite 1185 passed / 7 skipped**、ruff / ty / yamllint clean。

## レビュー
cross-review 2 round 収束(1st SHOULD FIX[codex#1 = sweep filter]→ 全取り込み / 2nd = gemini LGTM・codex SUGGESTION[keyword test]→ 取り込み)。pre-review-refactor + final-refactor 通過。

🤖 Generated with [Claude Code](https://claude.com/claude-code)