### PR TITLE
refactor: session-close の冗長な `ex` standalone stub 8 件を撤去 (Tier 3) (#327)

### DIFF
--- a/simnos/plugins/nos/platforms/alcatel_aos/commands/ex.yaml
+++ b/simnos/plugins/nos/platforms/alcatel_aos/commands/ex.yaml
@@ -1,7 +1,0 @@
-command: ex
-type: simnos
-help: exit the terminal
-mode:
-- user
-- enable
-exit: true

--- a/simnos/plugins/nos/platforms/avaya_ers/commands/ex.yaml
+++ b/simnos/plugins/nos/platforms/avaya_ers/commands/ex.yaml
@@ -1,7 +1,0 @@
-command: ex
-type: simnos
-help: exit the terminal
-mode:
-- user
-- enable
-exit: true

--- a/simnos/plugins/nos/platforms/cisco_nxos/commands/ex.yaml
+++ b/simnos/plugins/nos/platforms/cisco_nxos/commands/ex.yaml
@@ -1,7 +1,0 @@
-command: ex
-type: simnos
-help: exit the terminal
-mode:
-- user
-- enable
-exit: true

--- a/simnos/plugins/nos/platforms/eltex/commands/ex.yaml
+++ b/simnos/plugins/nos/platforms/eltex/commands/ex.yaml
@@ -1,7 +1,0 @@
-command: ex
-type: simnos
-help: exit the terminal
-mode:
-- user
-- enable
-exit: true

--- a/simnos/plugins/nos/platforms/extreme_exos/commands/ex.yaml
+++ b/simnos/plugins/nos/platforms/extreme_exos/commands/ex.yaml
@@ -1,7 +1,0 @@
-command: ex
-type: simnos
-help: exit the terminal
-mode:
-- user
-- enable
-exit: true

--- a/simnos/plugins/nos/platforms/paloalto_panos/commands/ex.yaml
+++ b/simnos/plugins/nos/platforms/paloalto_panos/commands/ex.yaml
@@ -1,6 +1,0 @@
-command: ex
-type: simnos
-help: exit the terminal
-mode:
-- user
-exit: true

--- a/simnos/plugins/nos/platforms/ubiquiti_edgeswitch/commands/ex.yaml
+++ b/simnos/plugins/nos/platforms/ubiquiti_edgeswitch/commands/ex.yaml
@@ -1,7 +1,0 @@
-command: ex
-type: simnos
-help: exit the terminal
-mode:
-- user
-- enable
-exit: true

--- a/simnos/plugins/nos/platforms/zyxel_os/commands/ex.yaml
+++ b/simnos/plugins/nos/platforms/zyxel_os/commands/ex.yaml
@@ -1,7 +1,0 @@
-command: ex
-type: simnos
-help: exit the terminal
-mode:
-- user
-- enable
-exit: true

--- a/tests/assets/oracle/alcatel_aos.json
+++ b/tests/assets/oracle/alcatel_aos.json
@@ -9,17 +9,6 @@
     "output": null,
     "variants": []
   },
-  "ex": {
-    "exit": true,
-    "help": "exit the terminal",
-    "modes": [
-      "enable",
-      "user"
-    ],
-    "new_mode": null,
-    "output": null,
-    "variants": []
-  },
   "show chassis": {
     "exit": false,
     "help": "execute the command \"show chassis\"",

--- a/tests/assets/oracle/avaya_ers.json
+++ b/tests/assets/oracle/avaya_ers.json
@@ -19,17 +19,6 @@
     "output": null,
     "variants": []
   },
-  "ex": {
-    "exit": true,
-    "help": "exit the terminal",
-    "modes": [
-      "enable",
-      "user"
-    ],
-    "new_mode": null,
-    "output": null,
-    "variants": []
-  },
   "logout": {
     "exit": true,
     "help": "Logout of the CLI session",

--- a/tests/assets/oracle/cisco_nxos.json
+++ b/tests/assets/oracle/cisco_nxos.json
@@ -44,17 +44,6 @@
     "output": null,
     "variants": []
   },
-  "ex": {
-    "exit": true,
-    "help": "exit the terminal",
-    "modes": [
-      "enable",
-      "user"
-    ],
-    "new_mode": null,
-    "output": null,
-    "variants": []
-  },
   "show access-lists": {
     "exit": false,
     "help": "execute the command \"show access-lists\"",

--- a/tests/assets/oracle/eltex.json
+++ b/tests/assets/oracle/eltex.json
@@ -9,17 +9,6 @@
     "output": null,
     "variants": []
   },
