### PR TITLE
feat: challenge データ Phase 2 — 残 5 platform + SKIP_ENABLE 撤去 (#338)

### DIFF
--- a/simnos/plugins/nos/platforms/alcatel_sros/commands/enable-admin.txt
+++ b/simnos/plugins/nos/platforms/alcatel_sros/commands/enable-admin.txt
@@ -1,0 +1,1 @@
+MINOR: CLI Already in admin mode.

--- a/simnos/plugins/nos/platforms/alcatel_sros/commands/enable-admin.yaml
+++ b/simnos/plugins/nos/platforms/alcatel_sros/commands/enable-admin.yaml
@@ -1,0 +1,16 @@
+command: enable-admin
+type: simnos
+help: enable administrative mode
+mode:
+- user
+- enable
+challenge:
+  mode:
+  - user
+  kind: password
+  prompt: "Password: "
+  auth: secret
+  success:
+    new_mode: enable
+  failure_output: "MINOR: CLI Invalid password."
+output: enable-admin.txt

--- a/simnos/plugins/nos/platforms/alcatel_sros/commands/enable.yaml
+++ b/simnos/plugins/nos/platforms/alcatel_sros/commands/enable.yaml
@@ -1,6 +1,0 @@
-command: enable
-type: simnos
-help: enter enable mode
-mode:
-- user
-new_mode: enable

--- a/simnos/plugins/nos/platforms/cisco_apic/commands/enable.yaml
+++ b/simnos/plugins/nos/platforms/cisco_apic/commands/enable.yaml
@@ -1,6 +1,0 @@
-command: enable
-type: simnos
-help: enter enable mode
-mode:
-- user
-new_mode: enable

--- a/simnos/plugins/nos/platforms/cisco_apic/commands/sudo_-s.yaml
+++ b/simnos/plugins/nos/platforms/cisco_apic/commands/sudo_-s.yaml
@@ -1,0 +1,12 @@
+command: sudo -s
+type: simnos
+help: run a shell as root
+mode:
+- user
+challenge:
+  kind: password
+  prompt: "[sudo] password for {{ username }}: "
+  auth: password
+  success:
+    new_mode: enable
+  failure_output: "Sorry, try again."

--- a/simnos/plugins/nos/platforms/edgecore/commands/enable.yaml
+++ b/simnos/plugins/nos/platforms/edgecore/commands/enable.yaml
@@ -1,6 +1,0 @@
-command: enable
-type: simnos
-help: enter enable mode
-mode:
-- user
-new_mode: enable

--- a/simnos/plugins/nos/platforms/edgecore/commands/sudo_-s.yaml
+++ b/simnos/plugins/nos/platforms/edgecore/commands/sudo_-s.yaml
@@ -1,0 +1,12 @@
+command: sudo -s
+type: simnos
+help: run a shell as root
+mode:
+- user
+challenge:
+  kind: password
+  prompt: "[sudo] password for {{ username }}: "
+  auth: password
+  success:
+    new_mode: enable
+  failure_output: "Sorry, try again."

--- a/simnos/plugins/nos/platforms/ericsson_ipos/commands/enable.yaml
+++ b/simnos/plugins/nos/platforms/ericsson_ipos/commands/enable.yaml
@@ -1,6 +1,0 @@
-command: enable
-type: simnos
-help: enter enable mode
-mode:
-- user
-new_mode: enable

--- a/simnos/plugins/nos/platforms/ericsson_ipos/commands/enable_15.yaml
+++ b/simnos/plugins/nos/platforms/ericsson_ipos/commands/enable_15.yaml
@@ -1,0 +1,12 @@
+command: enable 15
+type: simnos
+help: enter privileged (level 15) mode
+mode:
+- user
+challenge:
+  kind: password
+  prompt: "Password: "
+  auth: secret
+  success:
+    new_mode: enable
+  failure_output: "% Access denied"

--- a/simnos/plugins/nos/platforms/yamaha/commands/administrator.yaml
+++ b/simnos/plugins/nos/platforms/yamaha/commands/administrator.yaml
@@ -1,0 +1,12 @@
+command: administrator
+type: simnos
+help: enter administrator mode
+mode:
+- user
+challenge:
+  kind: password
+  prompt: "Password: "
+  auth: secret
+  success:
+    new_mode: enable
+  failure_output: "Bad password"

--- a/simnos/plugins/nos/platforms/yamaha/commands/enable.yaml
+++ b/simnos/plugins/nos/platforms/yamaha/commands/enable.yaml
@@ -1,6 +1,0 @@
-command: enable
-type: simnos
-help: enter enable mode
-mode:
-- user
-new_mode: enable

--- a/tests/_platform_quirks.py
+++ b/tests/_platform_quirks.py
@@ -33,16 +33,11 @@ INIT_UNKNOWN_CMD_ALLOWED: dict[str, Quirk] = {
     "vyatta_vyos": Quirk("set terminal width 512", None, "2026-06-08"),
 }
 
-# Platforms where enable()/config_mode() cannot be exercised because they need
-# a secret or sudo. Their initial (show) commands are still tested.
-SKIP_ENABLE: dict[str, Quirk] = {
-    "alcatel_sros": Quirk("requires enable-admin with secret", None, "2026-06-08"),
-    "cisco_apic": Quirk("Linux-based, requires sudo -s for enable", None, "2026-06-08"),
-    "edgecore": Quirk("Linux-based (SONiC), requires sudo -s for enable", None, "2026-06-08"),
-    "ericsson_ipos": Quirk("requires administrator with secret", None, "2026-06-08"),
-    "linux": Quirk("Linux-based, requires sudo -s for enable", None, "2026-06-08"),
-    "yamaha": Quirk("requires enable with secret", None, "2026-06-08"),
-}
+# Platforms where enable()/config_mode() need an interactive secret or sudo
+# password. As of #338 (challenge mechanism, Phase 2) all such platforms model
+# the sub-prompt as A3 `challenge:` data and netmiko's enable() drives it, so
+# this quirk is now empty — the enable/config sweep runs for every platform.
+SKIP_ENABLE: dict[str, Quirk] = {}
 
 # Python-plugin platforms whose "all commands" sweep is xfailed.
 # huawei_smartax was xfailed here until #115 (then via a `changes_prompt`

--- a/tests/assets/oracle/alcatel_sros.json
+++ b/tests/assets/oracle/alcatel_sros.json
@@ -21,14 +21,30 @@
     ],
     "variants": []
   },
