### PR TITLE
refactor: v3 コードベース俯瞰クリーンアップ — dead code / DRY / stale コメント整理

### DIFF
--- a/simnos/core/nos.py
+++ b/simnos/core/nos.py
@@ -262,7 +262,7 @@ class Nos:
         # `auth` has live behavior (ssh_server allows auth-none when nos.auth ==
         # "none"); wire it from the A3 meta so it is not a silent dead field
         # (1st round claude #2). Other meta (netmiko_device_type / ntc_platform)
-        # stay unconsumed placeholders until #266.
+        # is consumed by the platform registry (#266), not here.
         self.auth = self.resolved_platform.auth
 
     def from_file(self, filename: str) -> None:

--- a/simnos/core/overlay_loader.py
+++ b/simnos/core/overlay_loader.py
@@ -36,6 +36,7 @@ import os
 
 from simnos.core.platform_loader import _resolve_output_file
 from simnos.core.resolved_command import ResolvedCommand, ResolvedOutput, ResolvedPlatform
+from simnos.core.utils import _is_unsafe_bare_ref
 
 log = logging.getLogger(__name__)
 
@@ -161,7 +162,7 @@ def _validate_overlay_ref(ref: str, *, where: str) -> None:
     the same invariant here: a bare filename, no separators / ``..``, not absolute,
     ``.txt`` / ``.j2`` only (design Decision 10c).
     """
-    if not ref or ref != os.path.basename(ref) or ref in (".", "..") or os.path.isabs(ref):
+    if _is_unsafe_bare_ref(ref):
         raise ValueError(f"{where}: overlay file reference {ref!r} must be a bare filename in the overlay directory")
     if not ref.endswith(_ALLOWED_EXTS):
         raise ValueError(f"{where}: overlay file {ref!r} must end with .txt or .j2")

--- a/simnos/core/platform_loader.py
+++ b/simnos/core/platform_loader.py
@@ -147,8 +147,7 @@ def _resolve_commands(
         if model.alias is not None:
             target = _follow_alias(name, authored, resolved)
             # An alias carries the target's dispatch fields but keeps its own
-            # help (usually blank) — same as the legacy adapter and v2 do_help
-            # (#264 / D6, Decision 6).
+            # help (usually blank) (#264 / D6, Decision 6).
             aliased = replace(target, name=model.command, help=model.help or "")
             # A `mode:` override lets an alias run in a different mode set than
             # its target (e.g. arista `do show ip int brief`: target is

--- a/simnos/core/pydantic_models.py
+++ b/simnos/core/pydantic_models.py
@@ -488,7 +488,8 @@ class ModelPlatformMeta(BaseModel):
     mode names only (M2). No `name` field — the platform name is the directory
     name (D1). `netmiko_device_type` / `ntc_platform` are consumed by the platform
     registry (#266) as device-type aliases that resolve to this platform (see
-    `simnos.plugins.nos.register`). `paging` is the optional P3-4 pager settings
+    `simnos.plugins.nos._build_device_type_index`). `paging` is the optional P3-4
+    pager settings
     (#307); omitted = the Cisco-style default `--More--` prompt.
     """
 

--- a/simnos/core/pydantic_models.py
+++ b/simnos/core/pydantic_models.py
@@ -3,7 +3,6 @@ File to contain pydantic models for plugins input/output data validation
 """
 
 import keyword
-import os
 from typing import Annotated, Literal
 
 from pydantic import (
@@ -17,6 +16,8 @@ from pydantic import (
     field_validator,
     model_validator,
 )
+
+from simnos.core.utils import _is_unsafe_bare_ref
 
 # Valid TCP port. Restores the range constraint lost in the pydantic v1 -> v2
 # migration (v1 used `conint(strict=True, gt=0, le=65535)`); #237 / #199 C-15.
@@ -51,7 +52,7 @@ def _reject_unsafe_output_ref(value: str | None) -> str | None:
     """
     if value is None:
         return value
-    if value != os.path.basename(value) or value in ("", ".", "..") or os.path.isabs(value):
+    if _is_unsafe_bare_ref(value):
         raise ValueError(f"output reference {value!r} must be a bare filename in the command's own directory")
     return value
 
@@ -485,8 +486,9 @@ class ModelPlatformMeta(BaseModel):
 
     Modes are declared centrally (name -> prompt template); commands reference
     mode names only (M2). No `name` field — the platform name is the directory
