### PR TITLE
fix: per-session 行バッファに _LINE_MAX cap + 対話 echo に drain backpressure (#347)

### DIFF
--- a/simnos/plugins/servers/async_session.py
+++ b/simnos/plugins/servers/async_session.py
@@ -147,6 +147,16 @@ _CSI_ACTIONS = {
 }
 _MAX_ESC_LEN = 8  # give up on an unterminated escape past this many bytes
 _HISTORY_MAX = 1000  # per-session command-history cap (bounds long-session memory)
+# Per-line input cap (#347): a client that never sends CR/LF must not grow the
+# line buffer without bound. Real devices cap the edit buffer too (IOS ~256
+# chars); 4096 is far above any realistic CLI line — the longest byte-parity
+# golden line is 34 bytes — so the cap is unreachable for scrapers and the wire
+# stays byte-identical. Past the cap a byte is dropped unechoed (the editor's
+# "ignored, no bell" convention). Enforced at the single growth points
+# (`_LineEditor.insert` / the challenge answer buffer); `set_line` inflows are
+# themselves built from capped lines, so this is an abuse bound, not an exact
+# length contract.
+_LINE_MAX = 4096
 
 
 def _parse_escape(seq: bytes) -> str:
@@ -226,6 +236,8 @@ class _LineEditor:
         return self._line.decode("utf-8", errors="replace")
 
     def insert(self, byte: bytes) -> None:
+        if len(self._line) >= _LINE_MAX:
+            return  # line cap (#347): drop + no echo, real-device style
         if self._pos == len(self._line):
             self._send(byte)  # fast path: raw echo at end (byte-parity preserved)
             self._line += byte
@@ -509,10 +521,16 @@ async def _read_challenge_line(
                 del buf[-1:]
                 if echo:
                     transport.send(b"\b \b")  # erase one echoed char (confirm only)
+                    await transport.drain()
             continue
+        if len(buf) >= _LINE_MAX:
+            continue  # answer cap (#347): drop + no echo, same bound as the editor
         buf += byte
         if echo:
             transport.send(byte)
+            # Interactive echo backpressure (#347): flush before the next key so a
+            # client that never reads cannot grow the write buffer without bound.
+            await transport.drain()
 
 
 async def _run_challenge(
@@ -642,6 +660,12 @@ async def run_async_push_session(
                 if verdict != "pass":
                     if verdict != "consumed":
                         editor.apply_action(verdict)  # a completed action key
+                        # Interactive echo backpressure (#347): the redraw a
+                        # cursor/history action emits is flushed before the next
+                        # key, so a client that never reads cannot grow the write
+                        # buffer without bound. `drain` writes nothing (pacing
+                        # only), so the wire byte stream is untouched.
+                        await transport.drain()
                     continue  # escape consumed (collecting / applied / discarded)
 
             # Classify the byte against the shared terminator machine (#350): a NUL
@@ -699,12 +723,16 @@ async def run_async_push_session(
                     return
             elif editing and byte in (b"\x08", b"\x7f"):
                 editor.backspace()
+                await transport.drain()  # echo backpressure (#347), see above
             elif editing and byte == b"\t":
                 _complete(editor, shell, transport)
+                await transport.drain()  # echo backpressure (#347), see above
             else:
                 # Regular character: immediate raw echo at the line end
-                # (interactive latency + byte-parity unchanged).
+                # (interactive latency + byte-parity unchanged — `drain` writes
+                # nothing, it only paces a client that stopped reading, #347).
                 editor.insert(byte)
+                await transport.drain()
         except transport.io_errors as e:
             log.error("async_session [%s] client write error: %s", transport.name, e)
             return

--- a/simnos/plugins/servers/async_session.py
+++ b/simnos/plugins/servers/async_session.py
@@ -235,29 +235,37 @@ class _LineEditor:
     def line_text(self) -> str:
         return self._line.decode("utf-8", errors="replace")
 
-    def insert(self, byte: bytes) -> None:
+    def insert(self, byte: bytes) -> bool:
+        """Insert *byte* at the cursor; returns whether anything was echoed.
+
+        ``False`` = the byte was dropped at the ``_LINE_MAX`` cap (no echo), so
+        the caller can skip the backpressure drain for no-op input (#347).
+        """
         if len(self._line) >= _LINE_MAX:
-            return  # line cap (#347): drop + no echo, real-device style
+            return False  # line cap (#347): drop + no echo, real-device style
         if self._pos == len(self._line):
             self._send(byte)  # fast path: raw echo at end (byte-parity preserved)
             self._line += byte
             self._pos += 1
-            return
+            return True
         # Mid-line insert (only after a cursor move): echo the tail, then step back.
         self._line[self._pos : self._pos] = byte
         self._pos += 1
         tail = bytes(self._line[self._pos - 1 :])
         self._send(tail)
         self._send(b"\b" * (len(tail) - 1))
+        return True
 
-    def backspace(self) -> None:
+    def backspace(self) -> bool:
+        """Delete before the cursor; returns whether anything was echoed."""
         if self._pos == 0:
-            return
+            return False
         del self._line[self._pos - 1 : self._pos]
         self._pos -= 1
         tail = bytes(self._line[self._pos :])
         self._send(b"\b" + tail + b" ")  # move left, rewrite tail, clear the freed cell
         self._send(b"\b" * (len(tail) + 1))  # cursor back to the edit point
+        return True
 
     def delete(self) -> None:
         if self._pos >= len(self._line):
@@ -300,7 +308,17 @@ class _LineEditor:
         self._pos = len(self._line)
 
     def set_line(self, new: bytes) -> None:
-        """Replace the line (Tab completion)."""
+        """Replace the line (Tab completion).
+
+        An oversized replacement is refused as a no-op rather than truncated —
+        a cut command is a *different* command, so completing to it would
+        dispatch the wrong thing (#347, 1st round codex #1). This keeps the
+        ``_LINE_MAX`` bound intact for the one inflow that does not pass through
+        ``insert`` (completion candidates are canonical commands, not client
+        bytes; history / ``_saved`` re-entry is built from already-capped lines).
+        """
+        if len(new) > _LINE_MAX:
+            return
         self._replace_line(new)
 
     def history_prev(self) -> None:
@@ -724,8 +742,8 @@ async def run_async_push_session(
                 if result.close:
                     return
             elif editing and byte in (b"\x08", b"\x7f"):
-                editor.backspace()
-                await transport.drain()  # echo backpressure (#347), see above
+                if editor.backspace():
+                    await transport.drain()  # echo backpressure (#347), see above
             elif editing and byte == b"\t":
                 _complete(editor, shell, transport)
                 await transport.drain()  # echo backpressure (#347), see above
@@ -733,8 +751,11 @@ async def run_async_push_session(
                 # Regular character: immediate raw echo at the line end
                 # (interactive latency + byte-parity unchanged — `drain` writes
                 # nothing, it only paces a client that stopped reading, #347).
-                editor.insert(byte)
-                await transport.drain()
+                # The drain is gated on "echoed something" so a CR-less flood
+                # past the line cap costs no await per dropped byte (1st round
+                # codex #4).
+                if editor.insert(byte):
+                    await transport.drain()
         except transport.io_errors as e:
             log.error("async_session [%s] client write error: %s", transport.name, e)
             return

--- a/simnos/plugins/servers/async_session.py
+++ b/simnos/plugins/servers/async_session.py
@@ -497,7 +497,9 @@ async def _read_challenge_line(
     following ``_render_response`` supplies the answer line's newline (the
     main-loop held-echo principle), so exactly one ``\\r\\n`` reaches the wire per
     Enter. Returns ``(answer, next_skip_lf)``, or ``(None, skip_lf)`` on an EOF
-    (peer gone mid-challenge).
+    (peer gone mid-challenge). The answer shares the ``_LINE_MAX`` bound (#347):
+    past it a byte is dropped unechoed, while backspace and the terminating
+    CR/LF keep working.
     """
     buf = bytearray()
     esc = bytearray()

--- a/simnos/plugins/servers/async_session.py
+++ b/simnos/plugins/servers/async_session.py
@@ -152,10 +152,11 @@ _HISTORY_MAX = 1000  # per-session command-history cap (bounds long-session memo
 # chars); 4096 is far above any realistic CLI line — the longest byte-parity
 # golden line is 34 bytes — so the cap is unreachable for scrapers and the wire
 # stays byte-identical. Past the cap a byte is dropped unechoed (the editor's
-# "ignored, no bell" convention). Enforced at the single growth points
-# (`_LineEditor.insert` / the challenge answer buffer); `set_line` inflows are
-# themselves built from capped lines, so this is an abuse bound, not an exact
-# length contract.
+# "ignored, no bell" convention). Enforced at the client-byte growth points
+# (`_LineEditor.insert` / the challenge answer buffer) and at `set_line` (the
+# Tab-completion inflow that bypasses `insert` — an oversized replacement is
+# refused); history / `_saved` re-entry is built from already-capped lines, so
+# every inflow honours the bound.
 _LINE_MAX = 4096
 
 

--- a/tests/plugins/test_async_session.py
+++ b/tests/plugins/test_async_session.py
@@ -15,6 +15,7 @@ import pytest
 from simnos.core.resolved_command import ResolvedChallenge, ResolvedOutput, Transition
 from simnos.plugins.servers.async_session import (
     _CSI_ACTIONS,
+    _LINE_MAX,
     _consume_escape,
     _consume_terminator,
     _read_challenge_line,
@@ -78,6 +79,7 @@ class _FakeTransport:
         # (#307, the phantom-Enter keystone, codex 4th#4).
         self._chunks = list(chunks)
         self.out = bytearray()
+        self.drains = 0  # drain() call count — pins the echo backpressure sites (#347)
         self._fail_on = fail_on
         # page_rows() return value: None = paging off (the default, byte-identical
         # path); a positive int makes the driver page over-long bodies (#307).
@@ -106,6 +108,7 @@ class _FakeTransport:
         self.out += data
 
     async def drain(self) -> None:
+        self.drains += 1
         if self._fail_drain_on is not None and self._fail_drain_on in self.out:
             raise OSError("simulated drain failure")
 
@@ -309,6 +312,59 @@ def test_write_failure_ends_session():
     # Intro write succeeds, the response write raises -> driver returns (no crash).
     out = _drive(transport, _FakeShell())
     assert out.startswith(b"Custom SSH Shell\r\ndevice>show vlan")
+
+
+# ---------------------------------------------------------------- line buffer bound + echo backpressure (#347)
+def test_line_cap_truncates_input_and_echo():
+    """A CR-less byte flood stops accumulating AND echoing at `_LINE_MAX`; the
+    eventual CR dispatches the truncated line. Pins the #347 unbounded-line
+    bound; the cap (4096) is ~120x the longest golden line, so the scraper wire
+    never reaches this branch and byte parity is untouched."""
+    seen: list[str] = []
+
+    async def _dispatch(line: str):
+        seen.append(line)
+        return DispatchResult(body=None, prompt="device>", close=True, mode="user")
+
+    transport = _FakeTransport([b"a" * (_LINE_MAX + 100) + b"\r"])
+    asyncio.run(run_async_push_session(transport, _FakeShell(), _dispatch))
+    assert len(seen) == 1 and len(seen[0]) == _LINE_MAX  # excess bytes dropped
+    assert transport.out.count(b"a") == _LINE_MAX  # ...and never echoed
+
+
+def test_challenge_answer_cap():
+    """The challenge answer buffer shares the `_LINE_MAX` bound (#347): a CR-less
+    flood mid-challenge cannot grow the answer (nor its echo) without limit."""
+    transport = _FakeTransport([])
+    data = b"y" * (_LINE_MAX + 50) + b"\r"
+    stream = iter(data[i : i + 1] for i in range(len(data)))
+
+    async def _read_byte():
+        return next(stream, None)
+
+    entered, _skip = asyncio.run(_read_challenge_line(transport, _read_byte, False, echo=True))
+    assert entered is not None and len(entered) == _LINE_MAX
+    assert transport.out.count(b"y") == _LINE_MAX
+
+
+def test_interactive_echo_drains_per_key():
+    """Every interactive echo site is followed by a drain (#347): regular char,
+    backspace, Tab, escape action. A client that stops reading is paced by the
+    transport's backpressure instead of growing the user-space write buffer.
+    `drain` writes nothing, so the wire byte stream is unchanged."""
+    # intro(1) + 'a'(1) + 'b'(1) + backspace(1) + Tab(1) + Up action(1) + response(1)
+    transport = _FakeTransport([b"ab\x7f\t\x1b[A\r"])
+    _drive(transport, _FakeShell(), editing=True)
+    assert transport.drains == 7
+
+
+def test_scraper_path_drains_per_char():
+    """The non-editing (Telnet / scraper) char echo drains too — the #347 bound
+    is not gated on the editing flag."""
+    transport = _FakeTransport([b"hi\r"])
+    _drive(transport, _FakeShell())
+    # intro(1) + 'h'(1) + 'i'(1) + response(1)
+    assert transport.drains == 4
 
 
 def test_async_interactive_login_success_and_skip_lf():

--- a/tests/plugins/test_async_session.py
+++ b/tests/plugins/test_async_session.py
@@ -330,6 +330,73 @@ def test_line_cap_truncates_input_and_echo():
     asyncio.run(run_async_push_session(transport, _FakeShell(), _dispatch))
     assert len(seen) == 1 and len(seen[0]) == _LINE_MAX  # excess bytes dropped
     assert transport.out.count(b"a") == _LINE_MAX  # ...and never echoed
+    # Dropped bytes cost no drain either (1st round codex #4): intro(1) +
+    # one per accepted char (_LINE_MAX) + response(1).
+    assert transport.drains == _LINE_MAX + 2
+
+
+def test_line_cap_backspace_reopens_the_line():
+    """At the cap the line is still editable (real-device behaviour, 1st round
+    codex #2): backspace frees a byte, the next byte is accepted and echoed
+    again, and CR dispatches the edited line."""
+    seen: list[str] = []
+
+    async def _dispatch(line: str):
+        seen.append(line)
+        return DispatchResult(body=None, prompt="device>", close=True, mode="user")
+
+    flood = b"a" * (_LINE_MAX + 10) + b"\x7f" + b"b" + b"\r"
+    transport = _FakeTransport([flood])
+    asyncio.run(run_async_push_session(transport, _FakeShell(), _dispatch, editing=True))
+    assert len(seen[0]) == _LINE_MAX
+    assert seen[0].endswith("ab")  # freed cell refilled with the new byte
+    assert transport.out.count(b"b") == 1  # the replacement byte echoed
+
+
+def test_challenge_answer_cap_backspace_reopens():
+    """The challenge answer stays editable at its cap too (1st round codex #2):
+    backspace frees a byte and the next byte lands."""
+    transport = _FakeTransport([])
+    data = b"y" * (_LINE_MAX + 5) + b"\x08" + b"n" + b"\r"
+    stream = iter(data[i : i + 1] for i in range(len(data)))
+
+    async def _read_byte():
+        return next(stream, None)
+
+    entered, _skip = asyncio.run(_read_challenge_line(transport, _read_byte, False, echo=True))
+    assert entered is not None and len(entered) == _LINE_MAX
+    assert entered.endswith("yn")
+
+
+def test_challenge_answer_cap_echo_off_silent():
+    """echo=False (password) at the cap: the buffer is bounded and nothing at
+    all reaches the wire — no echo, no drain (1st round gemini #1)."""
+    transport = _FakeTransport([])
+    data = b"p" * (_LINE_MAX + 50) + b"\r"
+    stream = iter(data[i : i + 1] for i in range(len(data)))
+
+    async def _read_byte():
+        return next(stream, None)
+
+    entered, _skip = asyncio.run(_read_challenge_line(transport, _read_byte, False, echo=False))
+    assert entered is not None and len(entered) == _LINE_MAX
+    assert bytes(transport.out) == b""
+    assert transport.drains == 0
+
+
+def test_set_line_refuses_oversized_replacement():
+    """`set_line` (the Tab-completion inflow that bypasses `insert`) refuses an
+    oversized replacement as a no-op — truncating would complete to a
+    *different* command (1st round codex #1)."""
+    from simnos.plugins.servers.async_session import _LineEditor
+
+    sent = bytearray()
+    editor = _LineEditor(sent.extend)
+    editor.set_line(b"x" * (_LINE_MAX + 1))
+    assert editor.line_text == ""  # refused: line unchanged
+    assert bytes(sent) == b""  # ...and nothing echoed
+    editor.set_line(b"x" * _LINE_MAX)  # exactly at the cap is still accepted
+    assert len(editor.line_text) == _LINE_MAX
 
 
 def test_challenge_answer_cap():

--- a/tests/plugins/test_async_session.py
+++ b/tests/plugins/test_async_session.py
@@ -392,9 +392,12 @@ def test_set_line_refuses_oversized_replacement():
 
     sent = bytearray()
     editor = _LineEditor(sent.extend)
+    editor.insert(b"s")
+    editor.insert(b"h")
+    sent.clear()
     editor.set_line(b"x" * (_LINE_MAX + 1))
-    assert editor.line_text == ""  # refused: line unchanged
-    assert bytes(sent) == b""  # ...and nothing echoed
+    assert editor.line_text == "sh"  # refused: the existing line is preserved
+    assert bytes(sent) == b""  # ...and nothing echoed (no clear-on-reject either)
     editor.set_line(b"x" * _LINE_MAX)  # exactly at the cap is still accepted
     assert len(editor.line_text) == _LINE_MAX
 


### PR DESCRIPTION
🐙claude:

refs #347 項目 2 (BUG-MED、残項目。項目 1/3/4 は PR #354 で対応済。issue は v3→main まで OPEN 維持)

## 概要
per-session の入力行バッファ無制限成長と、対話 echo の backpressure 欠如を封鎖する。issue 指定の「軽設計」として byte-parity 非接触の論証を設計メモ (`design/20260730_202753`、ローカル) で pin してから実装した。

## 実装
- **`_LINE_MAX = 4096` cap**: `_LineEditor.insert` (client byte の単一成長点) / `set_line` (Tab 補完の迂回流入 — 超過置換は no-op 拒否、truncate は別コマンド化するため不採用) / challenge answer buf。超過 byte は drop + no echo (実機式)、**cap 到達後も backspace / CR は生存**
- **対話 echo 6 箇所に `await transport.drain()`**: char echo / backspace / Tab / escape action / challenge echo / challenge backspace erase。drain は「実際に echo した時のみ」に gate (cap 超過 flood が await を生まない)
- login path (`_async_read_line`) は #269 の明示 scope のため非接触

## byte-parity 非接触の論証 (設計メモの要旨)
1. cap 4096 は golden 最長送信行 34B の ~120 倍 — golden・現実の scraper のどの行も到達しない
2. drain は byte を 1 つも書かない (pacing のみ) — golden は byte 列比較
3. **byte-parity golden (SSH/Telnet/paging) 無変更で green** = 論証の機械的裏付け

## cross-review (設計メモ + code 2 round 収束)
- 1st: codex SHOULD FIX ×2 (set_line の cap 迂回 / cap 後の編集生存性テスト) + gemini/claude SUGGESTION → 全取り込み (codex#5 のみ reviewer split で理由付き不採用)
- 2nd: codex SUGGESTION (収束) → 定数コメント追従 + no-op テスト強化

## 検証
- test_async_session 70 passed (新規 9 テスト) / golden 13 passed 無変更 / full CI 相当 green (1282 passed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