-  "enable": {
+  "enable-admin": {
+    "challenge": {
+      "auth": "secret",
+      "failure_output": "MINOR: CLI Invalid password.",
+      "kind": "password",
+      "modes": [
+        "user"
+      ],
+      "prompt": "Password: ",
+      "success": {
+        "exit": false,
+        "new_mode": "enable"
+      }
+    },
     "exit": false,
-    "help": "enter enable mode",
+    "help": "enable administrative mode",
     "modes": [
+      "enable",
       "user"
     ],
-    "new_mode": "enable",
-    "output": null,
+    "new_mode": null,
+    "output": [
+      "MINOR: CLI Already in admin mode."
+    ],
     "variants": []
   },
   "environment no more": {

--- a/tests/assets/oracle/cisco_apic.json
+++ b/tests/assets/oracle/cisco_apic.json
@@ -9,16 +9,6 @@
     ],
     "variants": []
   },
-  "enable": {
-    "exit": false,
-    "help": "enter enable mode",
-    "modes": [
-      "user"
-    ],
-    "new_mode": "enable",
-    "output": null,
-    "variants": []
-  },
   "fabric show vlan extended": {
     "exit": false,
     "help": "execute the command \"fabric show vlan extended\"",
@@ -60,6 +50,29 @@
       " 14   infra:default                    vxlan-16777209,  Eth1/1, Eth1/48          ",
       "                                       vlan-3914"
     ],
