### PR TITLE
fix: SimNOS インスタンス間の global 状態汚染を解消 — registry per-instance 化 + caller container 非破壊 (#346)

### DIFF
--- a/docs/changelog.ja.md
+++ b/docs/changelog.ja.md
@@ -63,7 +63,7 @@ golden で固定されています — コマンドを送って出力を読む�
 
 **バグ修正**
 
-- `SimNOS` インスタンス間 (およびインスタンス → 呼び出し元) の状態汚染を解消 (#346)。`SimNOS(plugins=[...])` の登録先が共有 module-global からプラットフォームレジストリの per-instance copy に変わり、インスタンス A で登録した custom plugin はインスタンス B から見えなくなりました — この漏れに依存していた場合は、利用する各 `SimNOS` の `plugins=[...]` に渡してください。また explicit な `inventory` dict (と `plugins` list) を in-place で書き換えなくなりました: SimNOS は自身の copy 上で動作する (inventory は deep copy、plugins list は container copy) ため、同じ inventory dict を異なる `sys_config` 設定のインスタンス間で使い回しても、最初のインスタンスが seed した `variants_policy` を silent に継承しません
+- `SimNOS` インスタンス間 (およびインスタンス → 呼び出し元) の状態汚染を解消 (#346)。`SimNOS(plugins=[...])` の登録先が共有 module-global からプラットフォームレジストリの per-instance copy に変わり、インスタンス A で登録した custom plugin はインスタンス B から見えなくなりました — この漏れに依存していた場合は、利用する各 `SimNOS` の `plugins=[...]` に渡してください。また explicit な `inventory` dict を in-place で書き換えなくなりました (`plugins` list も契約として同様に copy されます): SimNOS は自身の copy 上で動作する (inventory は deep copy、plugins list は container copy) ため、同じ inventory dict を異なる `sys_config` 設定のインスタンス間で使い回しても、最初のインスタンスが seed した `variants_policy` を silent に継承しません
 
 ## v2.3.1
 

--- a/docs/changelog.ja.md
+++ b/docs/changelog.ja.md
@@ -63,7 +63,7 @@ golden で固定されています — コマンドを送って出力を読む�
 
 **バグ修正**
 
-- `SimNOS` インスタンス間 (およびインスタンス → 呼び出し元) の状態汚染を解消 (#346)。`SimNOS(plugins=[...])` の登録先が共有 module-global からプラットフォームレジストリの per-instance copy に変わり、インスタンス A で登録した custom plugin はインスタンス B から見えなくなりました — この漏れに依存していた場合は、利用する各 `SimNOS` の `plugins=[...]` に渡してください。また explicit な `inventory` dict (と `plugins` list) を in-place で書き換えなくなりました: SimNOS は自身の deep copy 上で動作するため、同じ inventory dict を異なる `sys_config` 設定のインスタンス間で使い回しても、最初のインスタンスが seed した `variants_policy` を silent に継承しません
+- `SimNOS` インスタンス間 (およびインスタンス → 呼び出し元) の状態汚染を解消 (#346)。`SimNOS(plugins=[...])` の登録先が共有 module-global からプラットフォームレジストリの per-instance copy に変わり、インスタンス A で登録した custom plugin はインスタンス B から見えなくなりました — この漏れに依存していた場合は、利用する各 `SimNOS` の `plugins=[...]` に渡してください。また explicit な `inventory` dict (と `plugins` list) を in-place で書き換えなくなりました: SimNOS は自身の copy 上で動作する (inventory は deep copy、plugins list は container copy) ため、同じ inventory dict を異なる `sys_config` 設定のインスタンス間で使い回しても、最初のインスタンスが seed した `variants_policy` を silent に継承しません
 
 ## v2.3.1
 

--- a/docs/changelog.ja.md
+++ b/docs/changelog.ja.md
@@ -61,6 +61,10 @@ golden で固定されています — コマンドを送って出力を読む�
 - 長い出力向けにターミナルページング (`--More--`) を追加 (#307)。ページ高は PTY / Telnet NAWS の行数に従い (取得できなければ `sys_config.paging.default_rows`、既定 24 にフォールバック)、`terminal length 0` 系のコマンドはそのセッションのページングを無効化します (`disables_paging` データフラグ)。非対話クライアント (netmiko の `height=1000`、scraper) は byte-parity を保つ行数ゲートを通じてページャをバイパスします。`--More--` 文字列はプラットフォームデータです (`platform.yaml` の `paging.more_prompt`、Cisco 既定は `" --More-- "`)
 - コマンドの hot-reload ウォッチャ (`SIMNOS_RELOAD_COMMANDS`) を、per-shell スナップショット + プラットフォーム単位 watch にスコープし、共有 reload を host ロック下で直列化することで、並行セッションと競合しないようにしました (#281)
 
+**バグ修正**
+
+- `SimNOS` インスタンス間 (およびインスタンス → 呼び出し元) の状態汚染を解消 (#346)。`SimNOS(plugins=[...])` の登録先が共有 module-global からプラットフォームレジストリの per-instance copy に変わり、インスタンス A で登録した custom plugin はインスタンス B から見えなくなりました — この漏れに依存していた場合は、利用する各 `SimNOS` の `plugins=[...]` に渡してください。また explicit な `inventory` dict (と `plugins` list) を in-place で書き換えなくなりました: SimNOS は自身の deep copy 上で動作するため、同じ inventory dict を異なる `sys_config` 設定のインスタンス間で使い回しても、最初のインスタンスが seed した `variants_policy` を silent に継承しません
+
 ## v2.3.1
 
 **バグ修正**

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -64,7 +64,7 @@ automated tooling that only sends commands and reads output.
 
 **Bug Fixes**
 
-- Stop `SimNOS` instances from contaminating each other and their callers (#346). `SimNOS(plugins=[...])` registrations now land on a per-instance copy of the platform registry instead of a shared module-global, so a custom plugin registered on instance A is no longer visible from instance B — if you relied on that leak, pass the plugin to each `SimNOS(plugins=[...])` that uses it. An explicit `inventory` dict (and the `plugins` list) is also no longer mutated in place: SimNOS works on its own copies — a deep copy of the inventory, a container copy of the plugins list — so reusing one inventory dict across instances with different `sys_config` settings no longer silently inherits the first instance's seeded `variants_policy`
+- Stop `SimNOS` instances from contaminating each other and their callers (#346). `SimNOS(plugins=[...])` registrations now land on a per-instance copy of the platform registry instead of a shared module-global, so a custom plugin registered on instance A is no longer visible from instance B — if you relied on that leak, pass the plugin to each `SimNOS(plugins=[...])` that uses it. An explicit `inventory` dict is also no longer mutated in place (and the `plugins` list is likewise copied as a contract): SimNOS works on its own copies — a deep copy of the inventory, a container copy of the plugins list — so reusing one inventory dict across instances with different `sys_config` settings no longer silently inherits the first instance's seeded `variants_policy`
 
 ## v2.3.1
 

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -62,6 +62,10 @@ automated tooling that only sends commands and reads output.
 - Add terminal paging (`--More--`) for long command output (#307). The page height follows the PTY / Telnet NAWS rows (falling back to `sys_config.paging.default_rows`, default 24); a `terminal length 0`-class command disables paging for the session (the `disables_paging` data flag), and non-interactive clients (netmiko at `height=1000`, scrapers) bypass the pager through a line-count gate that preserves byte parity. The `--More--` string is platform data (`platform.yaml` `paging.more_prompt`, Cisco default `" --More-- "`)
 - Scope the command hot-reload watcher (`SIMNOS_RELOAD_COMMANDS`) to per-shell snapshots and per-platform watches, serialising a shared reload under the host lock so it no longer races concurrent sessions (#281)
 
+**Bug Fixes**
+
+- Stop `SimNOS` instances from contaminating each other and their callers (#346). `SimNOS(plugins=[...])` registrations now land on a per-instance copy of the platform registry instead of a shared module-global, so a custom plugin registered on instance A is no longer visible from instance B — if you relied on that leak, pass the plugin to each `SimNOS(plugins=[...])` that uses it. An explicit `inventory` dict (and the `plugins` list) is also no longer mutated in place: SimNOS works on its own deep copy, so reusing one inventory dict across instances with different `sys_config` settings no longer silently inherits the first instance's seeded `variants_policy`
+
 ## v2.3.1
 
 **Bug Fixes**

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -64,7 +64,7 @@ automated tooling that only sends commands and reads output.
 
 **Bug Fixes**
 
-- Stop `SimNOS` instances from contaminating each other and their callers (#346). `SimNOS(plugins=[...])` registrations now land on a per-instance copy of the platform registry instead of a shared module-global, so a custom plugin registered on instance A is no longer visible from instance B — if you relied on that leak, pass the plugin to each `SimNOS(plugins=[...])` that uses it. An explicit `inventory` dict (and the `plugins` list) is also no longer mutated in place: SimNOS works on its own deep copy, so reusing one inventory dict across instances with different `sys_config` settings no longer silently inherits the first instance's seeded `variants_policy`
+- Stop `SimNOS` instances from contaminating each other and their callers (#346). `SimNOS(plugins=[...])` registrations now land on a per-instance copy of the platform registry instead of a shared module-global, so a custom plugin registered on instance A is no longer visible from instance B — if you relied on that leak, pass the plugin to each `SimNOS(plugins=[...])` that uses it. An explicit `inventory` dict (and the `plugins` list) is also no longer mutated in place: SimNOS works on its own copies — a deep copy of the inventory, a container copy of the plugins list — so reusing one inventory dict across instances with different `sys_config` settings no longer silently inherits the first instance's seeded `variants_policy`
 
 ## v2.3.1
 

--- a/simnos/core/simnos.py
+++ b/simnos/core/simnos.py
@@ -74,13 +74,21 @@ class SimNOS:
 
     :param inventory: SimNOS inventory dictionary or
                       OS path to .yaml file with inventory data
-    :param plugins: Plugins to add extra devices/commands
-                    currently not supported easily.
+    :param plugins: NOS plugins to register on this instance: ready ``Nos``
+                    instances and/or str paths to A3 platform dirs
+                    (see ``_register_nos_plugins``).
     :param sys_config: SimNOS environment config (`sys_config.yaml`): a dict, an
                        OS path to a .yaml file, or None to auto-discover
                        (see ``_discover_sys_config``). Holds environment-wide
                        settings (data_dir, variants_policy); the inventory holds
                        topology (#266 / D4).
+
+    Ownership contract (#346): caller-passed containers — the inventory dict,
+    the sys_config dict, and the plugins list — are borrowed read-only during
+    ``__init__``; SimNOS works on its own copies and never mutates the caller's
+    objects. The one deliberate exception is a ``Nos`` *element* of the plugins
+    list: it is registered as-is and shared/reused for this instance's lifetime
+    (handing over a built instance is the feature's whole point).
 
     Sample usage:
 
@@ -95,25 +103,36 @@ class SimNOS:
     def __init__(
         self,
         inventory: dict | str | None = None,
-        plugins: list | None = None,
+        plugins: list[str | Nos] | None = None,
         sys_config: dict | str | None = None,
     ) -> None:
-        # deepcopy the module-global fallback: `_load_inventory` reassigns
-        # `self.inventory["default"]` (and `_seed_inventory_default_from_sys_config`
-        # seeds sys_config into it), so aliasing the global would bake per-instance
-        # state into it and leak to later `SimNOS()` calls (1st round codex#1). An
-        # explicit `inventory` is the caller's own object and left untouched.
-        # `is None` (not falsy): an explicit `inventory={}` must reach the schema
-        # and fail loudly on the missing `hosts`, not silently become the 3-host
-        # default environment (#345).
-        self.inventory: dict | str = copy.deepcopy(default_inventory) if inventory is None else inventory
-        self.plugins: list = plugins or []
+        # Work on our own copy (#346): aliasing the module-global fallback would
+        # accumulate per-instance state, and an explicit dict belongs to the
+        # caller — `_load_inventory` reassigns `self.inventory["default"]` (with
+        # sys_config seeded in), which must not be baked into the caller's object
+        # (reusing that dict for a second instance would silently inherit the
+        # first instance's seed). A str path is loaded fresh by
+        # `_load_inventory_yaml` and needs no copy. `is None` (not falsy): an
+        # explicit `inventory={}` must reach the schema and fail loudly on the
+        # missing `hosts`, not silently become the 3-host default environment (#345).
+        if inventory is None:
+            inventory = default_inventory
+        self.inventory: dict | str = inventory if isinstance(inventory, str) else copy.deepcopy(inventory)
+        # Copy the container so the caller's list stays untouched; the `Nos`
+        # elements themselves are shared by design (class docstring, #346).
+        self.plugins: list[str | Nos] = list(plugins) if plugins else []
 
         self.hosts: dict[str, Host] = {}
         self.allocated_ports: set[int] = set()
 
         self.shell_plugins = shell_plugins
-        self.nos_plugins = nos_plugins
+        # Per-instance view of the import-time registry (#346): mapping AND value
+        # lists are copied so `_register_nos_plugins` writes (and any list
+        # mutation) stay on this instance and never leak into the module-global,
+        # which is frozen after import — see the plugins/nos docstring. One level
+        # deep is enough: str sources have no depth, and a registered `Nos` value
+        # is shared by design (the caller handed us the built instance to reuse).
+        self.nos_plugins: dict[str, list[str] | Nos] = {name: list(sources) for name, sources in nos_plugins.items()}
         self.servers_plugins = servers_plugins
 
         # The shared asyncio loop the async server plugins (AsyncSshServer +

--- a/simnos/core/simnos.py
+++ b/simnos/core/simnos.py
@@ -125,6 +125,9 @@ class SimNOS:
         self.hosts: dict[str, Host] = {}
         self.allocated_ports: set[int] = set()
 
+        # The shell/servers registries are aliased, not copied: they are
+        # read-only class maps with no runtime write path (unlike nos_plugins
+        # below, whose `_register_nos_plugins` writes forced the #346 copy).
         self.shell_plugins = shell_plugins
         # Per-instance view of the import-time registry (#346): mapping AND value
         # lists are copied so `_register_nos_plugins` writes (and any list

--- a/simnos/plugins/nos/__init__.py
+++ b/simnos/plugins/nos/__init__.py
@@ -143,10 +143,10 @@ def resolve_device_type(device_type: str) -> str | None:
 
     Returns the internal platform name for any accepted ``device_type``:
     - a ``netmiko_device_type`` / ``ntc_platform`` alias, via the static index;
-    - any platform present in ``nos_plugins``'s own name (*identity*), checked
-      dynamically so a test-injected entry (the monkeypatch seam the frozen
-      registry deliberately keeps, #346) still resolves by its own name even
-      though the import-time index predates it. ``SimNOS(plugins=[...])``
+    - the own name (*identity*) of any platform present in ``nos_plugins``,
+      checked dynamically so a test-injected entry (the monkeypatch seam the
+      frozen registry deliberately keeps, #346) still resolves by its own name
+      even though the import-time index predates it. ``SimNOS(plugins=[...])``
       registrations do NOT land here — they live on the per-instance copy and
       resolve via the raw-key fallback below.
 

--- a/simnos/plugins/nos/__init__.py
+++ b/simnos/plugins/nos/__init__.py
@@ -20,6 +20,14 @@ Inventory refers to a platform by its ``device_type`` (#266): besides the
 internal platform name (= directory basename, the registry key), a platform's
 ``netmiko_device_type`` / ``ntc_platform`` aliases also resolve to it via the
 ``device_type_to_platform`` reverse index built below.
+
+Ownership (#346): once this module's import completes, ``nos_plugins`` is
+frozen — production code never writes to it again. Runtime registrations
+(``SimNOS(plugins=[...])``) go to the per-instance copy ``SimNOS.nos_plugins``
+and never land here, so instances cannot contaminate each other. This is a
+*logical* freeze (an ownership contract, not ``MappingProxyType``-enforced
+immutability); tests may still monkeypatch entries in deliberately — the
+dynamic fallback in ``resolve_device_type`` remains as that injection seam.
 """
 
 import glob
@@ -33,7 +41,7 @@ from simnos.core.platform_loader import PLATFORM_META_FILENAME, _load_platform_m
 
 log = logging.getLogger(__name__)
 
-nos_plugins: dict = {}
+nos_plugins: dict[str, list[str]] = {}
 
 current_file_path = os.path.abspath(__file__)
 current_directory = os.path.dirname(current_file_path)
@@ -135,11 +143,12 @@ def resolve_device_type(device_type: str) -> str | None:
 
     Returns the internal platform name for any accepted ``device_type``:
     - a ``netmiko_device_type`` / ``ntc_platform`` alias, via the static index;
-    - any registered platform's own name (*identity*), checked dynamically
-      against ``nos_plugins`` so that platforms registered *after* import — a
-      custom plugin from ``SimNOS(plugins=[...])`` or a test-injected one —
-      still resolve by their own name even though the import-time index predates
-      them.
+    - any platform present in ``nos_plugins``'s own name (*identity*), checked
+      dynamically so a test-injected entry (the monkeypatch seam the frozen
+      registry deliberately keeps, #346) still resolves by its own name even
+      though the import-time index predates it. ``SimNOS(plugins=[...])``
+      registrations do NOT land here — they live on the per-instance copy and
+      resolve via the raw-key fallback below.
 
     Returns ``None`` when the value is not a known device_type, which lets
     callers fall back to the raw value (the chokepoint then hands it to the
@@ -170,8 +179,9 @@ def assert_platform_supported(platform: str) -> None:
         # netmiko/ntc aliases are accepted too, so a user who typed an alias
         # is not misled by the canonical-only list (#266 1st round gemini #4).
         # Built from the live registry (not the import-time `available_platforms`
-        # tuple) so runtime-registered platforms appear, matching what
-        # `resolve_device_type` just checked against (#344).
+        # tuple) so test-injected platforms appear, matching what
+        # `resolve_device_type` just checked against (#344; the registry is
+        # otherwise frozen after import — #346).
         raise ValueError(
             f"Platform {platform} is not supported by SIMNOS. Supported platforms are: "
             f"{', '.join(sorted(nos_plugins))} (their netmiko_device_type / ntc_platform aliases are also accepted)."

--- a/simnos/plugins/nos/__init__.py
+++ b/simnos/plugins/nos/__init__.py
@@ -26,7 +26,7 @@ frozen — production code never writes to it again. Runtime registrations
 (``SimNOS(plugins=[...])``) go to the per-instance copy ``SimNOS.nos_plugins``
 and never land here, so instances cannot contaminate each other. This is a
 *logical* freeze (an ownership contract, not ``MappingProxyType``-enforced
-immutability); tests may still monkeypatch entries in deliberately — the
+immutability); tests may still deliberately monkeypatch entries in — the
 dynamic fallback in ``resolve_device_type`` remains as that injection seam.
 """
 

--- a/tests/core/test_simnos.py
+++ b/tests/core/test_simnos.py
@@ -4,6 +4,7 @@ The file can be found in simnos/core/simnos.py
 """
 
 # pylint: disable=protected-access
+import copy
 import logging
 import os
 import platform
@@ -17,7 +18,7 @@ import yaml
 
 from a3_paths import PLATFORMS_DIR
 from simnos.core.host import Host
-from simnos.core.nos import available_platforms
+from simnos.core.nos import Nos, available_platforms
 from simnos.core.pydantic_models import ModelOverlay, ModelSysConfig
 from simnos.core.simnos import SimNOS, default_inventory, simnos
 from simnos.core.utils import _is_in_docker
@@ -470,19 +471,17 @@ class TestSimNOS:
         The route `creating_nos_plugin.md` documents for an external
         static-only platform: `SimNOS(plugins=["path/to/dir"])` builds a Nos
         from the dir and keys it by the platform name (= dir basename), so an
-        inventory `nos: {plugin: <basename>}` resolves to it.
+        inventory `nos: {plugin: <basename>}` resolves to it. The registration
+        lands on the per-instance registry only — the module-global stays
+        clean (#346), so no teardown is needed.
         """
-        # `SimNOS.nos_plugins` IS the module-global registry, so the entry must
-        # be dropped on the way out or the registry-invariant tests (which
-        # expect source-path lists, not Nos instances) see the leak.
-        try:
-            net = SimNOS(inventory={"hosts": {}}, plugins=[SYNTHETIC_CUSTOM_A3_DIR])
-            assert "synthetic_custom" in net.nos_plugins
-            registered = net.nos_plugins["synthetic_custom"]
-            assert registered.resolved_platform is not None
-            assert "show clock" in registered.resolved_platform.commands
-        finally:
-            nos_plugins.pop("synthetic_custom", None)
+        net = SimNOS(inventory={"hosts": {}}, plugins=[SYNTHETIC_CUSTOM_A3_DIR])
+        assert "synthetic_custom" in net.nos_plugins
+        registered = net.nos_plugins["synthetic_custom"]
+        assert isinstance(registered, Nos)
+        assert registered.resolved_platform is not None
+        assert "show clock" in registered.resolved_platform.commands
+        assert "synthetic_custom" not in nos_plugins
 
     def test_plugins_str_py_path_rejected(self):
         """A str plugin pointing at a `.py` file (or any non-dir) is loud (#317 P-4).
@@ -497,7 +496,9 @@ class TestSimNOS:
     def test_plugins_dict_rejected(self):
         """The dict plugin form (legacy `from_dict` inflow) is gone (#317 P-4)."""
         with pytest.raises(TypeError, match=r"supported str \(A3 platform dir\) or Nos"):
-            SimNOS(inventory={"hosts": {}}, plugins=[{"name": "legacy", "commands": {}}])
+            # cast: this deliberately violates the `list[str | Nos]` annotation —
+            # the loud runtime TypeError is exactly what the test pins.
+            SimNOS(inventory={"hosts": {}}, plugins=cast("list[str | Nos]", [{"name": "legacy", "commands": {}}]))
 
     def test_device_type_netmiko_alias_resolves(self):
         """A netmiko-canonical `device_type` resolves to its internal platform (#266 / D2).
@@ -516,14 +517,15 @@ class TestSimNOS:
         assert resolve_device_type("edgecore_sonic") == "edgecore"
 
     def test_resolve_device_type_runtime_registered_and_unknown(self, monkeypatch):
-        """resolve_device_type serves a runtime-registered platform and None-passes the unknown (#266 / D2).
+        """resolve_device_type serves a test-injected platform and None-passes the unknown (#266 / D2).
 
-        This is the mechanism the `nos.plugin` direct-write path relies on
-        (a custom plugin from `SimNOS(plugins=[...])`, or a `nos: {plugin: X}`
-        absent from the import-time index, 1st round codex #3): an unknown value
-        must return None so the `start()` chokepoint falls back to the raw key,
-        and a name added to `nos_plugins` after import must resolve by identity
-        via the dynamic fallback (not just the static reverse index).
+        The unknown → None half is what the `nos: {plugin: X}` path relies on:
+        the `start()` chokepoint falls back to the raw key and resolves it
+        against the per-instance registry — `SimNOS(plugins=[...])` registrations
+        never reach the frozen module-global (#346). The dynamic-fallback half
+        is the deliberate monkeypatch seam the frozen registry keeps: an entry
+        injected into the global still resolves by identity even though the
+        import-time index predates it.
         """
         import simnos.plugins.nos as nos_registry
 
@@ -671,7 +673,119 @@ class TestSimNOS:
         """
         inventory = {"hosts": {"R1": {"port": 5001, "device_type": "cisco_ios"}}}
         net = SimNOS(inventory)
-        assert len(net.nos_plugins["cisco_ios"]) == 2, "Not all files detected"
+        cisco_sources = net.nos_plugins["cisco_ios"]
+        assert isinstance(cisco_sources, list)
+        assert len(cisco_sources) == 2, "Not all files detected"
+
+
+class TestInstanceIsolation:
+    """SimNOS instances do not contaminate each other or their callers (#346).
+
+    Ownership contract: the module-global `nos_plugins` registry is frozen after
+    import — `SimNOS(plugins=[...])` registrations go to the per-instance copy —
+    and caller-passed containers (inventory dict / sys_config dict / plugins
+    list) are borrowed read-only; SimNOS mutates only its own copies.
+    """
+
+    def test_plugin_registration_stays_per_instance(self):
+        """A `plugins=[...]` registration is invisible to the global and to other instances."""
+        net_a = SimNOS(inventory={"hosts": {}}, plugins=[SYNTHETIC_CUSTOM_A3_DIR])
+        net_b = SimNOS(inventory={"hosts": {}})
+        assert "synthetic_custom" in net_a.nos_plugins
+        assert "synthetic_custom" not in nos_plugins
+        assert "synthetic_custom" not in net_b.nos_plugins
+
+    def test_builtin_shadowing_is_instance_local_and_lists_are_copied(self):
+        """Shadowing a built-in name, and mutating an entry list, stay instance-local.
+
+        The identity / append pins run against a NON-shadowed entry on purpose:
+        the shadowed one holds a `Nos` instance, so an identity check against the
+        global's path list would be vacuous (different types) and `append` an
+        AttributeError. What must not leak is an element added to a copied path
+        list — the one-level-deep copy's whole point (#346).
+        """
+        shadow_nos = Nos(filename=os.path.join(PLATFORMS_DIR, "cisco_ios"))
+        net_a = SimNOS(inventory={"hosts": {}}, plugins=[shadow_nos])
+        net_b = SimNOS(inventory={"hosts": {}})
+        # The shadow is visible only inside net_a; global / net_b keep the path list.
+        assert net_a.nos_plugins["cisco_ios"] is shadow_nos
+        assert isinstance(nos_plugins["cisco_ios"], list)
+        assert isinstance(net_b.nos_plugins["cisco_ios"], list)
+        # Value lists are copied, and an element appended to one instance's list
+        # reaches neither the global nor another instance. `cast` for ty: the
+        # runtime isinstance pin narrows to `list | (Nos & list)` (Nos is not
+        # final), which still rejects `.append(str)`.
+        entry_a = cast("list[str]", net_a.nos_plugins["arista_eos"])
+        assert isinstance(entry_a, list)
+        assert entry_a is not nos_plugins["arista_eos"]
+        entry_a.append("<instance-local>")
+        entry_b = cast("list[str]", net_b.nos_plugins["arista_eos"])
+        assert "<instance-local>" not in nos_plugins["arista_eos"]
+        assert "<instance-local>" not in entry_b
+
+    def test_registered_nos_resolves_for_host_and_is_shared_as_is(self):
+        """The documented custom-plugin flow works off the per-instance registry (#346).
+
+        `resolve_device_type` no longer sees instance registrations (the global
+        is frozen), so the raw-key fallback → per-instance lookup chain in
+        `Host.start` is load-bearing — this pins the `creating_nos_plugin.md`
+        flow end to end (the handler-platform variant: the synthetic platform
+        has `handler:` commands, so the Nos needs the A3 dir plus the handler
+        module), plus the contract's deliberate exception: a caller-built `Nos`
+        is registered and reused as-is, never copied.
+        """
+        caller_nos = Nos(filename=[SYNTHETIC_CUSTOM_A3_DIR, SYNTHETIC_CUSTOM_HANDLERS])
+        inventory = {"hosts": {"R1": {"nos": {"plugin": "synthetic_custom"}}}}
+        net = SimNOS(inventory=inventory, plugins=[caller_nos])
+        assert net.plugins[0] is caller_nos
+        assert net.nos_plugins["synthetic_custom"] is caller_nos
+        net.start()
+        try:
+            assert net.hosts["R1"].nos is caller_nos
+        finally:
+            net.stop()
+
+    def test_explicit_inventory_dict_is_not_mutated(self):
+        """An explicit inventory dict is borrowed read-only — no defaults baked in."""
+        caller_inventory = {"hosts": {"R1": {"device_type": "cisco_ios"}}}
+        snapshot = copy.deepcopy(caller_inventory)
+        SimNOS(inventory=caller_inventory)
+        assert caller_inventory == snapshot
+
+    def test_reused_inventory_does_not_inherit_prior_sys_config_seed(self):
+        """The #346 failure scenario: instance A's sys_config seed must not leak into B.
+
+        Before the fix, `_load_inventory` baked A's seeded `variants_policy` into
+        the caller's dict; B's seed check then mistook it for an explicit
+        inventory value and silently inherited A's setting.
+        """
+        inventory = {"hosts": {}}
+        SimNOS(inventory=inventory, sys_config={"variants_policy": {"select": 1}})
+        net_b = SimNOS(inventory=inventory, sys_config={"variants_policy": {"select": 2}})
+        assert isinstance(net_b.inventory, dict)
+        assert net_b.inventory["default"]["variants_policy"]["select"] == 2
+
+    def test_caller_plugins_list_is_not_mutated(self):
+        """The plugins list container is copied; a later caller append is invisible.
+
+        (The `Nos` *elements* are deliberately shared, pinned by
+        `test_registered_nos_resolves_for_host_and_is_shared_as_is`.)
+        """
+        caller_plugins: list[str | Nos] = [SYNTHETIC_CUSTOM_A3_DIR]
+        net = SimNOS(inventory={"hosts": {}}, plugins=caller_plugins)
+        caller_plugins.append("<appended-after-init>")
+        assert net.plugins == [SYNTHETIC_CUSTOM_A3_DIR]
+
+    def test_caller_sys_config_dict_is_not_mutated(self):
+        """An explicit sys_config dict is borrowed read-only (contract symmetry).
+
+        Already true before #346 (`ModelSysConfig(**raw).model_dump()` builds a
+        fresh dict); pinned so all three caller-passed containers stay covered.
+        """
+        caller_sys_config = {"variants_policy": {"select": 1}}
+        snapshot = copy.deepcopy(caller_sys_config)
+        SimNOS(inventory={"hosts": {}}, sys_config=caller_sys_config)
+        assert caller_sys_config == snapshot
 
 
 class TestReservedInventoryFields:

--- a/tests/core/test_simnos.py
+++ b/tests/core/test_simnos.py
@@ -716,10 +716,12 @@ class TestInstanceIsolation:
         # runtime isinstance pin narrows to `list | (Nos & list)` (Nos is not
         # final), which still rejects `.append(str)`.
         entry_a = cast("list[str]", net_a.nos_plugins["arista_eos"])
+        entry_b = cast("list[str]", net_b.nos_plugins["arista_eos"])
         assert isinstance(entry_a, list)
         assert entry_a is not nos_plugins["arista_eos"]
+        assert entry_b is not nos_plugins["arista_eos"]
+        assert entry_a is not entry_b
         entry_a.append("<instance-local>")
-        entry_b = cast("list[str]", net_b.nos_plugins["arista_eos"])
         assert "<instance-local>" not in nos_plugins["arista_eos"]
         assert "<instance-local>" not in entry_b
 
@@ -739,8 +741,10 @@ class TestInstanceIsolation:
         net = SimNOS(inventory=inventory, plugins=[caller_nos])
         assert net.plugins[0] is caller_nos
         assert net.nos_plugins["synthetic_custom"] is caller_nos
-        net.start()
+        # start() inside the try: a mid-start failure must still reach stop()
+        # (partial-start resources would otherwise leak into later tests).
         try:
+            net.start()
             assert net.hosts["R1"].nos is caller_nos
         finally:
             net.stop()
@@ -775,6 +779,9 @@ class TestInstanceIsolation:
         net = SimNOS(inventory={"hosts": {}}, plugins=caller_plugins)
         caller_plugins.append("<appended-after-init>")
         assert net.plugins == [SYNTHETIC_CUSTOM_A3_DIR]
+        # And the read-only-borrow half: SimNOS wrote nothing into the caller's
+        # list — only the caller's own append is there.
+        assert caller_plugins == [SYNTHETIC_CUSTOM_A3_DIR, "<appended-after-init>"]
 
     def test_caller_sys_config_dict_is_not_mutated(self):
         """An explicit sys_config dict is borrowed read-only (contract symmetry).

--- a/tests/core/test_simnos.py
+++ b/tests/core/test_simnos.py
@@ -516,7 +516,7 @@ class TestSimNOS:
         # The alias resolves to the internal platform key (the reverse-index core).
         assert resolve_device_type("edgecore_sonic") == "edgecore"
 
-    def test_resolve_device_type_runtime_registered_and_unknown(self, monkeypatch):
+    def test_resolve_device_type_test_injected_and_unknown(self, monkeypatch):
         """resolve_device_type serves a test-injected platform and None-passes the unknown (#266 / D2).
 
         The unknown → None half is what the `nos: {plugin: X}` path relies on:


### PR DESCRIPTION
🐙claude: SimNOS インスタンス間の global 状態汚染 2 系統 (#346) を、ownership 契約の明文化とともに解消する。design doc (cross-review 2 round 収束) + code cross-review 1 round (3 者 SUGGESTION 収束) を経た実装。**本 PR で #346 を close する** (v3 全体監査 issue のうち唯一の bug 系統単独 issue、scope 完結)。

## ownership 契約 (本 PR で確立)

1. **module-global `nos_plugins` は import 後 logical freeze** — production code は二度と書き込まない (`MappingProxyType` 強制ではなく契約。test の monkeypatch 直接注入は `resolve_device_type` dynamic fallback の互換 seam として例外的に存置)
2. **`SimNOS.nos_plugins` は per-instance view** — global の 1 段 copy (mapping + 値 path list の両方を複製、型 `dict[str, list[str] | Nos]`)。`plugins=[...]` の登録はインスタンス内に閉じる
3. **caller-passed container は read-only borrow** — inventory dict は deepcopy、plugins list は container copy、sys_config は従来から非汚染 (pin 追加)。例外は plugins list の `Nos` **要素** = as-is 登録で意図的共有 (built 済みインスタンスを渡す機能の本質)

## 直った実バグ

- **registry 汚染**: `SimNOS(plugins=[...])` の登録が module-global に永続し後続の全インスタンスへ漏れる (削除経路なし)。built-in 名で登録すると global の path-list entry が `Nos` インスタンスに置換され、path-list 前提の下流 (dev hot-reload watch roots / tests) が型破綻
- **caller inventory 破壊**: explicit inventory dict に defaults + sys_config seed 済み `variants_policy` が焼き込まれる (「caller's own object and left untouched」コメントと実装の矛盾)。同一 dict をインスタンス A (`select: 1`) → B (`select: 2`) で再利用すると **B が A の値を silent 継承**

## 実装のポイント

- custom plugin の解決経路は不変: `Host.start` の `resolve_device_type(X) or raw-key` fallback → per-instance `.get` chain が load-bearing 化するため、公開 docs の flow (`plugins=[Nos(...)]` + `nos: {plugin: X}`) を start() まで通す identity 3 点 pin を新設
- 「`SimNOS(plugins=[...])` → dynamic fallback で解決」という stale 記述を repo sweep (`resolve_device_type` docstring / `assert_platform_supported` #344 コメント / 既存 pin test 名+docstring)
- `TestInstanceIsolation` 新設 (隔離 pin 7 test: registry 隔離 / shadowing 局所性 + 値 list identity・append 非伝播 / 正規経路 + Nos 共有 / inventory・plugins・sys_config 非破壊 / issue 失敗シナリオ再現) + 既存 2 test 更新 (try/finally workaround 撤去 → 「global が汚れない」正の assertion へ)
- changelog en/ja (Unreleased に Bug Fixes 節新設、migration action 込み: 「custom plugin は利用する各 `SimNOS` の `plugins=[...]` に渡す」)

## 挙動変化 (breaking 級ではない)

cross-instance の plugin 可視性が消える — undocumented な汚染の副作用に依存していた場合のみ影響 (正規経路は 1 行)。公開 API / golden / wire 非接触 (byte-parity suite green に含まれる)。

## レビュー

- design: cross-review 2 round (1st: SHOULD FIX×2 → 2nd: 3 者 SUGGESTION 収束)。値 list までの 1 段 copy 強化 / 正規経路 pin test / logical freeze 文言はレビュー起点
- code: cross-review 1 round — codex / gemini / claude **3 者とも SUGGESTION** (bug/regression 指摘ゼロ)、SUGGESTION 5 件全て取り込み済 (start の try 内移動 / 隔離 pin の全インスタンス対称化 / plugins list の read-only borrow 直接 assert / 文言 2 点)
- pre-review-refactor + final-refactor 済

## 検証

- full CI: `invoke ruff` ✅ / `invoke yamllint` ✅ / `uv run ty check` ✅ / `pytest tests/ -n auto` → **1239 passed, 9 skipped** (+7 net 新規 test)
- wire/golden 非接触

Closes #346

🤖 Generated with [Claude Code](https://claude.com/claude-code)
