### PR TITLE
fix: session-close realism を reachable-config 3 platform に整備 (Tier 2) (#327)

### DIFF
--- a/simnos/plugins/nos/platforms/brocade_fastiron/commands/end.yaml
+++ b/simnos/plugins/nos/platforms/brocade_fastiron/commands/end.yaml
@@ -1,0 +1,7 @@
+# FastIron `end` jumps straight from config back to privileged EXEC (#327 Tier 2).
+command: end
+type: simnos
+help: End configuration mode and return to privileged EXEC
+mode:
+- config
+new_mode: enable

--- a/simnos/plugins/nos/platforms/brocade_fastiron/commands/end.yaml
+++ b/simnos/plugins/nos/platforms/brocade_fastiron/commands/end.yaml
@@ -1,4 +1,6 @@
 # FastIron `end` jumps straight from config back to privileged EXEC (#327 Tier 2).
+# Command exists per netmiko RuckusFastironBase (exit_config_mode default `end`). No
+# `output:` field -> NO_OUTPUT: the prompt returns to enable with no body.
 command: end
 type: simnos
 help: End configuration mode and return to privileged EXEC

--- a/simnos/plugins/nos/platforms/brocade_fastiron/commands/exit.yaml
+++ b/simnos/plugins/nos/platforms/brocade_fastiron/commands/exit.yaml
@@ -1,0 +1,20 @@
+# Mode-conditional transition (#327 Tier 2): real FastIron `exit` steps back one
+# level each time — config -> privileged EXEC (enable), enable -> user EXEC, and
+# user EXEC exit ends the session. transitions expresses the full step-down; this
+# overrides the all-modes BASIC exit. No `output:` field -> NO_OUTPUT (each step
+# returns with no body, faithful to FastIron; the user branch closes before
+# rendering).
+command: exit
+type: simnos
+help: Exit the current CLI level
+mode:
+- user
+- enable
+- config
+transitions:
+  user:
+    exit: true
+  enable:
+    new_mode: user
+  config:
+    new_mode: enable

--- a/simnos/plugins/nos/platforms/cisco_asa/commands/exit.yaml
+++ b/simnos/plugins/nos/platforms/cisco_asa/commands/exit.yaml
@@ -1,0 +1,18 @@
+# Mode-conditional transition (#327 Tier 2, cisco_ios Tier 1 pattern): ASA `exit`
+# logs out from user/privileged EXEC and steps config -> enable. Overrides the
+# all-modes BASIC exit. No `output:` field -> NO_OUTPUT: the config branch returns
+# to enable with no body, and the user/enable branches close before rendering.
+command: exit
+type: simnos
+help: Exit from the current mode
+mode:
+- user
+- enable
+- config
+transitions:
+  user:
+    exit: true
+  enable:
+    exit: true
+  config:
+    new_mode: enable

--- a/simnos/plugins/nos/platforms/cisco_asa/commands/logout.yaml
+++ b/simnos/plugins/nos/platforms/cisco_asa/commands/logout.yaml
@@ -1,0 +1,9 @@
+# Real ASA `logout` closes the session from user/privileged EXEC (it is not offered
+# inside a config mode). Static `exit: true` like cisco_ios `logout` (#327 Tier 2).
+command: logout
+type: simnos
+help: Exit from the EXEC
+mode:
+- user
+- enable
+exit: true

--- a/simnos/plugins/nos/platforms/hp_comware/commands/quit.yaml
+++ b/simnos/plugins/nos/platforms/hp_comware/commands/quit.yaml
@@ -1,7 +1,15 @@
+# Real HP Comware `quit`: from user-view it logs out; from system-view it steps up
+# one level to user-view (#327 Tier 2). `return` jumps straight to user-view from
+# any view (already authored). `exit` is not a Comware command -> left to the BASIC
+# all-modes close safety net. No `output:` field -> NO_OUTPUT.
 command: quit
 type: simnos
-help: exit the terminal (user view only; from system view use `return` to go back
-  to user view)
+help: Exit the current view (user-view logs out; system-view returns to user-view)
 mode:
 - user
-exit: true
+- config
+transitions:
+  user:
+    exit: true
+  config:
+    new_mode: user

--- a/tests/assets/oracle/brocade_fastiron.json
+++ b/tests/assets/oracle/brocade_fastiron.json
@@ -30,6 +30,42 @@
     "output": null,
     "variants": []
   },