-  "ex": {
-    "exit": true,
-    "help": "exit the terminal",
-    "modes": [
-      "enable",
-      "user"
-    ],
-    "new_mode": null,
-    "output": null,
-    "variants": []
-  },
   "show interface": {
     "exit": false,
     "help": "execute the command \"show interface\"",

--- a/tests/assets/oracle/extreme_exos.json
+++ b/tests/assets/oracle/extreme_exos.json
@@ -42,17 +42,6 @@
     "output": null,
     "variants": []
   },
-  "ex": {
-    "exit": true,
-    "help": "exit the terminal",
-    "modes": [
-      "enable",
-      "user"
-    ],
-    "new_mode": null,
-    "output": null,
-    "variants": []
-  },
   "show fdb": {
     "exit": false,
     "help": "execute the command \"show fdb\"",

--- a/tests/assets/oracle/paloalto_panos.json
+++ b/tests/assets/oracle/paloalto_panos.json
@@ -16,16 +16,6 @@
     ],
     "variants": []
   },
-  "ex": {
-    "exit": true,
-    "help": "exit the terminal",
-    "modes": [
-      "user"
-    ],
-    "new_mode": null,
-    "output": null,
-    "variants": []
-  },
   "request license info": {
     "exit": false,
     "help": "execute the command \"request license info\"",

--- a/tests/assets/oracle/ubiquiti_edgeswitch.json
+++ b/tests/assets/oracle/ubiquiti_edgeswitch.json
@@ -19,17 +19,6 @@
     "output": null,
     "variants": []
   },
-  "ex": {
-    "exit": true,
-    "help": "exit the terminal",
-    "modes": [
-      "enable",
-      "user"
-    ],
-    "new_mode": null,
-    "output": null,
-    "variants": []
-  },
   "show arp": {
     "exit": false,
     "help": "execute the command \"show arp\"",

--- a/tests/assets/oracle/zyxel_os.json
+++ b/tests/assets/oracle/zyxel_os.json
@@ -253,17 +253,6 @@
     "output": null,
     "variants": []
   },