+    "variants": []
+  },
+  "sudo -s": {
+    "challenge": {
+      "auth": "password",
+      "failure_output": "Sorry, try again.",
+      "kind": "password",
+      "modes": [
+        "user"
+      ],
+      "prompt": "[sudo] password for user: ",
+      "success": {
+        "exit": false,
+        "new_mode": "enable"
+      }
+    },
+    "exit": false,
+    "help": "run a shell as root",
+    "modes": [
+      "user"
+    ],
+    "new_mode": null,
+    "output": null,
     "variants": []
   }
 }

--- a/tests/assets/oracle/edgecore.json
+++ b/tests/assets/oracle/edgecore.json
@@ -9,16 +9,6 @@
     ],
     "variants": []
   },
-  "enable": {
-    "exit": false,
-    "help": "enter enable mode",
-    "modes": [
-      "user"
-    ],
-    "new_mode": "enable",
-    "output": null,
-    "variants": []
-  },
   "show interfaces brief": {
     "exit": false,
     "help": "execute the command \"show interfaces brief\"",
@@ -717,6 +707,29 @@
       "Status:                Active",
       "Ports/Port Channels:   Eth1/ 3(S) Eth1/ 5(S) Eth1/25(S)"
     ],
+    "variants": []
+  },
+  "sudo -s": {
+    "challenge": {
+      "auth": "password",
+      "failure_output": "Sorry, try again.",
+      "kind": "password",
+      "modes": [
+        "user"
+      ],
+      "prompt": "[sudo] password for user: ",
+      "success": {
+        "exit": false,
+        "new_mode": "enable"
+      }
+    },
+    "exit": false,
+    "help": "run a shell as root",
+    "modes": [
+      "user"
+    ],
+    "new_mode": null,
+    "output": null,
     "variants": []
   }
 }

--- a/tests/assets/oracle/ericsson_ipos.json
+++ b/tests/assets/oracle/ericsson_ipos.json
@@ -1,11 +1,24 @@
 {
-  "enable": {
+  "enable 15": {
+    "challenge": {
+      "auth": "secret",
+      "failure_output": "% Access denied",
+      "kind": "password",
+      "modes": [
+        "user"
+      ],
+      "prompt": "Password: ",
+      "success": {
+        "exit": false,
+        "new_mode": "enable"
+      }
+    },
     "exit": false,
-    "help": "enter enable mode",
+    "help": "enter privileged (level 15) mode",
     "modes": [
       "user"
     ],
-    "new_mode": "enable",
+    "new_mode": null,
     "output": null,
     "variants": []
   },

--- a/tests/assets/oracle/yamaha.json
+++ b/tests/assets/oracle/yamaha.json
@@ -9,6 +9,29 @@
     ],
     "variants": []
   },
+  "administrator": {
+    "challenge": {
+      "auth": "secret",
+      "failure_output": "Bad password",
+      "kind": "password",
+      "modes": [
+        "user"
+      ],
+      "prompt": "Password: ",
+      "success": {
+        "exit": false,
+        "new_mode": "enable"
+      }
+    },
+    "exit": false,
+    "help": "enter administrator mode",
+    "modes": [
+      "user"
+    ],
+    "new_mode": null,
+    "output": null,
+    "variants": []
+  },
   "console lines infinity": {
     "disables_paging": true,
     "exit": false,
@@ -18,16 +41,6 @@
       "user"
     ],
     "new_mode": null,
-    "output": null,
-    "variants": []
-  },
-  "enable": {
-    "exit": false,
-    "help": "enter enable mode",
-    "modes": [
-      "user"
-    ],
-    "new_mode": "enable",
     "output": null,
     "variants": []
   },

--- a/tests/core/test_netmiko_init_compat.py
+++ b/tests/core/test_netmiko_init_compat.py
@@ -127,13 +127,14 @@ def _get_test_command(device_type: str) -> tuple[str, str] | None:
             continue
         if cmd_name in ("enable", "exit", "quit", "logout", "ex"):
             continue