+  "end": {
+    "exit": false,
+    "help": "End configuration mode and return to privileged EXEC",
+    "modes": [
+      "config"
+    ],
+    "new_mode": "enable",
+    "output": null,
+    "variants": []
+  },
+  "exit": {
+    "exit": false,
+    "help": "Exit the current CLI level",
+    "modes": [
+      "config",
+      "enable",
+      "user"
+    ],
+    "new_mode": null,
+    "output": null,
+    "transitions": {
+      "config": {
+        "exit": false,
+        "new_mode": "enable"
+      },
+      "enable": {
+        "exit": false,
+        "new_mode": "user"
+      },
+      "user": {
+        "exit": true,
+        "new_mode": null
+      }
+    },
+    "variants": []
+  },
   "show arp": {
     "exit": false,
     "help": "execute the command \"show arp\"",

--- a/tests/assets/oracle/cisco_asa.json
+++ b/tests/assets/oracle/cisco_asa.json
@@ -74,6 +74,32 @@
     "output": null,
     "variants": []
   },
+  "exit": {
+    "exit": false,
+    "help": "Exit from the current mode",
+    "modes": [
+      "config",
+      "enable",
+      "user"
+    ],
+    "new_mode": null,
+    "output": null,
+    "transitions": {
+      "config": {
+        "exit": false,
+        "new_mode": "enable"
+      },
+      "enable": {
+        "exit": true,
+        "new_mode": null
+      },
+      "user": {
+        "exit": true,
+        "new_mode": null
+      }
+    },
+    "variants": []
+  },
   "login": {
     "exit": false,
     "help": "It enters the terminal",
@@ -81,6 +107,17 @@
       "user"
     ],
     "new_mode": "enable",
+    "output": null,
+    "variants": []
+  },
+  "logout": {
+    "exit": true,
+    "help": "Exit from the EXEC",
+    "modes": [
+      "enable",
+      "user"
+    ],
+    "new_mode": null,
     "output": null,
     "variants": []
   },

