### PR TITLE
fix: CI lint gate 盲目化解消 + 入力検証 loud-failure 一括是正 (#344, #345)

### DIFF
--- a/simnos/core/host.py
+++ b/simnos/core/host.py
@@ -77,6 +77,15 @@ class Host:
         self.secret: str | None = secret
         self.port: int = port
         self.simnos = simnos  # SimNOS object
+        # The schema allows `configuration` to be omitted or null on all three
+        # plugin sections, and a host-authored `shell:`/`server:` replaces the
+        # default's whole dict in the shallow `{**default, **host}` merge — so a
+        # schema-valid inventory used to reach the `["configuration"]` accesses
+        # below / in `start()` / in the CLI and die with a raw KeyError (#345).
+        # Normalize once here so downstream can assume a dict.
+        for section in (self.server_inventory, self.shell_inventory, self.nos_inventory):
+            if section.get("configuration") is None:
+                section["configuration"] = {}
         self.shell_inventory["configuration"].setdefault("base_prompt", self.name)
         self.running = False
         self.server = None
@@ -130,6 +139,17 @@ class Host:
         # (e.g. a runtime-registered custom plugin) falls through unchanged.
         plugin_key = resolve_device_type(self.nos_inventory["plugin"]) or self.nos_inventory["plugin"]
         self.nos_plugin = self.simnos.nos_plugins.get(plugin_key, plugin_key)
+        if isinstance(self.nos_plugin, Nos) and self.configuration_file:
+            # A pre-registered Nos instance is reused as-is, so this host's
+            # `configuration_file` never reaches it — warn instead of silently
+            # dropping the setting (anti-silent-bug, same policy as
+            # `_warn_reserved_fields`; #345).
+            log.warning(
+                "Host %s: configuration_file %r is ignored because the nos plugin resolves to a "
+                "pre-registered Nos instance (its device was built from the registrant's configuration).",
+                self.name,
+                self.configuration_file,
+            )
         self.nos = (
             Nos(filename=self.nos_plugin, configuration_file=self.configuration_file)
             if not isinstance(self.nos_plugin, Nos)
@@ -151,7 +171,7 @@ class Host:
             shell=self.shell_plugin,
             shell_configuration=self.shell_inventory["configuration"],
             nos=self.nos,
-            nos_inventory_config=self.nos_inventory.get("configuration", {}),
+            nos_inventory_config=self.nos_inventory["configuration"],
             port=self.port,
             username=self.username,
             password=self.password,

--- a/simnos/core/simnos.py
+++ b/simnos/core/simnos.py
@@ -103,7 +103,10 @@ class SimNOS:
         # seeds sys_config into it), so aliasing the global would bake per-instance
         # state into it and leak to later `SimNOS()` calls (1st round codex#1). An
         # explicit `inventory` is the caller's own object and left untouched.
-        self.inventory: dict | str = inventory or copy.deepcopy(default_inventory)
+        # `is None` (not falsy): an explicit `inventory={}` must reach the schema
+        # and fail loudly on the missing `hosts`, not silently become the 3-host
+        # default environment (#345).
+        self.inventory: dict | str = copy.deepcopy(default_inventory) if inventory is None else inventory
         self.plugins: list = plugins or []
 
         self.hosts: dict[str, Host] = {}
@@ -170,8 +173,13 @@ class SimNOS:
         raw = self._discover_sys_config(sys_config)
         resolved = ModelSysConfig(**raw).model_dump()
         # env > sys_config file (Decision 7): SIMNOS_DATA_DIR overrides the file.
+        # Set-but-empty is loud, matching the SIMNOS_SYS_CONFIG contract (#267 /
+        # #345) — an empty override would otherwise be silently ignored.
         env_data_dir = os.environ.get("SIMNOS_DATA_DIR")
-        if env_data_dir:
+        if env_data_dir is not None:
+            env_data_dir = env_data_dir.strip()
+            if not env_data_dir:
+                raise ValueError("SIMNOS_DATA_DIR is set but empty; unset it or provide a path")
             resolved["data_dir"] = env_data_dir
         self.sys_config: dict = resolved
 
@@ -305,6 +313,12 @@ class SimNOS:
         if replicas is None:
             if isinstance(port, list):
                 raise ValueError("If replicas is not set, port must be an integer.")
+            if not isinstance(port, int):
+                # An explicit `port: null` overrides the default's 0 in the
+                # per-host merge and passes the schema (port is Optional there);
+                # reject it here instead of dying later on the narrowing assert
+                # in `_get_hosts_and_ports` (#345).
+                raise ValueError(f"port must be an integer (0 = ephemeral), got {port!r}.")
             return  # port is int, no further check needed
         if replicas < 1:
             raise ValueError("If replicas is set, replicas must be greater than 0.")
@@ -368,6 +382,11 @@ class SimNOS:
         :param port: port to allocate
         :param params: parameters to pass to the host like configurations
         """
+        if host in self.hosts:
+            # Replica-generated names (`f"{name}{i}"`) can collide with an
+            # explicit host; without this guard the later instantiation silently
+            # replaced the earlier one and a configured host never started (#345).
+            raise ValueError(f"Duplicate host name '{host}' (a replicas-generated name collides with another host).")
         self._allocate_port(port)
         self.hosts[host] = Host(name=host, port=port, simnos=self, **params)
 
@@ -419,7 +438,10 @@ class SimNOS:
         :param hosts: string or list of strings
         :return: list of Host objects
         """
-        if not hosts:
+        # `is None` (not falsy): an explicit empty list means "no hosts" — a
+        # programmatic filter that matches nothing must not fan out to every
+        # host (#345). Only the omitted/None default selects all.
+        if hosts is None:
             hosts = list(self.hosts.keys())
         if isinstance(hosts, str):
             hosts = [hosts]

--- a/simnos/core/utils.py
+++ b/simnos/core/utils.py
@@ -3,6 +3,21 @@
 import os
 from pathlib import Path
 
+# Spellings a user plausibly means as "off" when setting an on/off env flag.
+_FALSY_ENV_VALUES = frozenset({"", "0", "false", "no", "off"})
+
+
+def env_flag_enabled(name: str) -> bool:
+    """Whether the on/off environment flag ``name`` is enabled.
+
+    Unset — or set to a falsy spelling (case-insensitive: empty, ``0``,
+    ``false``, ``no``, ``off``) — reads as disabled; any other value enables.
+    Plain truthiness checks treated ``SIMNOS_RELOAD_COMMANDS=0`` / ``=false``
+    as *enabled* (#345); this is the single interpretation every flag site
+    shares.
+    """
+    return os.environ.get(name, "").strip().lower() not in _FALSY_ENV_VALUES
+
 
 def _is_unsafe_bare_ref(ref: str) -> bool:
     """Whether ``ref`` escapes its own directory (the root-confinement invariant).

--- a/simnos/plugins/nos/__init__.py
+++ b/simnos/plugins/nos/__init__.py
@@ -63,7 +63,7 @@ platforms_directory_py: str = os.path.join(current_directory, "platforms_py")
 py_files = glob.glob(os.path.join(platforms_directory_py, "*.py"))
 py_files = [file for file in py_files if os.path.basename(file) != "__init__.py"]
 for file in py_files:
-    platform_name: str = os.path.basename(file).replace(".py", "")
+    platform_name: str = os.path.basename(file).removesuffix(".py")
     if platform_name in nos_plugins:
         nos_plugins[platform_name].append(file)
     else:
@@ -167,7 +167,10 @@ def assert_platform_supported(platform: str) -> None:
         # registry container type (tuple vs list repr). Spell out that
         # netmiko/ntc aliases are accepted too, so a user who typed an alias
         # is not misled by the canonical-only list (#266 1st round gemini #4).
+        # Built from the live registry (not the import-time `available_platforms`
+        # tuple) so runtime-registered platforms appear, matching what
+        # `resolve_device_type` just checked against (#344).
         raise ValueError(
             f"Platform {platform} is not supported by SIMNOS. Supported platforms are: "
-            f"{', '.join(available_platforms)} (their netmiko_device_type / ntc_platform aliases are also accepted)."
+            f"{', '.join(sorted(nos_plugins))} (their netmiko_device_type / ntc_platform aliases are also accepted)."
         )

--- a/simnos/plugins/nos/platforms_py/_templates/base_template.py
+++ b/simnos/plugins/nos/platforms_py/_templates/base_template.py
@@ -45,8 +45,10 @@ class BaseDevice:
         """
         if not configuration_file:
             return {}
-        if not configuration_file.endswith((".yaml", ".j2")):
-            raise ValueError("Configuration file must be a YAML file or a Jinja2 template.")
+        # `.yml` accepted to match the inventory loader (#345); it takes the
+        # plain-YAML branch below.
+        if not configuration_file.endswith((".yaml", ".yml", ".j2")):
+            raise ValueError("Configuration file must be a YAML file (.yaml/.yml) or a Jinja2 template (.j2).")
         if configuration_file.endswith(".j2"):
             data: str = ""
             with open(configuration_file, encoding="utf-8") as file:

--- a/simnos/plugins/nos/platforms_py/huawei_smartax.py
+++ b/simnos/plugins/nos/platforms_py/huawei_smartax.py
@@ -52,7 +52,7 @@ class HuaweiSmartAX(BaseDevice):
             results = self._add_whitespaces([title, *board_column])
             board_column = results[1:]
             titles[index] = results[0]
-            for board in boards:
-                board[title] = board_column[boards.index(board)]
+            for board_index, board in enumerate(boards):
+                board[title] = board_column[board_index]
         rows = [list(board.values()) for board in boards]
         return self.render("huawei_smartax/display_board.j2", titles=titles, rows=rows)

--- a/simnos/plugins/shell/cmd_shell.py
+++ b/simnos/plugins/shell/cmd_shell.py
@@ -5,7 +5,6 @@ Custom shell class to interact with NOS.
 from dataclasses import dataclass, replace
 import hashlib
 import logging
-import os
 import random
 import string
 import threading
@@ -30,6 +29,7 @@ from simnos.core.resolved_command import (
     Transition,
     compile_template,
 )
+from simnos.core.utils import env_flag_enabled
 from simnos.core.values_loader import validate_render_values
 
 # `nos_pkg` is the package module (for `__path__`); the `__init__` arg `nos` is a
@@ -428,7 +428,7 @@ class CMDShell:
         self._watch_roots: list[str] = []
         self._reload_snapshot: dict[str, float] = {}
         self._package_root: str | None = None
-        if os.environ.get("SIMNOS_RELOAD_COMMANDS"):
+        if env_flag_enabled("SIMNOS_RELOAD_COMMANDS"):
             self._package_root = nos_pkg.__path__[0]  # rollup root; module ref avoids the `nos` arg shadowing (D5)
             self._watch_roots = platform_watch_roots(nos_plugins.get(self.nos.name, []))
             self._reload_snapshot = get_files_lasttime_changed(get_files_under_roots(self._watch_roots))
@@ -451,7 +451,7 @@ class CMDShell:
         edits propagate to new connections, so there is no shared snapshot (the
         per-shell `_render_config` carries the overlay through `_rebuild`).
         """
-        if os.environ.get("SIMNOS_RELOAD_COMMANDS"):
+        if env_flag_enabled("SIMNOS_RELOAD_COMMANDS"):
             return None
         return build_resolved_platform(nos, nos_inventory_config.get("commands", {}), render_config)
 
@@ -696,7 +696,7 @@ class CMDShell:
         # (no baseline seeded) or `python -O` degrades to a graceful no-op instead
         # of a `TypeError` deep in `resolve_reload_targets`. The diff runs against
         # this shell's own snapshot (per-shell, D1), then swaps in the returned one.
-        if os.environ.get("SIMNOS_RELOAD_COMMANDS") and self._package_root is not None:
+        if env_flag_enabled("SIMNOS_RELOAD_COMMANDS") and self._package_root is not None:
             reload_targets, self._reload_snapshot = get_files_changed(
                 self._watch_roots, self._package_root, self._reload_snapshot
             )

--- a/simnos/plugins/utils/cli.py
+++ b/simnos/plugins/utils/cli.py
@@ -180,7 +180,15 @@ def main(argv: list[str] | None = None) -> int:
     # .upper() 不要。force=True で main(argv) を同一 process から複数回呼ぶ test でも
     # level 変更が反映される。
     logging.basicConfig(level=args.log_level, force=True)
-    return args.func(args)
+    # argparse 以降の error boundary (#345): 設定/入力起因の想定内エラー (存在しない
+    # inventory path = OSError、schema/値エラー = ValueError [pydantic ValidationError
+    # 含む]、port 占有 = OSError) は raw traceback でなくメッセージ + exit 1 で返す。
+    # argparse の clean な exit 2 と対になる。traceback は -l DEBUG でのみ添付。
+    try:
+        return args.func(args)
+    except (ValueError, OSError) as exc:
+        log.error("%s", exc, exc_info=log.isEnabledFor(logging.DEBUG))
+        return 1
 
 
 def run_cli() -> None:  # pyproject entry point (name preserved)

--- a/tasks.py
+++ b/tasks.py
@@ -30,7 +30,11 @@ def run_cmd(context, exec_cmd):
 @task
 def ruff(context):
     """Run ruff to check that Python files adherence to ruff standards."""
-    run_cmd(context, "ruff check --diff")
+    # `ruff check --diff` only reports violations that HAVE an autofix (exit 0 on
+    # e.g. F821/S/B/PERF hits), which silently blinded the CI gate to most of the
+    # selected rule set (#344); the plain `check` reports everything. `format
+    # --diff` is a real format check and stays.
+    run_cmd(context, "ruff check")
     run_cmd(context, "ruff format --diff")
 
 
@@ -506,12 +510,15 @@ _PRESERVED_PLATFORM_DOCS: frozenset[str] = frozenset({"index.md", "index.ja.md"}
 NAV_DISPLAY_NAME_OVERRIDES: dict[str, str] = {
     "alcatel_aos": "Alcatel AOS",
     "alcatel_sros": "Alcatel SROS",
+    "allied_telesis_awplus": "Allied Telesis AW+",
     "arista_eos": "Arista EOS",
     "aruba_aoscx": "Aruba AOS-CX",
     "aruba_os": "Aruba OS",
     "avaya_ers": "Avaya ERS",
     "avaya_vsp": "Avaya VSP",
     "broadcom_icos": "Broadcom ICOS",
+    "brocade_fastiron": "Brocade FastIron",
+    "checkpoint_gaia": "Check Point Gaia",
     "ciena_saos": "Ciena SAOS",
     "cisco_apic": "Cisco APIC",
     "cisco_asa": "Cisco ASA",
@@ -536,6 +543,7 @@ NAV_DISPLAY_NAME_OVERRIDES: dict[str, str] = {
     "mikrotik_routeros": "Mikrotik RouterOS",
     "oneaccess_oneos": "OneAccess OneOS",
     "paloalto_panos": "PaloAlto PanOS",
+    "ruckus_fastiron": "Ruckus FastIron",
     "ubiquiti_edgerouter": "Ubiquiti EdgeRouter",
     "ubiquiti_edgeswitch": "Ubiquiti EdgeSwitch",
     "vyatta_vyos": "Vyatta VyOS",
@@ -678,32 +686,36 @@ def netmiko_check(ctx, device_type: str):
     from simnos import SimNOS
 
     init_time = time.time()
+    # Ephemeral port (0) + read-back after start, same as the default inventory
+    # (#271): a fixed 6000 collided with a running `simnos up` / parallel
+    # invocations and died with a raw bind traceback (#344).
     inventory = {
         "hosts": {
             "host1": {
                 "username": "user",
                 "password": "user",
                 "device_type": device_type,
-                "port": 6000,
+                "port": 0,
             }
         }
     }
 
-    credentials = {
-        "host": "localhost",
-        "username": "user",
-        "password": "user",
-        "port": 6000,
-        "device_type": device_type,
-    }
-
     net = SimNOS(inventory=inventory)
+    # try/finally so a Netmiko failure still stops the server (#344); before, a
+    # raise skipped `net.stop()` and left the host running.
     net.start()
-
-    with ConnectHandler(**credentials):
-        time.sleep(1)
-
-    net.stop()
+    try:
+        credentials = {
+            "host": "localhost",
+            "username": "user",
+            "password": "user",
+            "port": net.hosts["host1"].port,
+            "device_type": device_type,
+        }
+        with ConnectHandler(**credentials):
+            time.sleep(1)
+    finally:
+        net.stop()
 
     print("Everything is OK! ✅")
     print(f"Time spent: {time.time() - init_time:.2f}s")

--- a/tests/core/test_host.py
+++ b/tests/core/test_host.py
@@ -3,13 +3,15 @@ Test module for the module simnos.core.host
 under simnos/core/host.py
 """
 
+import logging
 from unittest.mock import MagicMock, Mock, patch
 
 import pytest
 
 from simnos import SimNOS
 from simnos.core.host import Host
-from simnos.core.nos import available_platforms
+from simnos.core.nos import Nos, available_platforms
+from tests.utils import SYNTHETIC_CUSTOM_A3_DIR
 
 
 class TestHost:
@@ -219,6 +221,60 @@ class TestHost:
         platform = available_platforms[0]
         # pylint: disable=protected-access
         host._check_if_platform_is_supported(platform)
+
+
+class TestConfigurationNormalization:
+    """Schema-valid plugin sections without `configuration` must not KeyError (#345).
+
+    The schema allows `configuration` to be omitted or null on all three plugin
+    sections, and a host-authored `shell:`/`server:` replaces the default's whole
+    dict in the shallow merge — so these inventories passed validation and then
+    died with a raw KeyError (shell at `Host.__init__`, server at `Host.start`).
+    """
+
+    def test_shell_without_configuration_constructs(self):
+        """`shell: {plugin: CMDShell}` (no configuration key) builds the host."""
+        inventory = {"hosts": {"r1": {"device_type": "cisco_ios", "port": 0, "shell": {"plugin": "CMDShell"}}}}
+        net = SimNOS(inventory=inventory)
+        assert net.hosts["r1"].shell_inventory["configuration"]["base_prompt"] == "r1"
+
+    def test_server_with_null_configuration_normalized(self):
+        """`server: {plugin: AsyncSshServer, configuration: null}` normalizes to {}."""
+        inventory = {
+            "hosts": {
+                "r1": {
+                    "device_type": "cisco_ios",
+                    "port": 0,
+                    "server": {"plugin": "AsyncSshServer", "configuration": None},
+                }
+            }
+        }
+        net = SimNOS(inventory=inventory)
+        assert net.hosts["r1"].server_inventory["configuration"] == {}
+
+
+class TestConfigurationFileIgnoredWarning:
+    """A host whose nos plugin resolves to a pre-registered Nos instance warns
+    when `configuration_file` is set (set-but-inert, anti-silent-bug; #345)."""
+
+    def test_registered_nos_with_configuration_file_warns(self, caplog):
+        server = {"plugin": "server_plugin", "configuration": {}}
+        shell = {"plugin": "shell_plugin", "configuration": {}}
+        nos = {"plugin": "nos_plugin", "configuration": {}}
+        net = Mock()
+        server_plugin = Mock()
+        server_plugin.return_value.port = 22
+        net.servers_plugins = {"server_plugin": server_plugin}
+        net.shell_plugins = {"shell_plugin": Mock()}
+        # The registry value is a real (registered) Nos instance, so `start()`
+        # reuses it as-is and the host's configuration_file never reaches it.
+        net.nos_plugins = {"nos_plugin": Nos(filename=SYNTHETIC_CUSTOM_A3_DIR)}
+        with patch.object(Host, "_check_if_platform_is_supported", return_value=None):
+            host = Host("name", "username", "password", 22, server, shell, nos, net, configuration_file="ignored.yaml")
+        with caplog.at_level(logging.WARNING):
+            host.start()
+        host.stop()
+        assert "configuration_file 'ignored.yaml' is ignored" in caplog.text
 
 
 class TestResolveOverlayRoot:

--- a/tests/core/test_simnos.py
+++ b/tests/core/test_simnos.py
@@ -83,6 +83,11 @@ _REPLICAS_REJECT_CASES = [
         r"port range must be equal to the number of replicas",
         id="len_mismatch",
     ),
+    pytest.param(
+        {"default": {"port": 5000}, "hosts": {"R1": {"port": None}}},
+        r"port must be an integer \(0 = ephemeral\)",
+        id="port_explicit_null",
+    ),
 ]
 
 
@@ -339,6 +344,50 @@ class TestSimNOS:
         """
         with pytest.raises(ValueError, match=match):
             SimNOS(inventory=inventory)
+
+    def test_inventory_empty_dict_is_loud(self):
+        """An explicit `inventory={}` fails on the missing `hosts`, loudly (#345).
+
+        The old `inventory or deepcopy(default)` falsy check silently swapped an
+        empty dict for the 3-host default environment.
+        """
+        with pytest.raises(ValueError, match="hosts"):
+            SimNOS(inventory={})
+
+    def test_get_hosts_as_list_empty_means_none(self):
+        """An explicit empty host list selects NO hosts; only None selects all (#345).
+
+        The old falsy check expanded `hosts=[]` (e.g. a programmatic filter that
+        matched nothing) to every host, so `stop([])` stopped the whole environment.
+        """
+        net = SimNOS()
+        assert net._get_hosts_as_list([]) == []
+        assert len(net._get_hosts_as_list(None)) == len(net.hosts)
+
+    def test_duplicate_host_name_from_replicas_is_loud(self):
+        """A replicas-generated name colliding with an explicit host raises (#345).
+
+        `r` with `replicas: 2` generates `r0`/`r1`; without the guard the later
+        instantiation silently replaced the explicit `r0` in `self.hosts` and one
+        configured host never started.
+        """
+        inventory = {
+            "hosts": {
+                "r0": {"port": 5100},
+                "r": {"replicas": 2, "port": [5000, 5001]},
+            }
+        }
+        with pytest.raises(ValueError, match=r"Duplicate host name 'r0'"):
+            SimNOS(inventory=inventory)
+
+    def test_env_data_dir_empty_is_loud(self, monkeypatch):
+        """A set-but-empty SIMNOS_DATA_DIR raises, matching SIMNOS_SYS_CONFIG (#345).
+
+        The old `if env_data_dir:` truthiness silently ignored an empty override.
+        """
+        monkeypatch.setenv("SIMNOS_DATA_DIR", "  ")
+        with pytest.raises(ValueError, match="SIMNOS_DATA_DIR is set but empty"):
+            SimNOS(inventory={"hosts": {}})
 
     def test_wrong_plugin_name(self):
         """

--- a/tests/core/test_utils.py
+++ b/tests/core/test_utils.py
@@ -2,7 +2,33 @@
 
 from unittest.mock import MagicMock, patch
 
-from simnos.core.utils import _is_in_docker
+import pytest
+
+from simnos.core.utils import _is_in_docker, env_flag_enabled
+
+
+class TestEnvFlagEnabled:
+    """Pins the single on/off interpretation shared by env-flag sites (#345).
+
+    The regression class: plain truthiness checks treated
+    ``SIMNOS_RELOAD_COMMANDS=0`` / ``=false`` as *enabled*.
+    """
+
+    _FLAG = "SIMNOS_TEST_FLAG"
+
+    def test_unset_is_disabled(self, monkeypatch):
+        monkeypatch.delenv(self._FLAG, raising=False)
+        assert env_flag_enabled(self._FLAG) is False
+
+    @pytest.mark.parametrize("value", ["", "0", "false", "FALSE", "no", "off", "OFF", " off "])
+    def test_falsy_spellings_are_disabled(self, monkeypatch, value):
+        monkeypatch.setenv(self._FLAG, value)
+        assert env_flag_enabled(self._FLAG) is False
+
+    @pytest.mark.parametrize("value", ["1", "ON", "true", "yes", " 1 "])
+    def test_other_values_are_enabled(self, monkeypatch, value):
+        monkeypatch.setenv(self._FLAG, value)
+        assert env_flag_enabled(self._FLAG) is True
 
 
 class TestIsInDocker:

--- a/tests/plugins/nos/test_base_template.py
+++ b/tests/plugins/nos/test_base_template.py
@@ -33,6 +33,14 @@ class TestLoadConfigurations:
         """No configuration file at all means an empty dict (existing contract)."""
         assert BaseDevice(configuration_file=None).configurations == {}
 
+    def test_yml_suffix_accepted(self):
+        """`.yml` loads on the plain-YAML branch, matching the inventory loader (#345).
+
+        The suffix gate used to accept only `.yaml`/`.j2`, so a `.yml` file the
+        inventory loader happily reads was rejected here.
+        """
+        assert self._load(".yml", "key: value\n") == {"key": "value"}
+
     def test_empty_yaml_normalized_to_empty_dict(self):
         """An empty yaml file means "no configuration", not None.
 

--- a/tests/plugins/utils/test_cli.py
+++ b/tests/plugins/utils/test_cli.py
@@ -371,3 +371,30 @@ class TestRunCli:
         with pytest.raises(SystemExit) as exc:
             cli.run_cli()
         assert exc.value.code == 0
+
+
+class TestMainErrorBoundary:
+    """`main()` turns expected config/user errors into message + exit 1 (#345).
+
+    Raw tracebacks for a missing inventory path / unknown device_type were
+    inconsistent with argparse's clean exit 2. Unexpected errors (RuntimeError)
+    must still propagate — the boundary catches ValueError/OSError only.
+    """
+
+    # Assertions read capsys stderr, not caplog: main()'s `basicConfig(force=True)`
+    # removes caplog's root handler, so the boundary's log.error only reaches the
+    # fresh stderr StreamHandler.
+
+    def test_missing_inventory_path_returns_1(self, tmp_path, _restore_root_logging, capsys):
+        missing = str(tmp_path / "nope.yaml")
+        assert cli.main(["up", "-i", missing]) == 1
+        assert "nope.yaml" in capsys.readouterr().err
+
+    def test_unknown_device_type_returns_1(self, _restore_root_logging, capsys):
+        assert cli.main(["up", "-d", "bogus_platform"]) == 1
+        assert "bogus_platform is not supported" in capsys.readouterr().err
+
+    def test_unexpected_error_still_propagates(self, monkeypatch, _restore_root_logging):
+        _patch_simnos(monkeypatch, ctor_exc=RuntimeError("unexpected"))
+        with pytest.raises(RuntimeError, match="unexpected"):
+            cli.main(["up", "-d", "cisco_ios"])


### PR DESCRIPTION
🐙claude: v3 全体監査 (2026-07-16) の設計不要 finding 2 束を 1 PR で消化する。対象 issue: #344 / #345 (どちらも scope 全項目を実装、merge 後に issue close 可 — v3→main 待ちにするかは従来運用に従い user 判断)。

## #344 — CI lint gate 盲目化解消 + tooling quick fixes

- **`invoke ruff` を `ruff check --diff` → `ruff check` に是正 (本命)**。`--diff` は autofix 可能な違反しか報告しない (F821 のみのファイルで exit 0 を実証)。選択ルールセットの大半 (F821 / S / B / PERF) が non-fixable のため CI では実質未執行だった。着手前に `ruff check` の潜在違反 0 件を確認済み。実装中、新 gate が本 PR 自身の I001 + F401 を即検出しており、gate が機能する実証になっている。
- `netmiko_check` task: 固定 port 6000 → ephemeral (0) + `net.hosts[...].port` 読み戻し、`ConnectHandler` を try/finally で包み失敗時も `net.stop()` 到達。
- `nos/__init__.py`: `.replace(".py", "")` → `removesuffix(".py")`、`assert_platform_supported` のエラーメッセージを live registry から生成 (runtime 登録 platform が一覧に出る)。
- `huawei_smartax.py`: padding loop の `boards.index(board)` → `enumerate` (O(n²) + 同値 row identity-fragile 解消)。
- `NAV_DISPLAY_NAME_OVERRIDES`: FastIron ×2 / AW+ / Check Point Gaia を追加 (docs 反映は次回 gen-docs 時)。

## #345 — 入力検証の loud-failure 漏れ一括是正 (9 項目)

| 項目 | Before → After |
|------|----------------|
| `shell:`/`server:` の configuration 欠落/null | schema 通過後 raw KeyError → `Host.__init__` で `{}` 正規化 |
| `SimNOS(inventory={})` | silent に 3-host default 化 → schema の hosts 欠落エラーで loud |
| `start([])` / `stop([])` | 全 host に作用 → 空 list は「対象なし」(None のみ全選択) |
| `port: null` | `_get_hosts_and_ports` の AssertionError 死 → `_check_ports_and_replicas` で loud 拒否 |
| replica 生成名と explicit host の衝突 | silent overwrite → `Duplicate host name` で loud 拒否 |
| `SIMNOS_RELOAD_COMMANDS=0/false` | **有効化**扱い → `env_flag_enabled` helper で統一解釈 (空/`0`/`false`/`no`/`off` = off) |
| 空 `SIMNOS_DATA_DIR` | silent 無視 → SYS_CONFIG と同じ loud-empty |
| CLI の想定内エラー | raw traceback → `main()` boundary で message + exit 1 (`-l DEBUG` で traceback、RuntimeError 等は propagate 維持) |
| 登録済 Nos 経路の `configuration_file` | silent 無視 → `log.warning` (set-but-inert の anti-silent 方針) |
| device `configuration_file` の `.yml` | 拒否 → 許容 (inventory loader と整合) |

## テスト

新規 13 test: 空 inventory / empty list / duplicate name / DATA_DIR 空 / `port: null` (reject cases param 追加) / configuration 正規化 ×2 / configuration_file warning / `env_flag_enabled` (falsy·truthy 綴り parametrize) / `.yml` 許容 / CLI boundary ×3 (RuntimeError propagate pin 含む)。

CLI boundary の assert は caplog でなく capsys: `main()` の `basicConfig(force=True)` が caplog の root handler を除去するため (テスト内コメントに明記)。

## 検証

- `invoke ruff` (新 strict gate) ✅ / `invoke yamllint` ✅ / `uv run ty check` ✅
- `pytest tests/ -n auto` → **1226 passed, 9 skipped** (wire/golden 非接触)
- 残 1 warning は `test_ephemeral_port.py` の asyncio GC unraisable — 本 PR 非接触ファイルで、単発 run では baseline/branch 両方不発の pre-existing flaky

## 備考

- #345 の configuration_file warning は #346 (registry ownership 設計) 確定時に raise 昇格を再検討する余地あり。
- cross-review なし (user 判断: 監査で検証済み finding の局所 fix 束のため、GitHub CI 通過を gate とする)。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
