### PR TITLE
chore: Issue / PR テンプレートを追加 (#122)

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,36 @@
+---
+name: Bug report
+about: Report something that does not work as documented
+title: "bug: "
+labels: bug
+---
+
+## What you expected to happen
+
+<!-- e.g. `netmiko` connects to a cisco_ios host and `show version` returns the platform output. -->
+
+## What actually happened
+
+<!-- Paste the actual output / traceback. For wire-level issues, a session log
+     (netmiko `session_log`) or a raw byte capture helps a lot. -->
+
+## Steps to reproduce
+
+<!-- Minimal steps. Ideally: the inventory (or `simnos up -d <platform>` command),
+     the client command(s) you sent, and how you connected (netmiko / scrapli /
+     ansible / plain ssh). -->
+
+1.
+2.
+3.
+
+## Environment
+
+- OS:
+- Python version:
+- simnos version (`pip show simnos` / git commit):
+- Client tool + version (netmiko / scrapli / ansible / ssh):
+
+## Additional context
+
+<!-- Anything else: platform name, custom platform dir, sys_config, logs. -->

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,28 @@
+---
+name: Feature request
+about: Suggest a new capability or platform
+title: "feat: "
+labels: enhancement
+---
+
+<!-- SIMNOS is a lightweight test stub for network automation tools, not a full
+     network emulator (no routing protocols, no packet forwarding — see
+     CONTRIBUTING.md "What SIMNOS Is (and Isn't)"). Please open an issue to
+     discuss before writing code: the scope is narrow on purpose. -->
+
+## Problem / motivation
+
+<!-- What are you trying to do that SIMNOS cannot do today? -->
+
+## Proposed solution
+
+<!-- What you would like to happen. For new platforms: name the NOS and, if
+     possible, point at NTC Templates / real-device reference output. -->
+
+## Alternatives considered
+
+<!-- Other approaches you thought about, including "solve it outside SIMNOS". -->
+
+## Additional context
+
+<!-- Links, captures, related issues. -->

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,34 @@
+<!-- Thank you for contributing! Please explain *why*, not just *what* —
+     PRs without context are hard to review (see CONTRIBUTING.md). -->
+
+## Summary
+
+<!-- What does this PR do, and why? -->
+
+## Related issue
+
+<!-- Larger changes should be discussed in an issue first (CONTRIBUTING.md).
+     Small fixes (typos, minor bugs) may open an issue and PR together. -->
+
+Closes #
+
+## Changes
+
+-
+
+## Testing
+
+<!-- How did you verify this? e.g. `pytest -n auto`, `invoke ruff`,
+     `invoke yamllint`, `invoke lint-platform-data`, a manual SSH session. -->
+
+## AI disclosure
+
+<!-- Per CONTRIBUTING.md "AI Transparency": if AI tools were used, name them and
+     confirm you reviewed the output yourself. Write "None" if no AI was used. -->
+
+## Checklist
+
+- [ ] Tests pass locally (`pytest -n auto`)
+- [ ] Lint passes (`invoke ruff` / `invoke yamllint`; for platform data also `invoke lint-platform-data`)
+- [ ] The byte-parity goldens are untouched (re-recording them requires maintainer approval)
+- [ ] Docs updated where behaviour changed (for platform data: `invoke gen-docs-platform-commands`)


### PR DESCRIPTION
🐙claude:

Closes #122

## 概要
Issue テンプレート 2 種 + PR テンプレートを追加する。文面は CONTRIBUTING.md の既存方針をそのままテンプレート化した。

## 変更内容
- `bug_report.md`: CONTRIBUTING「Reporting Bugs」の 4 項目 (期待/実際/再現手順/環境) + client tool 欄
- `feature_request.md`: narrow scope (test stub であり emulator ではない) の事前議論誘導 + platform 要望は NTC Templates 参照
- `PULL_REQUEST_TEMPLATE.md`: why 重視 / **AI Transparency 開示欄** / byte-parity golden 不可侵 + lint/test checklist

## 検証
- `yamllint .` green (テンプレートの frontmatter は yamllint 対象外)、label (bug / enhancement) は既存を使用

🤖 Generated with [Claude Code](https://claude.com/claude-code)