-        if rc.new_mode or rc.exit:
-            continue
-        # A `challenge:` command (#338) waits for an interactive answer in its
-        # firing mode (e.g. alcatel_sros `enable-admin` in user mode), so a plain
-        # send_command would hang on its sub-prompt. Its literal `output` is only
-        # the non-firing-mode response — never a valid initial-mode probe here.
-        if rc.challenge:
+        # Skip anything that changes mode or waits for input at the initial
+        # prompt — a plain send_command probe would desync or hang. This mirrors
+        # the `get_host_commands` sweep filter (tests/utils.py) exactly:
+        # `transitions` is the mode-conditional successor to new_mode/exit (#317
+        # P-1), and a `challenge:` command (#338) blocks on its password
+        # sub-prompt (e.g. alcatel_sros `enable-admin` in user mode, whose
+        # literal `output` is only the non-firing-mode response, not a probe).
+        if rc.new_mode or rc.exit or rc.transitions or rc.challenge:
             continue
         if rc.output.kind != "literal" or not rc.output.text or not rc.output.text.strip():
             continue

--- a/tests/core/test_netmiko_init_compat.py
+++ b/tests/core/test_netmiko_init_compat.py
@@ -129,6 +129,12 @@ def _get_test_command(device_type: str) -> tuple[str, str] | None:
             continue
         if rc.new_mode or rc.exit:
             continue
+        # A `challenge:` command (#338) waits for an interactive answer in its
+        # firing mode (e.g. alcatel_sros `enable-admin` in user mode), so a plain
+        # send_command would hang on its sub-prompt. Its literal `output` is only
+        # the non-firing-mode response — never a valid initial-mode probe here.
+        if rc.challenge:
+            continue
         if rc.output.kind != "literal" or not rc.output.text or not rc.output.text.strip():
             continue
         # Valid in the initial mode? (empty mode set = valid in every mode.)

--- a/tests/plugins/test_challenge.py
+++ b/tests/plugins/test_challenge.py
@@ -429,3 +429,38 @@ class TestChallengeWire:
                 conn.disconnect()
         finally:
             net.stop()
+
+    def test_alcatel_sros_enable_admin_per_mode(self):
+        """Pin the C2 per-mode contract for alcatel_sros `enable-admin` (design §6, 案D).
+
+        NokiaSros.check_enable_mode re-sends `enable-admin` and, on seeing the
+        password prompt, escapes it with a bare Enter (RETURN) before reading the
+        prompt back. That empty answer is a single failed attempt (C1) that leaves
+        the user prompt intact, so the escape does not hang:
+
+        - user mode: `enable-admin` fires the challenge → check_enable_mode's bare
+          Enter fails it → back at `>` → "in admin mode" absent → check returns False
+        - after enable() supplies the secret → admin (enable) mode `#`
+        - enable mode: `enable-admin` does NOT fire (challenge.mode=[user]); its
+          `output` carries "in admin mode" so check_enable_mode returns True
+        """
+        net = SimNOS(inventory=build_inventory("alcatel_sros"))
+        net.start()
+        try:
+            port = net.hosts["device"].port
+            conn = ConnectHandler(
+                host="localhost",
+                username=TEST_USERNAME,
+                password=TEST_PASSWORD,
+                port=port,
+                device_type=netmiko_device_type_of("alcatel_sros"),
+                secret=TEST_PASSWORD,  # no inventory secret → server falls back to password (案F)
+            )
+            try:
+                assert conn.check_enable_mode() is False  # bare-Enter escape, still user mode
+                conn.enable()
+                assert conn.check_enable_mode() is True  # enable-mode output carries "in admin mode"
+            finally:
+                conn.disconnect()
+        finally:
+            net.stop()

--- a/tests/plugins/test_platforms.py
+++ b/tests/plugins/test_platforms.py
@@ -136,8 +136,12 @@ class TestPlatforms:
             for command in initial_commands:
                 output = conn.send_command(command)
                 assert isinstance(output, str)
