### PR TITLE
chore: docs/platforms の pre-existing drift 一括再生成 (#322)

### DIFF
--- a/docs/platforms/arista_eos.md
+++ b/docs/platforms/arista_eos.md
@@ -335,8 +335,8 @@ Sensor  Description                             (C)         (C)    (C)       (C)
 
 **Output:**
 ```
-Hostname: {base_prompt}
-FQDN:     {base_prompt}
+Hostname: arista_eos
+FQDN:     arista_eos.company.com
 ```
 
 **Help:** Show the system hostname

--- a/docs/platforms/aruba_aoscx.md
+++ b/docs/platforms/aruba_aoscx.md
@@ -27,6 +27,16 @@
 **Prompt:**
 - aruba_aoscx>
 
+### no page
+
+**Output:** None
+
+**Help:** disable paging
+
+**Prompt:**
+- aruba_aoscx>
+- aruba_aoscx#
+
 ### show aaa authentication port-access interface all client-status
 
 **Output:**

--- a/docs/platforms/aruba_os.md
+++ b/docs/platforms/aruba_os.md
@@ -16,6 +16,16 @@
 **Prompt:**
 - aruba_os>
 
+### no paging
+
+**Output:** None
+
+**Help:** disable paging
+
+**Prompt:**
+- aruba_os>
+- aruba_os#
+
 ### show ap bss-table details
 
 **Output:**

--- a/docs/platforms/cisco_ios.md
+++ b/docs/platforms/cisco_ios.md
@@ -7968,8 +7968,7 @@ Tacacs+ Server -  public  :
 ```
 
 Cisco IOS XE Software, Version 17.03.01a
-Cisco IOS Software [Amsterdam], Virtual XE Software \
-    (X86_64_LINUX_IOSD-UNIVERSALK9-M), Version 17.3.1a, RELEASE SOFTWARE (fc3)
+Cisco IOS Software [Amsterdam], Virtual XE Software (X86_64_LINUX_IOSD-UNIVERSALK9-M), Version 17.3.1a, RELEASE SOFTWARE (fc3)
 Technical Support: http://www.cisco.com/techsupport
 Copyright (c) 1986-2020 by Cisco Systems, Inc.
 Compiled Wed 12-Aug-20 00:16 by mcpre
@@ -8019,8 +8018,7 @@ The current throughput level is 1000 kbps
 
 Smart Licensing Status: UNREGISTERED/No Licenses in Use
 
-cisco CSR1000V (VXE) processor (revision VXE) \
-    with 715705K/3075K bytes of memory.
+cisco CSR1000V (VXE) processor (revision VXE) with 715705K/3075K bytes of memory.
 Processor board ID 9ESGOBARV9D
 Router operating mode: Autonomous
 3 Gigabit Ethernet interfaces

--- a/docs/platforms/cisco_viptela.md
+++ b/docs/platforms/cisco_viptela.md
@@ -27,6 +27,16 @@
 **Prompt:**
 - cisco_viptela>
 
+### paginate false
+
+**Output:** None
+
+**Help:** disable paging
+
+**Prompt:**
+- cisco_viptela>
+- cisco_viptela#
+
 ### show arp
 
 **Output:**

--- a/docs/platforms/cisco_wlc_ssh.md
+++ b/docs/platforms/cisco_wlc_ssh.md
@@ -7,6 +7,16 @@
     open an issue on the GitHub repository. Thanks! 🤗📖
 ## Commands
 
+### config paging disable
+
+**Output:** None
+
+**Help:** disable paging
+
+**Prompt:**
+- cisco_wlc_ssh>
+- cisco_wlc_ssh#
+
 ### _default_
 
 **Output:**

--- a/docs/platforms/dlink_ds.md
+++ b/docs/platforms/dlink_ds.md
@@ -24,6 +24,20 @@ telnet              upload
 
 **Prompt:**
 
+### disable clipaging
+
+**Output:**
+```
+Command: disable clipaging
+
+Success.
+```
+
+**Help:** disable paging
+
+**Prompt:**
+- dlink_ds#
+
 ### enable
 
 **Output:** None
@@ -37,12 +51,12 @@ telnet              upload
 
 **Output:**
 ```
-Command: disable clipaging
+Command: enable clipaging
 
 Success.
 ```
 
-**Help:** enters the mmi mode (machine-machine interface)
+**Help:** enable paging
 
 **Prompt:**
 - dlink_ds#

--- a/docs/platforms/extreme_slxos.md
+++ b/docs/platforms/extreme_slxos.md
@@ -67,3 +67,12 @@ Ve 734                 10.224.8.137         ABC-PUBLIC-LEGACY                   
 **Prompt:**
 - extreme_slxos#
 
+### terminal length 0
+
+**Output:** None
+
+**Help:** disable paging
+
+**Prompt:**
+- extreme_slxos#
+

--- a/docs/platforms/ruckus_fastiron.md
+++ b/docs/platforms/ruckus_fastiron.md
@@ -1077,3 +1077,13 @@ PORT-VLAN 4085, Name Session-VLAN, Priority level0, Off
 - ruckus_fastiron>
 - ruckus_fastiron#
 
+### skip-page-display
+
+**Output:** None
+
+**Help:** disable paging
+
+**Prompt:**
+- ruckus_fastiron>
+- ruckus_fastiron#
+

--- a/docs/platforms/zte_zxros.md
+++ b/docs/platforms/zte_zxros.md
@@ -869,3 +869,13 @@ Uptime is N/A
 - zte_zxros>
 - zte_zxros#
 
+### terminal length 0
+
+**Output:** None
+
+**Help:** disable paging
+
+**Prompt:**
+- zte_zxros>
+- zte_zxros#
+


### PR DESCRIPTION
## 概要

`invoke gen-docs-platform-commands` を実行し、`docs/platforms/*.md` の pre-existing drift を一括再生成する(#322)。docs freshness は CI gate 外(`test_gen_docs_platform_commands.py` はジェネレータロジックのみ検証)のため、過去 PR で docs を再生成せず merge した古い help/output が実 A3 データからズレていた。**wire / 挙動には非接触(docs のみ)**。epic #263 配下。

## 再生成した 10 ファイルの内訳

| 種別 | platform | 内容 |
|---|---|---|
| #328 波及 | arista_eos / cisco_ios | `show hostname` の `{base_prompt}` → render 結果 / `show version` の `\` 継続除去 |
| #308 P3-4 波及 | aruba_aoscx, aruba_os, cisco_viptela, cisco_wlc_ssh, extreme_slxos, ruckus_fastiron, zte_zxros | `no page` 等 disable-paging コマンドの docs 反映漏れ |
| drift 是正 | dlink_ds | `disable clipaging` 追記 + 旧 docs の help/output 誤マッピング是正(`enable clipaging` に「enters the mmi mode」という誤 help がついていた → 「enable paging」に修正)|

## 検証

- 変更範囲は `docs/platforms/*.md` 10 ファイルのみ(コード・wire・oracle 非接触)。
- `mkdocs.yml` は再生成しても変更なし(新規 platform 無し = nav 冪等)。
- `pytest tests/test_gen_docs_platform_commands.py` = 15 passed(ジェネレータロジック不変)。
- diff は全て機械生成出力で、正当な doc-freshness 更新であることを目視レビュー済み。

## メモ

将来 `gen-docs` の diff-clean を CI で確認する gate を足せば drift 再発防止になるが、本 PR の scope 外。

Closes は v3→main 統合時に判断(#322 は OPEN 維持)。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