-  "ex": {
-    "exit": true,
-    "help": "exit the terminal",
-    "modes": [
-      "enable",
-      "user"
-    ],
-    "new_mode": null,
-    "output": null,
-    "variants": []
-  },
   "sys atsh": {
     "exit": false,
     "help": "execute the command \"sys atsh\"",

--- a/tests/plugins/test_ssh_byte_parity.py
+++ b/tests/plugins/test_ssh_byte_parity.py
@@ -232,12 +232,14 @@ def test_byte_parity_eof_on_disconnect(cisco_ios_port):
 
 
 def test_byte_parity_session_close_command():
-    """Pin the wire for a real session-closing command (exit:true), #297 codex#2.
+    """Pin the wire for a real session-closing command, #297 codex#2.
 
-    cisco_ios's `exit` is shadowed by an A3 config-mode command, so the
-    interactive golden never exercises a `DispatchResult.close` over the wire.
-    alcatel_aos `ex` is `exit: true` in user mode, so it drives the close path:
-    char echoes + the newline echo, then the server closes (no body, no prompt).
+    A minimal, dedicated close-over-wire pin: typing `ex` on alcatel_aos closes
+    the session. alcatel_aos declares no `exit`/`ex` command of its own, so `ex`
+    abbreviation-resolves to the all-modes BASIC `exit` (exit:true) — the char
+    echoes + the newline echo, then the server closes (no body, no prompt). Since
+    #327 Tier 3 removed the redundant standalone `ex` stub, this now exercises the
+    abbreviation path; the wire is byte-identical (`ex\\r` -> `ex\\r\\n` -> close).
     """
     with _running_host("alcatel_aos") as port:
         transport, channel = _open_shell_channel(port)

--- a/tests/plugins/test_ssh_byte_parity.py
+++ b/tests/plugins/test_ssh_byte_parity.py
@@ -240,6 +240,9 @@ def test_byte_parity_session_close_command():
     echoes + the newline echo, then the server closes (no body, no prompt). Since
     #327 Tier 3 removed the redundant standalone `ex` stub, this now exercises the
     abbreviation path; the wire is byte-identical (`ex\\r` -> `ex\\r\\n` -> close).
+    (The exact-match close path itself is pinned at unit level by
+    `test_abbreviation.test_session_close_authoring`, so this wire pin is free to
+    ride the abbreviation route without losing close-over-wire coverage.)
     """
     with _running_host("alcatel_aos") as port:
         transport, channel = _open_shell_channel(port)

--- a/tests/plugins/test_telnet_byte_parity.py
+++ b/tests/plugins/test_telnet_byte_parity.py
@@ -110,11 +110,12 @@ def test_telnet_byte_parity_interactive_session():
 
 
 def test_telnet_byte_parity_session_close_command():
-    """Pin the Telnet wire for a real session-closing command (exit: true).
+    """Pin the Telnet wire for a real session-closing command.
 
-    alcatel_aos ``ex`` is ``exit: true`` in user mode, so it drives the close
-    path: char echoes + the newline echo, then the server closes (no body, no
-    prompt) — same as the SSH session_close golden but over Telnet.
+    Typing ``ex`` on alcatel_aos abbreviation-resolves to the all-modes BASIC
+    ``exit`` (#327 Tier 3 removed the standalone ``ex`` stub): char echoes + the
+    newline echo, then the server closes (no body, no prompt) — same as the SSH
+    session_close golden but over Telnet.
     """
     with _running_telnet_host("alcatel_aos") as port:
         steps = asyncio.run(capture_telnet_transcript(port, [b"ex\r"]))


### PR DESCRIPTION
🐙claude:

## 概要
#327 Tier 3(cleanup)。session-close の冗長な `ex` standalone stub 8 件を撤去する。`ex` は `exit` の省略打鍵であって実機の literal コマンドではなく、P3-2 省略マッチ導入により standalone `ex.yaml` を消しても `ex` は一意に BASIC `exit`(全 mode exit:true)へ解決し **byte 一致で同一挙動 close** する。auto-generated stub の整理。

## 削除対象(8 platform)
`alcatel_aos / avaya_ers / cisco_nxos / eltex / extreme_exos / paloalto_panos / ubiquiti_edgeswitch / zyxel_os`

いずれも同一 stub(`command: ex` / `help: exit the terminal` / `exit: true`、paloalto のみ user-only)。8 platform とも `exit.yaml` を持たず BASIC `exit` に依存。

## 安全性(実証済)
- `ex` 削除後の省略解決: `ex*` で始まる他コマンドが無く ambiguity なし → `_resolve_abbreviation` で一意に BASIC `exit`(exit:true)へ解決。
- 挙動同一: 削除前(exact-match `ex`)/削除後(abbreviation→BASIC `exit`)とも `_dispatch_general` の収束点が同じ(`body=None, close=True`)。ex.yaml 無し platform(huawei_smartax)で `close=True/body=None` 完全一致を実証。

## 変更内容
- 8 `ex.yaml` 削除。
- oracle snapshot 8 件再生成 = `ex` entry が消えるだけのクリーン diff。
- byte-parity test docstring 更新: `ex` が省略マッチで BASIC `exit` に解決し close する旨を明記(SSH の stale text「cisco_ios exit is shadowed」= Tier 1 で解消済 も是正)。exact-match close path は unit `test_session_close_authoring` が別途 pin する旨も補足。

## golden / docs
- **wire golden 影響なし**: alcatel_aos(唯一の golden 保持)の session_close は `ex\r` → `ex\r\n` → close。省略解決後も wire byte 完全一致 = **再録なし**。
- **docs は意図的に stale**: `gen-docs-platform-commands` は global 再生成で Tier 1/2 の未再生成 drift も引き込むため、per-PR 再生成せず batch(#322 パターン、Tier 1/2 と同方針)に委ねる。Tier 1/2/3 分の docs 反映は **follow-up #336** で追跡。

## 検証
- ruff / yamllint / lint-platform-data / ty 全 pass。
- full suite `pytest -n auto` = **1148 passed, 9 skipped**(byte-parity session_close 含む)。
- pre-review-refactor(両 phase クリーン)→ 1st cross-review(総合 SUGGESTION: codex/gemini SUGGESTION・claude LGTM、全指摘取り込み)→ final-refactor(両 phase クリーン)。

## follow-up
- **#336**: docs/platforms を Tier 1/2/3 変更に追従して batch 再生成。
- 将来 これらの platform に `execute` 等 `ex*` コマンドを追加する際は `ex` が ambiguous 化するため、`ex` alias 明示のケアが必要(gemini review 指摘、worklog 記録)。

#327 は本 Tier 3 完了で 3 Tier 揃うが、v3→main まで OPEN 維持。

🤖 Generated with [Claude Code](https://claude.com/claude-code)