-            # SKIP_ENABLE platforms cannot enter enable()/config_mode() (need a
-            # secret or sudo); their initial (show) commands above still run.
+            # `SKIP_ENABLE` is an (currently empty) registry hook for platforms
+            # whose enable()/config_mode() cannot be exercised. Since #338 (the
+            # challenge mechanism) every enable-secret / sudo platform models its
+            # sub-prompt as A3 `challenge:` data that netmiko's enable() drives,
+            # so the guard passes every platform through today; it is kept so a
+            # future genuinely-unreachable platform can opt out again.
             if enable_commands and platform not in SKIP_ENABLE:
                 conn.enable()
                 for command in enable_commands:

--- a/tests/plugins/test_platforms.py
+++ b/tests/plugins/test_platforms.py
@@ -136,7 +136,7 @@ class TestPlatforms:
             for command in initial_commands:
                 output = conn.send_command(command)
                 assert isinstance(output, str)
-            # `SKIP_ENABLE` is an (currently empty) registry hook for platforms
+            # `SKIP_ENABLE` is a (currently empty) registry hook for platforms
             # whose enable()/config_mode() cannot be exercised. Since #338 (the
             # challenge mechanism) every enable-secret / sudo platform models its
             # sub-prompt as A3 `challenge:` data that netmiko's enable() drives,

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -88,15 +88,17 @@ def netmiko_device(device_type: str, creds: dict, **extra) -> dict:
 
     ``secret`` is the enable/sudo credential netmiko sends when driving a
     `challenge:` command's password sub-prompt (#338). It mirrors the server's