--- a/tests/assets/oracle/hp_comware.json
+++ b/tests/assets/oracle/hp_comware.json
@@ -971,13 +971,24 @@
     "variants": []
   },
   "quit": {
-    "exit": true,
-    "help": "exit the terminal (user view only; from system view use `return` to go back to user view)",
+    "exit": false,
+    "help": "Exit the current view (user-view logs out; system-view returns to user-view)",
     "modes": [
+      "config",
       "user"
     ],
     "new_mode": null,
     "output": null,
+    "transitions": {
+      "config": {
+        "exit": false,
+        "new_mode": "user"
+      },
+      "user": {
+        "exit": true,
+        "new_mode": null
+      }
+    },
     "variants": []
   },
   "return": {

--- a/tests/plugins/test_abbreviation.py
+++ b/tests/plugins/test_abbreviation.py
@@ -174,13 +174,21 @@ CLOSE_FIXTURE = [
     ("cisco_asa", "exit", "config", False, "enable"),
     ("cisco_asa", "logout", "user", True, None),
     ("cisco_asa", "logout", "enable", True, None),
-    # Tier 2 — brocade_fastiron (step-down: only user EXEC exit closes)
+    # Tier 2 — brocade_fastiron (step-down: only user EXEC exit closes;
+    # `end` jumps config -> enable, a non-close descent like `exit`@config)
     ("brocade_fastiron", "exit", "user", True, None),
     ("brocade_fastiron", "exit", "enable", False, "user"),
     ("brocade_fastiron", "exit", "config", False, "enable"),
-    # Tier 2 — hp_comware (quit: user-view logs out, system-view steps up)
+    ("brocade_fastiron", "end", "config", False, "enable"),
+    # Tier 2 — hp_comware (quit: user-view logs out, system-view steps up).
+    # `exit` is NOT a Comware command, so it falls through to the BASIC all-modes
+    # close even from system-view (config) — the one residual config-exit close this
+    # Tier does not fix. Pinned here to make that accepted trade-off explicit and
+    # regression-visible (the faithful ideal is `_default_`; deferred to #334/Tier 3,
+    # which needs a mode-restriction no-op override — see design Risks).
     ("hp_comware", "quit", "user", True, None),
     ("hp_comware", "quit", "config", False, "user"),
+    ("hp_comware", "exit", "config", True, None),
 ]
 
 

--- a/tests/plugins/test_abbreviation.py
+++ b/tests/plugins/test_abbreviation.py
@@ -147,10 +147,19 @@ def test_unknown_input_stays_default(platform, mode, line, reason):
 # (a frozenset, order not guaranteed), so it cannot deterministically cover every
 # branch of a multi-mode `transitions` command; and avaya_ers is outside
 # SWEEP_PLATFORMS entirely. These pin each branch explicitly, replacing the removed
-# `exit -> _default_` negative pin with the positive close behaviour it became:
+# `exit -> _default_` negative pin with the positive close behaviour it became.
+#
+# Tier 1 (#332, cisco_ios / avaya_ers):
 #   - cisco_ios `exit` closes from user/enable EXEC but steps config -> enable
 #     (the shadowing bug's fix — config must NOT close the session)
 #   - cisco_ios / avaya_ers `logout` closes from every EXEC mode it declares
+#
+# Tier 2 (#327, reachable-config platforms — the only 3 that can enter config):
+#   - cisco_asa `exit` = cisco_ios pattern (user/enable close, config -> enable);
+#     `logout` closes from user/enable (ASA real command)
+#   - brocade_fastiron `exit` = FastIron step-down (user closes, enable -> user,
+#     config -> enable), so enable/config exits do NOT close the session
+#   - hp_comware `quit` closes from user-view but steps config (system-view) -> user
 CLOSE_FIXTURE = [
     ("cisco_ios", "exit", "user", True, None),
     ("cisco_ios", "exit", "enable", True, None),
@@ -159,6 +168,19 @@ CLOSE_FIXTURE = [
     ("cisco_ios", "logout", "enable", True, None),
     ("avaya_ers", "logout", "user", True, None),
     ("avaya_ers", "logout", "enable", True, None),
+    # Tier 2 — cisco_asa (cisco_ios-same exit + real ASA logout)
+    ("cisco_asa", "exit", "user", True, None),
+    ("cisco_asa", "exit", "enable", True, None),
+    ("cisco_asa", "exit", "config", False, "enable"),
+    ("cisco_asa", "logout", "user", True, None),
+    ("cisco_asa", "logout", "enable", True, None),
+    # Tier 2 — brocade_fastiron (step-down: only user EXEC exit closes)
+    ("brocade_fastiron", "exit", "user", True, None),
+    ("brocade_fastiron", "exit", "enable", False, "user"),
+    ("brocade_fastiron", "exit", "config", False, "enable"),
+    # Tier 2 — hp_comware (quit: user-view logs out, system-view steps up)
+    ("hp_comware", "quit", "user", True, None),
+    ("hp_comware", "quit", "config", False, "user"),
 ]
 
 


### PR DESCRIPTION
🐙claude:

## 概要
#327 Tier 2。config mode に**実際に到達できる** 3 platform(brocade_fastiron / cisco_asa / hp_comware)の config-exit 実バグを、Tier 1(PR #332)と同じ mode 条件付き `transitions:` モデルで解消する。機構は実装済みゆえ **platform データのみ**の変更。

### scope の根拠
config mode に遷移できる(`new_mode: config` するコマンドを持つ)platform は 40 中 5 だけ = arista_eos / cisco_ios(Tier 1 済)+ **本 PR の 3 platform**。残り 32 は `configure`/`system-view` が無く config 到達不能ゆえ config-exit バグは顕在化しない(→ 別 issue #334 で config 入口整備)。juniper 実 Junos 化は #333。

## 変更内容

| platform | 変更 | モデル(実機忠実) |
|---|---|---|
| brocade_fastiron | `exit.yaml` + `end.yaml` 新規 | FastIron 段階降下: `exit` は user→close / enable→user / config→enable、`end` は config→enable |
| cisco_asa | `exit.yaml` + `logout.yaml` 新規 | cisco_ios Tier 1 同型: `exit` は user/enable→close / config→enable、`logout`(ASA 実在)は user/enable→close |
| hp_comware | `quit.yaml` 改訂 | user-view→close / system-view→user-view(transitions 化)。`return` は既存据え置き |

- **brocade `logout` は authoring せず**: FastIron 実在未確認(段階降下 `exit` が user レベルで logout 提供)。
- **hp_comware `exit`**: Comware 非標準コマンドゆえ BASIC 安全網(全 mode close)のまま。system-view から `exit` が close する残存不整合は意図的な割り切りで、忠実な理想(`_default_`)は #334/Tier 3 に defer(mode 制限 no-op override 要)。CLOSE_FIXTURE で現挙動を明示 pin。

## test
- oracle snapshot 3 件再生成(exit/end/logout/quit の transitions・close 追加のみ)。
- `CLOSE_FIXTURE`(`tests/plugins/test_abbreviation.py`)に 3 platform 全 branch を pin(cisco_asa 5 / brocade 4[end 含む] / hp_comware 3[exit residual 含む])。step-down は `closes=False` + `new_mode` 検証。
- **wire golden 影響なし**(3 platform とも golden 非保持 = cisco_ios/alcatel_aos のみ)。

## 検証
- ruff / yamllint / lint-platform-data / ty 全 pass。
- full suite `pytest -n auto` = **1148 passed, 9 skipped**(byte-parity session-close 含む)。

## レビュー
- pre-review-refactor(両 phase クリーン)→ 1st cross-review(総合 SHOULD FIX、codex/gemini/claude 全指摘取り込み)→ final-refactor(両 phase クリーン)。

#327 は Tier 3(`ex` cleanup)残ゆえ OPEN 維持。

🤖 Generated with [Claude Code](https://claude.com/claude-code)