### PR TITLE
chore: #338 phase 1-3 全体リファクタリング — challenge transition 適用の DRY + oracle helper 配置整合

### DIFF
--- a/simnos/plugins/shell/cmd_shell.py
+++ b/simnos/plugins/shell/cmd_shell.py
@@ -21,11 +21,13 @@ from simnos.core.platform_loader import load_platform_dir, resolve_modes, resolv
 from simnos.core.pydantic_models import ModelInventoryCommand, NosPluginConfig
 from simnos.core.resolved_command import (
     NO_OUTPUT,
+    ConfirmAction,
     ModeDef,
     ResolvedChallenge,
     ResolvedCommand,
     ResolvedOutput,
     ResolvedPlatform,
+    Transition,
     compile_template,
 )
 from simnos.core.values_loader import validate_render_values
@@ -917,6 +919,22 @@ class CMDShell:
             return out.template.render(base_prompt=self.base_prompt, username=username)
         return out.text or ""
 
+    def _apply_challenge_transition(self, action: "Transition | ConfirmAction") -> bool:
+        """Apply a challenge outcome's mode change; return whether it closes the session.
+
+        Shared by both `complete_challenge` kinds: a password `success` (a
+        `Transition`) and a confirm `on:` / `default:` (a `ConfirmAction`) carry the
+        same load-validated `exit` / `new_mode` shape (exactly one meaningful, exit
+        winning). `exit` closes the session (no transition); else a set `new_mode`
+        transitions; else the prompt stays put (a confirm cancel). Keeping the two
+        callers on one helper stops the password/confirm branches from drifting.
+        """
+        if action.exit:
+            return True
+        if action.new_mode is not None:
+            self._apply_new_mode(action.new_mode)
+        return False
+
     def complete_challenge(self, pending: "PendingChallenge", entered: str) -> DispatchResult:
         """Verify a challenge answer and return the resulting `DispatchResult` (#338 / §3).
 
@@ -951,14 +969,7 @@ class CMDShell:
                 )
                 body = spec.failure_output
             elif entered == expected:
-                # `success` is a load-validated `Transition` (exactly one of
-                # exit / new_mode), so exit False implies new_mode is set — the
-                # `is not None` narrows it for the type checker, mirroring
-                # `_dispatch_general`'s transition application.
-                if spec.success.exit:
-                    close = True
-                elif spec.success.new_mode is not None:
-                    self._apply_new_mode(spec.success.new_mode)
+                close = self._apply_challenge_transition(spec.success)
             else:
                 body = spec.failure_output
         elif spec.kind == "confirm":
@@ -968,10 +979,7 @@ class CMDShell:
             assert spec.on is not None  # noqa: S101 — loader guarantees a non-empty `on` on a confirm challenge
             action = spec.on.get(entered, spec.default)
             if action is not None:
-                if action.exit:
-                    close = True
-                elif action.new_mode is not None:
-                    self._apply_new_mode(action.new_mode)
+                close = self._apply_challenge_transition(action)
                 body = action.output
         if not self.is_running.is_set():
             close = True

--- a/tests/core/oracle_projection.py
+++ b/tests/core/oracle_projection.py
@@ -73,6 +73,17 @@ def _project_challenge_prompt(out: ResolvedOutput):
     return None
 
 
+def _project_confirm_action(action: ConfirmAction) -> dict:
+    """Project one resolved `ConfirmAction` (a confirm `on:` entry / `default:`).
+
+    `output` is kept as a raw string (not `splitlines()`), matching the sibling
+    challenge body `failure_output` in `project_resolved` — the `_project_output`
+    list form is for the separate `ResolvedOutput` channel (1st round gemini#1
+    declined).
+    """
+    return {"new_mode": action.new_mode, "exit": action.exit, "output": action.output}
+
+
 def project_resolved(commands: dict[str, ResolvedCommand]) -> dict[str, dict]:
     """Project resolved commands into a JSON-serializable comparison shape."""
     projection: dict[str, dict] = {}
@@ -122,13 +133,3 @@ def project_resolved(commands: dict[str, ResolvedCommand]) -> dict[str, dict]:
                 entry["default"] = _project_confirm_action(ch.default) if ch.default is not None else None
             projection[name]["challenge"] = entry
     return projection
-
-
-def _project_confirm_action(action: ConfirmAction) -> dict:
-    """Project one resolved `ConfirmAction` (a confirm `on:` entry / `default:`).
-
-    `output` is kept as a raw string (not `splitlines()`), matching the sibling
-    challenge body `failure_output` above — the `_project_output` list form is for
-    the separate `ResolvedOutput` channel (1st round gemini#1 declined).
-    """
-    return {"new_mode": action.new_mode, "exit": action.exit, "output": action.output}


### PR DESCRIPTION
🐙claude:

## 概要

#338 (challenge 機構、Phase 1-3 で v3 merge 済 = PR #339/#340/#341) を **3 Phase 通して俯瞰**したリファクタリング。振る舞い不変・golden/oracle 無変更。

各 Phase は既に pre-review-refactor + cross-review + final-refactor を通過済みで単体はクリーンだが、「3 Phase を並べて初めて見える」cross-phase drift を 2 件解消する。

## 変更

### 1. `complete_challenge` の transition 適用を DRY (`simnos/plugins/shell/cmd_shell.py`)

password / confirm の 2 分岐が同一形状の `exit→close / new_mode→apply` を重複していた (Phase 1 が password 版を書き、Phase 3 が confirm 版に複製した cross-phase 重複)。`Transition` と `ConfirmAction` は共に load-validated な `exit: bool` + `new_mode: str | None` を持つので、`_apply_challenge_transition(action) -> bool` helper に集約。1 か所で扱うことで今後の分岐 drift を防ぐ。

### 2. oracle helper の配置整合 (`tests/core/oracle_projection.py`)

`_project_confirm_action` (Phase 3 で末尾追加) を、兄弟 helper `_project_output` / `_project_challenge_prompt` と揃えて `project_resolved` の**前**へ移動 (helper-before-consumer の既存パターンに整合)。docstring の "above" 参照も是正。

## 検証

- `ruff check` (plain) / `ruff format` clean
- `ty check` (exclude=[]) → All checks passed
- `pytest -n auto` → **1200 passed, 9 skipped** (PR #341 baseline と同一 = 振る舞い不変)

🤖 Generated with [Claude Code](https://claude.com/claude-code)