-    案F resolution: an explicit ``host.secret`` when set, else the login password
-    (the fallback the server also uses for `auth: secret` when no secret is
-    configured). ``**extra`` merges additional kwargs such as ``session_log``.
+    案F resolution: an explicit ``host.secret`` when set (``is not None``, so an
+    empty secret is honoured verbatim), else the login password (the fallback the
+    server also uses for `auth: secret` when no secret is configured).
+    ``**extra`` merges additional kwargs such as ``session_log``.
     """
+    secret = creds.get("secret")
     return {
         "host": "localhost",
         "username": creds["username"],
         "password": creds["password"],
-        "secret": creds.get("secret") or creds["password"],
+        "secret": secret if secret is not None else creds["password"],
         "port": creds["port"],
         "device_type": netmiko_device_type_of(device_type),
         **extra,

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -78,20 +78,25 @@ def build_inventory(
 
 
 def creds_from_host(host: Host) -> dict:
-    """Return the username/password/port a netmiko client needs to reach ``host``."""
-    return {"username": host.username, "password": host.password, "port": host.port}
+    """Return the username/password/secret/port a netmiko client needs to reach ``host``."""
+    return {"username": host.username, "password": host.password, "secret": host.secret, "port": host.port}
 
 
 def netmiko_device(device_type: str, creds: dict, **extra) -> dict:
     """Build netmiko ``ConnectHandler`` kwargs (maps the simnos ``device_type``
     to netmiko's canonical device_type via platform.yaml, #266 / D3).
 
-    ``**extra`` merges additional kwargs such as ``session_log``.
+    ``secret`` is the enable/sudo credential netmiko sends when driving a
+    `challenge:` command's password sub-prompt (#338). It mirrors the server's
+    案F resolution: an explicit ``host.secret`` when set, else the login password
+    (the fallback the server also uses for `auth: secret` when no secret is
+    configured). ``**extra`` merges additional kwargs such as ``session_log``.
     """
     return {
         "host": "localhost",
         "username": creds["username"],
         "password": creds["password"],
+        "secret": creds.get("secret") or creds["password"],
         "port": creds["port"],
         "device_type": netmiko_device_type_of(device_type),
         **extra,

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -90,7 +90,11 @@ def netmiko_device(device_type: str, creds: dict, **extra) -> dict:
     `challenge:` command's password sub-prompt (#338). It mirrors the server's
     案F resolution: an explicit ``host.secret`` when set (``is not None``, so an
     empty secret is honoured verbatim), else the login password (the fallback the
-    server also uses for `auth: secret` when no secret is configured).
+    server also uses for `auth: secret` when no secret is configured). For an
+    `auth: password` challenge (sudo) the server only ever expects the login
+    password, and netmiko always transports ``self.secret`` — so a host that sets
+    a ``secret`` distinct from its password would make those sweeps fail; keep
+    them equal unless a test deliberately exercises the mismatch.
     ``**extra`` merges additional kwargs such as ``session_log``.
     """
     secret = creds.get("secret")


### PR DESCRIPTION
🐙claude:

## 概要

#338 challenge 機構の **Phase 2**。Phase 1 (機構本体 + linux `sudo -s` demo、PR #339 merged `fd9b1c5`) で確立した password challenge 機構に、残 5 platform のデータを投入し `SKIP_ENABLE` を全撤去して netmiko `enable()`/`config_mode()` sweep を全 platform で有効化する。

設計: `design/20260704_224447_claude_issue-338-challenge-mechanism.md` §7 Phase 2

## 変更内容

### challenge データ (5 platform、netmiko 実 driver 契約に整合)

| platform | netmiko cmd | pattern | auth | 備考 |
|---|---|---|---|---|
| alcatel_sros | `enable-admin` | `ssword` | secret | **C2/案D** |
| ericsson_ipos | `enable 15` | `ssword` | secret | |
| yamaha | `administrator` | `Password` | secret | pattern 大文字 |
| cisco_apic | `sudo -s` | `ssword` | password | LinuxSSH 継承 |
| edgecore | `sudo -s` | `ssword` | password | LinuxSSH(SONiC) 継承 |

- **alcatel_sros `enable-admin` (C2)**: `mode: [user, enable]` + `challenge.mode: [user]` + enable mode 用 `output: "MINOR: CLI Already in admin mode."`。nokia_sros driver は `check_enable_mode(check_string="in admin mode")` で `enable-admin` を再送し、user mode の password prompt を素 Enter で脱出する。この素 Enter が C1 (1 回失敗即復帰) の成功経路上にあることを個別 pin (`test_alcatel_sros_enable_admin_per_mode`)。
- 各 platform の dead `enable.yaml` stub (netmiko 実 cmd と不一致) を撤去。

### tests

- `_platform_quirks.SKIP_ENABLE` 6 件全撤去 (空 dict 化、registry hook は将来拡張用に維持)。
- `creds_from_host` / `netmiko_device` に `secret` 配線 (server 案F fallback を test 側でミラー: `host.secret is not None ? host.secret : host.password`)。
- `_get_test_command` の sweep filter を sibling `get_host_commands` と parity 化 (`rc.transitions` / `rc.challenge` 両方除外) — challenge command が非対話 probe に選ばれて hang する回帰を封じる。
- oracle 5 件再生成 (challenge projection、password/secret は非投影)。

## byte-parity golden

**無変更** — 対象 5 platform に既存 golden 無し、golden platform (cisco_ios / alcatel_aos) は非 touch。設計どおり Phase 1/2 は golden 不変。

## テスト結果

- netmiko enable/config sweep = 6 platform 全 PASS
- ruff / ruff format / yamllint / lint-platform-data / ty (exclude=[]) 全 clean
- full suite **1171 passed, 9 skipped**

## レビュー

1st cross-review = 全 reviewer 総合 **SUGGESTION** (MUST/SHOULD FIX ゼロ)。inline 取り込み: sweep filter parity (claude#2) / stale コメント是正 (codex#4・gemini#1・claude#3 収束) / docstring 明文化 (claude#4)。defer: 追加 wire pin (sweep が E2E gate 済=設計 §6) / sudo retry (C1 は netmiko 互換の意図的制約)。

Phase 3 (`kind: confirm` + cisco_ios reload/copy + `?` 一覧 golden 再録) は別 PR。全 Phase merge 後に #338 + #135 + #182 + #185 を同時 close。

🤖 Generated with [Claude Code](https://claude.com/claude-code)