-    name (D1). `netmiko_device_type` / `ntc_platform` are data placeholders the
-    consumer side wires up in #266. `paging` is the optional P3-4 pager settings
+    name (D1). `netmiko_device_type` / `ntc_platform` are consumed by the platform
+    registry (#266) as device-type aliases that resolve to this platform (see
+    `simnos.plugins.nos.register`). `paging` is the optional P3-4 pager settings
     (#307); omitted = the Cisco-style default `--More--` prompt.
     """
 

--- a/simnos/core/resolved_command.py
+++ b/simnos/core/resolved_command.py
@@ -25,9 +25,10 @@ if TYPE_CHECKING:
     from simnos.core.command_contract import CommandHandler
 
 # The single known render variable. Extracted template variables minus this
-# set become `ResolvedOutput.required_vars` — the host-facts to check at
-# start time (#265). `base_prompt` is always supplied by the shell, so it is
-# never a "missing var" (#264 / D4, 2nd round gemini #4).
+# set become `ResolvedOutput.required_vars` — the host-facts the build-time gate
+# (`values_loader.validate_render_values`, #287) checks at start. `base_prompt`
+# is always supplied by the shell, so it is never a "missing var" (#264 / D4,
+# 2nd round gemini #4).
 KNOWN_RENDER_VARS: frozenset[str] = frozenset({"base_prompt"})
 
 # The render variables a challenge prompt (#338) may reference. A superset of
@@ -73,9 +74,9 @@ def compile_template(jinja_source: str) -> tuple[Template, frozenset[str]]:
     """Compile jinja2 source and extract its non-`base_prompt` variables.
 
     The extracted variables (minus `KNOWN_RENDER_VARS`) are the host-facts a
-    later render needs; PR-1 only carries them on `ResolvedOutput` for #265
-    to consume — it does not check them against a host context yet
-    (#264 / Decision 7).
+    later render needs; they are carried on `ResolvedOutput.required_vars` and the
+    build-time gate (`values_loader.validate_render_values`, #287) rejects any a
+    host/sidecar cannot supply (#264 / Decision 7).
     """
     required = jinja_meta.find_undeclared_variables(_TEMPLATE_ENV.parse(jinja_source))
     return _TEMPLATE_ENV.from_string(jinja_source), frozenset(required) - KNOWN_RENDER_VARS
@@ -103,7 +104,7 @@ class ResolvedOutput:
     - ``none``: the command writes nothing (`text`/`template`/`handler` all None).
     - ``literal``: `text` is the verbatim wire body (no render step).
     - ``template``: `template` is a compiled jinja2 template rendered with
-      ``base_prompt`` (+ host facts in #265).
+      ``base_prompt`` (+ sidecar-json facts, #287).
     - ``handler``: `handler` is a callable producing the body at dispatch time.
     """
 

--- a/simnos/core/simnos.py
+++ b/simnos/core/simnos.py
@@ -100,10 +100,9 @@ class SimNOS:
     ) -> None:
         # deepcopy the module-global fallback: `_load_inventory` reassigns
         # `self.inventory["default"]` (and `_seed_inventory_default_from_sys_config`
-        # seeds sys_config into it), so
-        # aliasing the global would bake per-instance state into it and leak to
-        # later `SimNOS()` calls (1st round codex#1). An explicit `inventory` is
-        # the caller's own object and left untouched.
+        # seeds sys_config into it), so aliasing the global would bake per-instance
+        # state into it and leak to later `SimNOS()` calls (1st round codex#1). An
+        # explicit `inventory` is the caller's own object and left untouched.
         self.inventory: dict | str = inventory or copy.deepcopy(default_inventory)
         self.plugins: list = plugins or []
 

--- a/simnos/core/simnos.py
+++ b/simnos/core/simnos.py
@@ -99,7 +99,8 @@ class SimNOS:
         sys_config: dict | str | None = None,
     ) -> None:
         # deepcopy the module-global fallback: `_load_inventory` reassigns
-        # `self.inventory["default"]` (and PR2 seeds sys_config into it), so
+        # `self.inventory["default"]` (and `_seed_inventory_default_from_sys_config`
+        # seeds sys_config into it), so
         # aliasing the global would bake per-instance state into it and leak to
         # later `SimNOS()` calls (1st round codex#1). An explicit `inventory` is
         # the caller's own object and left untouched.

--- a/simnos/core/utils.py
+++ b/simnos/core/utils.py
@@ -1,6 +1,20 @@
 """Utility helpers for SimNOS core."""
 
+import os
 from pathlib import Path
+
+
+def _is_unsafe_bare_ref(ref: str) -> bool:
+    """Whether ``ref`` escapes its own directory (the root-confinement invariant).
+
+    A safe reference is a bare filename adjacent to its owner: not empty, not
+    ``.`` / ``..``, no path separators, not absolute. Shared by the A3 authoring
+    schema (`pydantic_models._reject_unsafe_output_ref`) and the overlay loader
+    (`overlay_loader._validate_overlay_ref`) so the one path-traversal defense has
+    a single definition; each caller keeps its own error message (and the overlay
+    its extra ``.txt`` / ``.j2`` extension rule).
+    """
+    return not ref or ref in (".", "..") or ref != os.path.basename(ref) or os.path.isabs(ref)
 
 
 def _is_in_docker() -> bool:

--- a/simnos/plugins/servers/async_server_base.py
+++ b/simnos/plugins/servers/async_server_base.py
@@ -113,7 +113,8 @@ class AsyncServerBase:
         self.port: int = port
         # timeout / watchdog_interval are inert on the async path (shutdown is
         # driven by closing the listener/sessions on the shared loop, not a recv
-        # poll); kept for sync-plugin signature + config parity.
+        # poll); kept for inventory config compatibility (the pydantic server
+        # models still accept them, #297 Stage 4).
         self.timeout: int = timeout
         self.watchdog_interval: float = watchdog_interval
         self._simnos = simnos

--- a/simnos/plugins/servers/tap_bridge.py
+++ b/simnos/plugins/servers/tap_bridge.py
@@ -15,13 +15,10 @@ formerly the standalone ``tap_io`` module's ``process_tap_line``, was folded in
 here at the same time).
 """
 
-import logging
 from typing import TYPE_CHECKING, Protocol
 
 if TYPE_CHECKING:
     from simnos.plugins.shell.cmd_shell import DispatchResult
-
-log = logging.getLogger(__name__)
 
 
 def _process_tap_line(line: str) -> str:

--- a/simnos/plugins/shell/cmd_shell.py
+++ b/simnos/plugins/shell/cmd_shell.py
@@ -680,7 +680,14 @@ class CMDShell:
                     continue
 
     def precmd(self, line):
-        """Method to return line before processing the command"""
+        """Poll for hot-reloaded plugin files, then return the line unchanged.
+
+        Runs before each dispatched line (kept from the cmd.Cmd hook name for
+        familiarity, though the base is gone since #303 P3-3). Its real job is the
+        hot-reload check: in dev mode it diffs this shell's watch roots and
+        reloads any changed platform/py targets before the command runs. The line
+        itself is passed through untouched.
+        """
         # Two-part gate (#281, 1st code review gemini#1/claude#2): the env var
         # keeps the current "env off mid-session stops reloading" semantics, and
         # `_package_root is not None` proves `__init__` actually seeded the watcher
@@ -699,7 +706,13 @@ class CMDShell:
         return line
 
     def postcmd(self, stop, line):
-        """Method to return stop value to stop the shell"""
+        """Return the close flag after a dispatched line (an override seam).
+
+        A pure pass-through today (kept from the cmd.Cmd hook name, base gone
+        since #303 P3-3): `dispatch` calls it with the post-dispatch close flag and
+        the line as typed, so a future subclass can veto/force close per line
+        without touching the dispatch core. No in-tree override exists yet.
+        """
         return stop
 
     def _in_current_mode(self, cmd: ResolvedCommand) -> bool:


### PR DESCRIPTION
🐙claude:

## 概要

v3 全 production コード (~7,700 行) を 4 サブシステム並列監査し、洗い出した**安全・高確度**の refactoring 機会を実施。振る舞い不変・golden/oracle 無変更 (byte-parity 含む 1200 passed)。

各ファイルは既に heavy review 済で単体はクリーンだが、「コードベース全体を並べて初めて見える」dead code / 重複 / stale コメントを潰した。

## 変更

### DRY
- path-traversal の root-confinement 述語を `utils._is_unsafe_bare_ref` に集約。`pydantic_models._reject_unsafe_output_ref` と `overlay_loader._validate_overlay_ref` が同一 invariant を二重実装していたのを 1 定義へ (各サイトの error message は温存、overlay の `.txt`/`.j2` 拡張子チェックは局所維持)。security invariant の単一ソース化 + `pydantic_models` の未使用 `import os` 除去。

### dead code
- `tap_bridge` の未使用 `log` / `import logging` 除去 (旧 sync tap 経路の残骸)。

### stale コメント / docstring 是正
- `cmd_shell` `precmd` / `postcmd` の cmd.Cmd 時代 stub docstring → 実責務 (hot-reload ポーリング / close override seam) に書換え。
- `resolved_command` の `#265` "まだ consume しない" 注記 3 箇所 → `#287` (build-time gate `validate_render_values` は既に存在) に retag。
- `pydantic_models` / `nos` の `netmiko_device_type`/`ntc_platform` "#266 で wire する placeholder" → 現在 registry が consume 済の現在形へ。
- `platform_loader` alias-help の "same as the legacy adapter" (#317 P-4 で撤去済) 除去。
- `async_server_base` timeout/watchdog の "sync-plugin signature" (sync plugin 消滅) 是正。
- `simnos` の内部スプリント略号 "PR2" → 実メソッド名 `_seed_inventory_default_from_sys_config`。

## 意図的に見送った項目 (follow-up 候補)

1. **ESC state-machine の DRY** (`async_session` メインループ vs `_read_challenge_line`) — 実在する ~15 行の重複だが **byte-parity wire path クリティカル**。broad sweep に混ぜず、専用変更 + golden 検証で独立に扱うべき (defer 理由 = wire-parity 隔離)。
2. **`_allocate_port` の dead `list[int]` 分岐** — 常に単一 int で到達不能だが test patch seam に依存する needs-care、効果小。

## 検証

- `invoke ruff` (check + format) / `invoke yamllint` / `invoke ty` (exclude=[]) → 全 green
- `pytest -n auto` (integration 含む) → **1200 passed, 9 skipped** (baseline 同一)

🤖 Generated with [Claude Code](https://claude.com/claude-code)