### PR TITLE
chore: literal .txt への jinja 変数漏れ検出 lint を追加 (#329)

### DIFF
--- a/tasks.py
+++ b/tasks.py
@@ -227,7 +227,7 @@ _RENDER_VAR_NAMES = ("base_prompt", "username")
 # hybrid are all flagged, including trailing jinja filters / format specs
 # (`{{ base_prompt | upper }}` / `{base_prompt:<20}` — `[^}]*` up to the closing
 # brace, 1st round codex #1) and jinja whitespace-control (`{{- base_prompt }}`
-# — `[-\s]*` after the braces, 2nd round codex #1; the closing-side `-}}` is
+# — `-?\s*` after the braces, 2nd/3rd round codex; the closing-side `-}}` is
 # already inside `[^}]*`): a brace expression *starting* with a render-var
 # name (`\b` keeps `{base_prompt_style}` a different identifier) has no
 # legitimate reading in a literal file. Real-device literals (`{ACDEF}` /
@@ -236,7 +236,7 @@ _RENDER_VAR_NAMES = ("base_prompt", "username")
 # no-op for the current names but keeps a future metachar-bearing name from
 # becoming a wildcard (1st round gemini #1).
 _RENDER_VAR_LEAK_RE = re.compile(
-    r"\{\{?[-\s]*(?:" + "|".join(re.escape(name) for name in _RENDER_VAR_NAMES) + r")\b[^}]*\}?\}"
+    r"\{\{?-?\s*(?:" + "|".join(re.escape(name) for name in _RENDER_VAR_NAMES) + r")\b[^}]*\}?\}"
 )
 
 

--- a/tasks.py
+++ b/tasks.py
@@ -225,11 +225,18 @@ def check_platform_data_device_type_collisions(platforms_dir: str = PLATFORMS_A3
 _RENDER_VAR_NAMES = ("base_prompt", "username")
 # Single-brace (`{base_prompt}`, the str.format heritage that leaked in #328),
 # double-brace (`{{ base_prompt }}`, the jinja spelling) and any mismatched
-# hybrid are all flagged — a render-var name inside braces has no legitimate
-# reading in a literal file. Real-device literals (`{ACDEF}` / `{master}` /
-# `flags={origin_is_acl,}`) never wrap these exact names, which is what keeps
-# the false-positive rate at zero (#329).
-_RENDER_VAR_LEAK_RE = re.compile(r"\{\{?\s*(?:" + "|".join(_RENDER_VAR_NAMES) + r")\s*\}?\}")
+# hybrid are all flagged, including trailing jinja filters / format specs
+# (`{{ base_prompt | upper }}` / `{base_prompt:<20}` — `[^}]*` up to the closing
+# brace, 1st round codex #1): a brace expression *starting* with a render-var
+# name (`\b` keeps `{base_prompt_style}` a different identifier) has no
+# legitimate reading in a literal file. Real-device literals (`{ACDEF}` /
+# `{master}` / `flags={origin_is_acl,}`) never start with these exact names,
+# which is what keeps the false-positive rate at zero (#329). `re.escape` is a
+# no-op for the current names but keeps a future metachar-bearing name from
+# becoming a wildcard (1st round gemini #1).
+_RENDER_VAR_LEAK_RE = re.compile(
+    r"\{\{?\s*(?:" + "|".join(re.escape(name) for name in _RENDER_VAR_NAMES) + r")\b[^}]*\}?\}"
+)
 
 
 def check_platform_data_render_leaks(platforms_dir: str = PLATFORMS_A3_DIR) -> list[str]:

--- a/tasks.py
+++ b/tasks.py
@@ -226,7 +226,9 @@ _RENDER_VAR_NAMES = ("base_prompt", "username")
 # double-brace (`{{ base_prompt }}`, the jinja spelling) and any mismatched
 # hybrid are all flagged, including trailing jinja filters / format specs
 # (`{{ base_prompt | upper }}` / `{base_prompt:<20}` — `[^}]*` up to the closing
-# brace, 1st round codex #1): a brace expression *starting* with a render-var
+# brace, 1st round codex #1) and jinja whitespace-control (`{{- base_prompt }}`
+# — `[-\s]*` after the braces, 2nd round codex #1; the closing-side `-}}` is
+# already inside `[^}]*`): a brace expression *starting* with a render-var
 # name (`\b` keeps `{base_prompt_style}` a different identifier) has no
 # legitimate reading in a literal file. Real-device literals (`{ACDEF}` /
 # `{master}` / `flags={origin_is_acl,}`) never start with these exact names,
@@ -234,7 +236,7 @@ _RENDER_VAR_NAMES = ("base_prompt", "username")
 # no-op for the current names but keeps a future metachar-bearing name from
 # becoming a wildcard (1st round gemini #1).
 _RENDER_VAR_LEAK_RE = re.compile(
-    r"\{\{?\s*(?:" + "|".join(re.escape(name) for name in _RENDER_VAR_NAMES) + r")\b[^}]*\}?\}"
+    r"\{\{?[-\s]*(?:" + "|".join(re.escape(name) for name in _RENDER_VAR_NAMES) + r")\b[^}]*\}?\}"
 )
 
 

--- a/tasks.py
+++ b/tasks.py
@@ -217,6 +217,49 @@ def check_platform_data_device_type_collisions(platforms_dir: str = PLATFORMS_A3
     return violations
 
 
+# Render variables the loader substitutes in the `.j2` / challenge channels,
+# mirrored from `simnos.core.resolved_command` (KNOWN_RENDER_VARS |
+# CHALLENGE_RENDER_VARS). Hardcoded because tasks.py stays simnos-import-free
+# (#264 / D1); `tests/test_lint_platform_data.py` pins this tuple against the
+# real constants so a new render variable cannot silently escape the guard.
+_RENDER_VAR_NAMES = ("base_prompt", "username")
+# Single-brace (`{base_prompt}`, the str.format heritage that leaked in #328),
+# double-brace (`{{ base_prompt }}`, the jinja spelling) and any mismatched
+# hybrid are all flagged — a render-var name inside braces has no legitimate
+# reading in a literal file. Real-device literals (`{ACDEF}` / `{master}` /
+# `flags={origin_is_acl,}`) never wrap these exact names, which is what keeps
+# the false-positive rate at zero (#329).
+_RENDER_VAR_LEAK_RE = re.compile(r"\{\{?\s*(?:" + "|".join(_RENDER_VAR_NAMES) + r")\s*\}?\}")
+
+
+def check_platform_data_render_leaks(platforms_dir: str = PLATFORMS_A3_DIR) -> list[str]:
+    """Flag jinja render variables leaked into literal ``.txt`` outputs (#329).
+
+    The ``.txt`` channel is served verbatim (never rendered), so a
+    ``{base_prompt}`` / ``{{ base_prompt }}`` inside one reaches the wire
+    unsubstituted — the #328 arista_eos ``show hostname`` regression class. A
+    body that needs a render variable must be authored as ``.j2``
+    (``output_template:``) instead. Scans every ``.txt`` under ``commands/``
+    (variants included); ``.j2`` is the render channel and exempt. Undecodable
+    bytes are replaced rather than raised — a broken encoding is already a
+    gating violation in `check_platform_data` and must not crash this pass.
+
+    Returns a list of human-readable violation strings (empty = clean).
+    """
+    violations: list[str] = []
+    for platform, commands_dir in _iter_platform_command_dirs(platforms_dir):
+        for txt_path in sorted(glob.glob(os.path.join(commands_dir, "*.txt"))):
+            with open(txt_path, encoding="utf-8", errors="replace") as f:
+                content = f.read()
+            for match in _RENDER_VAR_LEAK_RE.finditer(content):
+                line_no = content.count("\n", 0, match.start()) + 1
+                violations.append(
+                    f"{platform}/commands/{os.path.basename(txt_path)}:{line_no}: render variable "
+                    f"{match.group(0)!r} in a literal .txt — author it as a .j2 output_template instead (#328)"
+                )
+    return violations
+
+
 def check_platform_data_py_modules(platforms_dir: str = PLATFORMS_A3_DIR) -> list[str]:
     """Cross-check the A3 platforms against their py handler modules (#317 P-4).
 
@@ -437,7 +480,9 @@ def lint_platform_data(context):
     `check_platform_data_ratchet`) + device_type alias collisions across
     platforms (#266, see `check_platform_data_device_type_collisions`)
     + py-module cross-checks (orphan ``platforms_py`` module / unbindable
-    ``handler:`` ref, #317 P-4, see `check_platform_data_py_modules`).
+    ``handler:`` ref, #317 P-4, see `check_platform_data_py_modules`)
+    + render-variable leaks into literal ``.txt`` (#329, see
+    `check_platform_data_render_leaks`).
     Warning-tier (printed, non-blocking):
     filename convention + ``type: ntc`` provenance (see
     `check_platform_data_warnings`).
@@ -460,6 +505,7 @@ def lint_platform_data(context):
         + check_platform_data_ratchet()
         + check_platform_data_device_type_collisions()
         + check_platform_data_py_modules()
+        + check_platform_data_render_leaks()
     )
     for violation in violations:
         print(violation)

--- a/tasks.py
+++ b/tasks.py
@@ -56,8 +56,7 @@ def bandit(context):
 def _iter_platform_command_dirs(platforms_dir: str):
     """Yield ``(platform, commands_dir)`` for every platform with a commands dir.
 
-    The single walk shared by the lint passes (`check_platform_data` /
-    `check_platform_data_warnings` / `check_platform_data_ratchet`) — an
+    The single walk shared by every ``check_platform_data_*`` lint pass — an
     absent platforms dir or a platform without a ``commands/`` subdir is
     skipped, so callers loop over real targets only.
     """

--- a/tests/test_lint_platform_data.py
+++ b/tests/test_lint_platform_data.py
@@ -160,6 +160,7 @@ class TestRenderLeaks:
         _write(commands / "sudo.txt", "[sudo] password for {username}:\n")
         violations = check_platform_data_render_leaks(str(tmp_path))
         assert len(violations) == 1
+        assert "{username}" in violations[0]
 
     def test_real_device_literal_braces_pass(self, tmp_path):
         # The false-positive catalogue from #329: real devices print these

--- a/tests/test_lint_platform_data.py
+++ b/tests/test_lint_platform_data.py
@@ -152,6 +152,36 @@ class TestRenderLeaks:
         assert len(violations) == 1
         assert "show.txt:2" in violations[0]
 
+    def test_jinja_filter_and_format_spec_flagged(self, tmp_path):
+        # A trailing jinja filter / format spec is the same unsubstituted leak
+        # (1st round codex #1): the expression *starts* with the render var.
+        commands = _platform(tmp_path)
+        _write(commands / "show.yaml", "command: show\ntype: simnos\noutput: show.txt\n")
+        _write(commands / "show.txt", "{{ base_prompt | upper }} ready\npadded: {base_prompt:<20}|\n")
+        violations = check_platform_data_render_leaks(str(tmp_path))
+        assert len(violations) == 2
+        assert "show.txt:1" in violations[0]
+        assert "show.txt:2" in violations[1]
+
+    def test_similar_identifier_not_flagged(self, tmp_path):
+        # `\b` pins the name as a whole identifier: `base_prompt_style` is a
+        # different token and must not trip the guard.
+        commands = _platform(tmp_path)
+        _write(commands / "show.yaml", "command: show\ntype: simnos\noutput: show.txt\n")
+        _write(commands / "show.txt", "style is {base_prompt_style} today\n")
+        assert check_platform_data_render_leaks(str(tmp_path)) == []
+
+    def test_broken_encoding_does_not_crash_and_still_reports(self, tmp_path):
+        # errors="replace" contract (docstring): a broken encoding is the
+        # encoding gate's violation, but this pass must survive the file and
+        # still report the leak with the right line number (1st round codex #2).
+        commands = _platform(tmp_path)
+        _write(commands / "show.yaml", "command: show\ntype: simnos\noutput: show.txt\n")
+        _write(commands / "show.txt", b"\xff\xfe garbage\n{base_prompt}\n", binary=True)
+        violations = check_platform_data_render_leaks(str(tmp_path))
+        assert len(violations) == 1
+        assert "show.txt:2" in violations[0]
+
     def test_username_challenge_var_flagged(self, tmp_path):
         # `username` is a CHALLENGE_RENDER_VARS member and equally has no
         # legitimate braced reading in a literal file.

--- a/tests/test_lint_platform_data.py
+++ b/tests/test_lint_platform_data.py
@@ -10,10 +10,12 @@ actually fails — without these a bug in the lint logic would read as
 """
 
 from tasks import (
+    _RENDER_VAR_NAMES,
     check_platform_data,
     check_platform_data_device_type_collisions,
     check_platform_data_py_modules,
     check_platform_data_ratchet,
+    check_platform_data_render_leaks,
     check_platform_data_warnings,
     is_stub_help,
 )
@@ -120,6 +122,78 @@ class TestConventions:
 def test_absent_dir_is_clean(tmp_path):
     # No platforms dir at all (the state before any A3 migration) is not an error.
     assert check_platform_data(str(tmp_path / "nonexistent")) == []
+
+
+class TestRenderLeaks:
+    """Render-variable leak guard for literal ``.txt`` outputs (#329).
+
+    Pins both halves of the issue's contract: the #328 regression class
+    (``{base_prompt}`` served verbatim from a literal file) is caught, and the
+    real-device literal braces the issue catalogued (hp_comware ``{ACDEF}``,
+    juniper ``{master}``, cisco crypto ``flags={...}``) stay false-positive-free.
+    """
+
+    def test_single_brace_leak_flagged(self, tmp_path):
+        # The exact #328 shape: str.format heritage moved verbatim into .txt.
+        commands = _platform(tmp_path)
+        _write(commands / "show_hostname.yaml", "command: show hostname\ntype: simnos\noutput: show_hostname.txt\n")
+        _write(commands / "show_hostname.txt", "Hostname: {base_prompt}\n")
+        violations = check_platform_data_render_leaks(str(tmp_path))
+        assert len(violations) == 1
+        assert "show_hostname.txt:1" in violations[0]
+        assert "{base_prompt}" in violations[0]
+
+    def test_double_brace_leak_flagged(self, tmp_path):
+        # The jinja spelling in a literal file is the same authoring mistake.
+        commands = _platform(tmp_path)
+        _write(commands / "show.yaml", "command: show\ntype: simnos\noutput: show.txt\n")
+        _write(commands / "show.txt", "line one\n{{ base_prompt }} uptime is 1 day\n")
+        violations = check_platform_data_render_leaks(str(tmp_path))
+        assert len(violations) == 1
+        assert "show.txt:2" in violations[0]
+
+    def test_username_challenge_var_flagged(self, tmp_path):
+        # `username` is a CHALLENGE_RENDER_VARS member and equally has no
+        # legitimate braced reading in a literal file.
+        commands = _platform(tmp_path)
+        _write(commands / "sudo.yaml", "command: sudo -s\ntype: simnos\noutput: sudo.txt\n")
+        _write(commands / "sudo.txt", "[sudo] password for {username}:\n")
+        violations = check_platform_data_render_leaks(str(tmp_path))
+        assert len(violations) == 1
+
+    def test_real_device_literal_braces_pass(self, tmp_path):
+        # The false-positive catalogue from #329: real devices print these
+        # braces literally and a naive "any `{` in .txt" rule would flag them.
+        commands = _platform(tmp_path)
+        _write(commands / "display.yaml", "command: display link-aggregation\ntype: simnos\noutput: display.txt\n")
+        _write(
+            commands / "display.txt",
+            "Flag: {ACDEF} {ACG} {EF}\n"
+            "flags={origin_is_acl,}\n"
+            "current outbound spi: 0x0(0), flags={Transport UDP-Encaps, }\n"
+            "{master}\n"
+            "idle{idle: cpu7}\n",
+        )
+        assert check_platform_data_render_leaks(str(tmp_path)) == []
+
+    def test_j2_channel_is_exempt(self, tmp_path):
+        # `.j2` is the render channel — `{{ base_prompt }}` there is the point.
+        commands = _platform(tmp_path)
+        _write(commands / "show.yaml", "command: show\ntype: simnos\noutput_template: show.j2\n")
+        _write(commands / "show.j2", "{{ base_prompt }} uptime is 1 day\n")
+        assert check_platform_data_render_leaks(str(tmp_path)) == []
+
+    def test_real_repo_is_clean(self):
+        # Zero leaks in the shipped data is what makes this check safe to gate.
+        assert check_platform_data_render_leaks() == []
+
+    def test_var_names_stay_in_sync_with_loader(self):
+        # tasks.py hardcodes the names (it must stay simnos-import-free, #264 /
+        # D1); this pin is the sync contract — adding a render variable to the
+        # loader without extending the lint fails here, not in production.
+        from simnos.core.resolved_command import CHALLENGE_RENDER_VARS, KNOWN_RENDER_VARS
+
+        assert set(_RENDER_VAR_NAMES) == set(KNOWN_RENDER_VARS | CHALLENGE_RENDER_VARS)
 
 
 class TestWarnings:

--- a/tests/test_lint_platform_data.py
+++ b/tests/test_lint_platform_data.py
@@ -157,11 +157,17 @@ class TestRenderLeaks:
         # (1st round codex #1): the expression *starts* with the render var.
         commands = _platform(tmp_path)
         _write(commands / "show.yaml", "command: show\ntype: simnos\noutput: show.txt\n")
-        _write(commands / "show.txt", "{{ base_prompt | upper }} ready\npadded: {base_prompt:<20}|\n")
+        _write(
+            commands / "show.txt",
+            "{{ base_prompt | upper }} ready\npadded: {base_prompt:<20}|\n{{- base_prompt -}} trimmed\n",
+        )
         violations = check_platform_data_render_leaks(str(tmp_path))
-        assert len(violations) == 2
+        assert len(violations) == 3
         assert "show.txt:1" in violations[0]
         assert "show.txt:2" in violations[1]
+        # jinja whitespace-control is a valid spelling of the same leak
+        # (2nd round codex #1).
+        assert "show.txt:3" in violations[2]
 
     def test_similar_identifier_not_flagged(self, tmp_path):
         # `\b` pins the name as a whole identifier: `base_prompt_style` is a


### PR DESCRIPTION
🐙claude:

refs #329 (issue は v3→main まで OPEN 維持)

## 概要
literal `.txt` (非 render channel) への jinja 変数漏れを検出する gating lint を `invoke lint-platform-data` に追加する。#328 (arista_eos `show hostname` の `{base_prompt}` が未置換のまま wire 配信) と同型の regression クラスを機械的に再発防止する。

## 実装
- `check_platform_data_render_leaks`: commands/ 直下の全 `.txt` (variants 含む) を走査し、render 変数名 (`base_prompt` / `username`) の brace 出現を行番号付きで弾く。`.j2` は render channel なので対象外
- regex `\{\{?-?\s*(names)\b[^}]*\}?\}`: single-brace (str.format 遺産) / double-brace (jinja) / filter・format spec 付き (`{{ base_prompt | upper }}` / `{base_prompt:<20}`) / whitespace-control (`{{- base_prompt }}`) を全て検出。先頭 token 一致 + `\b` 境界で `{base_prompt_style}` 等の別 identifier は非対象
- token 集合は tasks.py にハードコード (simnos import 禁止 #264/D1) + **sync テストで `KNOWN_RENDER_VARS ∪ CHALLENGE_RENDER_VARS` と pin** — loader に変数を足すと lint 未追従がテストで落ちる
- 誤検知ゼロ担保: #329 カタログの実機リテラル (`{ACDEF}` / `{master}` / `flags={...}`) を負例テストで pin。shipped 全 `.txt` (~1000 ファイル) で現状ゼロ件 = gating 安全

## cross-review (code 3 round 収束)
- 1st: codex SHOULD FIX (filter/format spec の過少検出) / gemini LGTM / claude SUGGESTION → regex 拡大 + re.escape + UTF-8 劣化テスト取り込み
- 2nd: codex SHOULD FIX (whitespace-control 形) → opening 側 `-?\s*` 化
- 3rd: codex SUGGESTION (正規形 polish) → 取り込み、収束

## 検証
- 51 passed (新規 10 テスト) / `invoke lint-platform-data` OK / full CI 相当 green (1284 passed、docker 2 errors は iptables 起因の pre-existing 環境要因で v3 でも同一再現)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
