### PR TITLE
fix: hot-reload の cross-host 並行性ギャップ 3 件を封鎖 (#349)

### DIFF
--- a/simnos/core/host.py
+++ b/simnos/core/host.py
@@ -7,7 +7,6 @@ It also validates the host object using pydantic.
 from dataclasses import dataclass
 import logging
 import os
-import threading
 from typing import TYPE_CHECKING
 
 from simnos.core.nos import Nos
@@ -154,11 +153,10 @@ class Host:
             # The async server plugins (AsyncSshServer + telnetlib3 TelnetServer)
             # reach the SimNOS-owned shared loop through this back reference.
             simnos=self.simnos,
-            # Per-host hot-reload lock (#281 / D6): one lock per host, threaded
-            # to every session's shell so concurrent dev hot-reloads (and a new
-            # connection's self-build) serialize on the host-shared `nos`. A
-            # no-op cost in production (env off = no reload, no self-build).
-            reload_lock=threading.Lock(),
+            # The hot-reload lock is no longer threaded through here: it lives
+            # on the Nos itself (`nos.reload_lock`, #349) so hosts sharing one
+            # registered instance serialize on the same lock, and the shell
+            # reads it straight off `nos`.
             # Environment-wide pager page height (#307 / P3-4). sys_config always
             # materializes `paging.default_rows` (ModelPaging default 24), so the
             # `.get` chain is a defensive fallback only.

--- a/simnos/core/nos.py
+++ b/simnos/core/nos.py
@@ -6,6 +6,7 @@ import importlib.util
 import inspect
 import logging
 import os
+import threading
 import types
 from typing import TYPE_CHECKING
 
@@ -146,6 +147,17 @@ class Nos:
         self.name = name
         self.auth: str | None = None
         self.device = None
+        # Hot-reload serialization lock (#349): guards THIS instance's mutable
+        # reload state (the `_NOS_RELOAD_ATTRS` set — `device` / `handlers` /
+        # `sources` / `resolved_platform` / ...). The lock lives on the Nos
+        # because that is the resource it protects: a pre-registered instance
+        # shared by several hosts (`SimNOS(plugins=[Nos(...)])`) hands every
+        # host/shell the SAME lock, closing the cross-host mutate race the #281
+        # per-host locks could not (each host used to mint its own). Note that
+        # `auth` is also rewritten by a reload but servers read it once at
+        # construction — hot-reloading `auth:` never affects a live server (an
+        # intentional no-op, #349 / Decision 5).
+        self.reload_lock: threading.Lock = threading.Lock()
         # Every path handed to `from_file`, in load order — diagnostics only.
         # A py-only Nos keeps the constructor-default name (the module's legacy
         # ``NAME`` constant is no longer read, #317 P-4), so the A3-required

--- a/simnos/core/nos.py
+++ b/simnos/core/nos.py
@@ -126,6 +126,13 @@ class Nos:
     (``platforms/<name>/`` -> `resolved_platform`); a py module supplies the
     device class + the ``handler:`` namespace only. The legacy py dict form
     (``commands`` / scalar prompts / ``from_dict``) was removed.
+
+    Hot-reload contract (#349): `reload_lock` (owned by each instance) is what
+    every shell serializes reloads and self-builds on, so an instance shared by
+    several hosts (``SimNOS(plugins=[Nos(...)])``) is mutated under one lock.
+    ``auth`` is rewritten by a reload like the other state, but servers read it
+    once at construction — hot-reloading ``auth:`` never affects a live server
+    (an intentional no-op).
     """
 
     def __init__(
@@ -150,13 +157,9 @@ class Nos:
         # Hot-reload serialization lock (#349): guards THIS instance's mutable
         # reload state (the `_NOS_RELOAD_ATTRS` set — `device` / `handlers` /
         # `sources` / `resolved_platform` / ...). The lock lives on the Nos
-        # because that is the resource it protects: a pre-registered instance
-        # shared by several hosts (`SimNOS(plugins=[Nos(...)])`) hands every
-        # host/shell the SAME lock, closing the cross-host mutate race the #281
-        # per-host locks could not (each host used to mint its own). Note that
-        # `auth` is also rewritten by a reload but servers read it once at
-        # construction — hot-reloading `auth:` never affects a live server (an
-        # intentional no-op, #349 / Decision 5).
+        # because that is the resource it protects — see the class docstring's
+        # hot-reload contract (shared instance -> shared lock; the #281 per-host
+        # locks let two hosts mutate one instance under different locks).
         self.reload_lock: threading.Lock = threading.Lock()
         # Every path handed to `from_file`, in load order — diagnostics only.
         # A py-only Nos keeps the constructor-default name (the module's legacy

--- a/simnos/core/platform_loader.py
+++ b/simnos/core/platform_loader.py
@@ -15,9 +15,9 @@ boundary just above.
 """
 
 from dataclasses import replace
-import functools
 import glob
 import os
+import threading
 
 from jinja2 import TemplateSyntaxError
 import yaml
@@ -48,24 +48,86 @@ PLATFORM_META_FILENAME = "platform.yaml"
 COMMANDS_SUBDIR = "commands"
 
 
-@functools.cache
-def load_platform_dir(path: str) -> ResolvedPlatform:
-    """Load an A3 platform directory into a `ResolvedPlatform`.
+# Explicit generation-guarded cache for `load_platform_dir` (#349 / 案B4).
+# `functools.cache` could not stop a parse that STARTED before an invalidation
+# from committing its (possibly stale) result afterwards — a `Host.start` build
+# racing a hot reload could permanently re-poison the cache, and worse, hand the
+# stale parse to its own Nos/shell. The generation counter closes both: a
+# result whose parse straddled an invalidation is neither cached nor returned
+# (the loader retries at the current generation). `_CACHE_LOCK` guards only the
+# dict/counter operations (a few instructions) — parsing runs outside it, so
+# 100-host startup parallelism is untouched. Lock ordering is one-way by
+# construction: callers may hold a `Nos.reload_lock` when loading, and nothing
+# under `_CACHE_LOCK` ever takes a Nos lock.
+_CACHE: dict[str, ResolvedPlatform] = {}
+_CACHE_LOCK = threading.Lock()
+_cache_generation = 0
 
-    Cached by `path` (#264 / D6): the result is immutable and
+
+def invalidate_platform_cache() -> None:
+    """Drop every cached platform parse and start a new generation (#349).
+
+    Called by the hot-reload path (once per reload batch that contains an A3
+    dir target) instead of the former ``cache_clear()``. Bumping the generation
+    makes any in-flight `load_platform_dir` parse that began before this call
+    retry instead of committing/returning a result that may predate the change
+    being reloaded. Global by design: it also evicts unrelated platforms and
+    rejects their in-flight commits (they simply re-parse on next access) — the
+    conservative direction, and no worse than the previous global
+    ``cache_clear()``; a per-path generation was rejected for simplicity
+    (#349 / 案B4).
+    """
+    global _cache_generation
+    with _CACHE_LOCK:
+        _CACHE.clear()
+        _cache_generation += 1
+
+
+def load_platform_dir(path: str) -> ResolvedPlatform:
+    """Load an A3 platform directory into a `ResolvedPlatform`, cached by path.
+
+    The cache (#264 / D6): the result is immutable and
     ``configuration_file``-independent (per-host state lives on the `BaseDevice`,
     built separately), so every host / replica of a platform shares one parse
     instead of re-reading platform.yaml + the command files on each
     ``Host.start()``. Consumers MUST treat the result read-only (the shell
     layers it into a fresh dict, never mutating it). The hot-reload path calls
-    `load_platform_dir.cache_clear()` so a changed file is re-read; an unbounded
-    `functools.cache` is fine at ~50 platforms (an LRU bound is a future option
-    if platform count grows — D6).
+    `invalidate_platform_cache()` so a changed file is re-read; an unbounded
+    cache is fine at ~50 platforms (an LRU bound is a future option if platform
+    count grows — D6).
+
+    Guarantees (#349 / 案B4): a miss whose parse straddles an invalidation is
+    neither cached nor returned — the loop retries at the current generation.
+    Concurrent same-generation misses converge on the first committed entry
+    (``setdefault`` — same generation, same object). A hit linearizes at its
+    locked read: a load overlapping an invalidation may legitimately return the
+    just-previous generation, which the per-Nos reload lock (not this cache)
+    orders against same-Nos mutation.
 
     :param path: directory holding ``platform.yaml`` and ``commands/``
     :raises ValueError: on any schema, reference, or render violation — the
         loud load-time boundary that replaces v2's silent fallbacks (#264 / D5)
     """
+    while True:
+        with _CACHE_LOCK:
+            generation = _cache_generation
+            cached = _CACHE.get(path)
+        if cached is not None:
+            return cached
+        result = _load_platform_dir_uncached(path)
+        with _CACHE_LOCK:
+            if _cache_generation == generation:
+                return _CACHE.setdefault(path, result)
+        # An invalidation landed mid-parse: this result may predate the change
+        # that triggered it. Retry — returning it would let the caller's
+        # Nos/shell install a stale generation AFTER another host committed the
+        # fresh one (#349, design review codex 2nd#1). Termination: reloads are
+        # rare dev events; the generation stabilizes as soon as edits and the
+        # per-shell watcher catch-up stop.
+
+
+def _load_platform_dir_uncached(path: str) -> ResolvedPlatform:
+    """The uncached parse body of `load_platform_dir` (split for #349 / 案B4)."""
     meta = _load_platform_meta(os.path.join(path, PLATFORM_META_FILENAME))
     modes = _build_modes(meta)
     commands_dir = os.path.join(path, COMMANDS_SUBDIR)

--- a/simnos/plugins/servers/async_server_base.py
+++ b/simnos/plugins/servers/async_server_base.py
@@ -83,7 +83,6 @@ class AsyncServerBase:
         render_config: "HostRenderConfig | None" = None,
         simnos: "SimNOS | None" = None,
         page_default_rows: int = 24,
-        reload_lock: "threading.Lock | None" = None,
     ) -> None:
         self.nos: Nos = nos
         self.nos_inventory_config: dict = nos_inventory_config
@@ -94,10 +93,10 @@ class AsyncServerBase:
         # `shell_configuration` (which is inventory-derived) so the environment-wide
         # sys_config value flows through a distinct, non-colliding path.
         self.page_default_rows: int = page_default_rows
-        # Per-host hot-reload lock (#281 / D6), threaded to every session's shell
-        # so concurrent dev hot-reloads serialize on the host-shared `nos`. None in
-        # direct/test construction -> each shell falls back to a private lock.
-        self._reload_lock: threading.Lock | None = reload_lock
+        # The hot-reload lock is no longer plumbed through the server: it lives
+        # on the Nos (`nos.reload_lock`, #349) and the shell reads it straight
+        # off its `nos` — hosts sharing one registered instance serialize on the
+        # same lock by construction.
         self._render_config: HostRenderConfig | None = render_config
         # Normalize the merged platform once at Host.start (per-host invariant,
         # surfaces malformed data at startup rather than on the first connection).
@@ -325,7 +324,6 @@ class AsyncServerBase:
             resolved_platform=self._shared_platform,
             render_config=self._render_config,
             page_default_rows=self.page_default_rows,
-            reload_lock=self._reload_lock,
             # Credentials for `challenge:` commands (#338): username renders the
             # sub-prompt, password/secret are the expected answers. Kept off
             # `shell_configuration` (inventory CMDShellConfig, forbid-validated) as

--- a/simnos/plugins/servers/ssh_server_asyncssh.py
+++ b/simnos/plugins/servers/ssh_server_asyncssh.py
@@ -212,7 +212,6 @@ class AsyncSshServer(AsyncServerBase):
         render_config: "HostRenderConfig | None" = None,
         simnos: "SimNOS | None" = None,
         page_default_rows: int = 24,
-        reload_lock: "threading.Lock | None" = None,
     ) -> None:
         super().__init__(
             shell,
@@ -229,7 +228,6 @@ class AsyncSshServer(AsyncServerBase):
             render_config=render_config,
             simnos=simnos,
             page_default_rows=page_default_rows,
-            reload_lock=reload_lock,
         )
         self.ssh_banner: str = ssh_banner
         self._authorized_keys = self._load_authorized_keys(authorized_keys)

--- a/simnos/plugins/servers/telnet_server.py
+++ b/simnos/plugins/servers/telnet_server.py
@@ -29,7 +29,6 @@ import contextlib
 import ipaddress
 import logging
 import socket
-import threading
 from typing import TYPE_CHECKING
 
 import telnetlib3
@@ -132,7 +131,6 @@ class TelnetServer(AsyncServerBase):
         render_config: "HostRenderConfig | None" = None,
         simnos: "SimNOS | None" = None,
         page_default_rows: int = 24,
-        reload_lock: "threading.Lock | None" = None,
     ) -> None:
         super().__init__(
             shell,
@@ -149,7 +147,6 @@ class TelnetServer(AsyncServerBase):
             render_config=render_config,
             simnos=simnos,
             page_default_rows=page_default_rows,
-            reload_lock=reload_lock,
         )
         self.banner: str = banner
         if not _is_loopback(address):

--- a/simnos/plugins/shell/cmd_shell.py
+++ b/simnos/plugins/shell/cmd_shell.py
@@ -17,7 +17,12 @@ from jinja2 import TemplateSyntaxError
 from simnos.core.command_contract import CommandHandler
 from simnos.core.nos import Nos
 from simnos.core.overlay_loader import resolve_overlay
-from simnos.core.platform_loader import invalidate_platform_cache, resolve_modes, resolve_transitions
+from simnos.core.platform_loader import (
+    PLATFORM_META_FILENAME,
+    invalidate_platform_cache,
+    resolve_modes,
+    resolve_transitions,
+)
 from simnos.core.pydantic_models import ModelInventoryCommand, NosPluginConfig
 from simnos.core.resolved_command import (
     NO_OUTPUT,
@@ -684,7 +689,10 @@ class CMDShell:
         parse window the old per-host `cache_clear()` left (#281 / D6 follow-up).
         """
         with self._reload_lock:
-            if any(os.path.isdir(target) for target in reload_targets):
+            # "Is an A3 dir" = carries a platform.yaml, not merely "is a dir" —
+            # a future package-form py plugin (a dir with __init__.py) must not
+            # trigger a cache invalidation (code review gemini#3).
+            if any(os.path.isfile(os.path.join(target, PLATFORM_META_FILENAME)) for target in reload_targets):
                 invalidate_platform_cache()
             for target in reload_targets:
                 snapshot_attrs = {attr: getattr(self.nos, attr) for attr in self._NOS_RELOAD_ATTRS}

--- a/simnos/plugins/shell/cmd_shell.py
+++ b/simnos/plugins/shell/cmd_shell.py
@@ -5,6 +5,7 @@ Custom shell class to interact with NOS.
 from dataclasses import dataclass, replace
 import hashlib
 import logging
+import os
 import random
 import string
 import threading
@@ -16,7 +17,7 @@ from jinja2 import TemplateSyntaxError
 from simnos.core.command_contract import CommandHandler
 from simnos.core.nos import Nos
 from simnos.core.overlay_loader import resolve_overlay
-from simnos.core.platform_loader import load_platform_dir, resolve_modes, resolve_transitions
+from simnos.core.platform_loader import invalidate_platform_cache, resolve_modes, resolve_transitions
 from simnos.core.pydantic_models import ModelInventoryCommand, NosPluginConfig
 from simnos.core.resolved_command import (
     NO_OUTPUT,
@@ -339,7 +340,6 @@ class CMDShell:
         resolved_platform=None,
         render_config=None,
         page_default_rows=24,
-        reload_lock=None,
         username=None,
         password=None,
         secret=None,
@@ -391,14 +391,18 @@ class CMDShell:
         # connection (true non-determinism, the realism opt-in; D6). Seeded
         # selection uses `_stable_hash` instead, not this RNG.
         self._connection_rng = random.Random()  # noqa: S311 — variant pick, not cryptographic
-        # Per-host shared reload lock (#281 / D6): serializes the executor-thread
-        # `reload_commands` against both a concurrent reload (another session of
-        # this host) and this `__init__`'s self-build read below, all of which
-        # touch the host-shared `self.nos`. The server injects one lock per host
-        # (`Host.start` -> server kwarg); a direct construction / test gets a
-        # private fallback. Established BEFORE the self-build so the read is
-        # already protected.
-        self._reload_lock: threading.Lock = reload_lock or threading.Lock()
+        # Per-Nos shared reload lock (#281 / D6, ownership moved in #349):
+        # serializes the executor-thread `reload_commands` against both a
+        # concurrent reload (another session — possibly of ANOTHER host sharing
+        # a registered Nos) and this `__init__`'s self-build read below, all of
+        # which touch the shared `self.nos`. The lock lives on the Nos itself
+        # (`nos.reload_lock`) so every host/shell of one instance serializes on
+        # the same lock — the former per-host injection let two hosts mutate a
+        # shared registered Nos under different locks (#349 gap a). The
+        # `getattr` fallback exists only for non-Nos test fakes; a real `Nos`
+        # always owns the lock. Established BEFORE the self-build so the read
+        # is already protected.
+        self._reload_lock: threading.Lock = getattr(nos, "reload_lock", None) or threading.Lock()
         # The merged platform is per-host invariant (base_prompt is the host name,
         # nos/inventory are shared), so the server normalizes it once at
         # Host.start and passes it to every connection's shell (#264 / Impact —
@@ -407,17 +411,23 @@ class CMDShell:
         # fails loudly here (the #172 lenient fallback is gone, #264 / D5). In
         # hot-reload dev mode the shared snapshot is None (`build_shared_platform`
         # returns None), so every connection self-builds from the live shared
-        # `nos` — done under the reload lock so a concurrent executor reload does
-        # not mutate `nos` mid-read (#281 / D6, gemini#1). `_build_shell` runs on
-        # the shared event-loop thread, so a new connection contending here with an
-        # in-flight reload briefly blocks the loop until the reload releases the
-        # lock — dev-only (production passes a non-None shared platform, skipping
-        # this branch entirely) and accepted as the cost of the no-mid-mutation
-        # guarantee (#281 / Risks, 1st code review claude#1).
+        # `nos` — build AND install both run under the reload lock so a
+        # concurrent executor reload neither mutates `nos` mid-read nor swaps
+        # `nos.device` between the build and `_apply_platform`'s device pin
+        # (#281 / D6, gemini#1; the pin-pairing window is #349 gap c, design
+        # review gemini 2nd#3). `_build_shell` runs on the shared event-loop
+        # thread, so a new connection contending here with an in-flight reload
+        # briefly blocks the loop until the reload releases the lock — for a
+        # registered Nos shared across hosts that block now spans every sharing
+        # host's I/O (#349) — dev-only (production passes a non-None shared
+        # platform, skipping this branch entirely) and accepted as the cost of
+        # the no-mid-mutation guarantee (#281 / Risks, 1st code review claude#1).
         if resolved_platform is None:
             with self._reload_lock:
                 resolved_platform = build_resolved_platform(self.nos, self._inventory_commands, self._render_config)
-        self._apply_platform(resolved_platform)
+                self._apply_platform(resolved_platform)
+        else:
+            self._apply_platform(resolved_platform)
         # Hot-reload watcher state (#281 / D1, D2, D5). Built ONLY in dev hot-reload
         # mode so production (env off) does no walk and holds no snapshot — the
         # per-shell baseline replaces the #274 process-global consume-once snapshot.
@@ -498,6 +508,15 @@ class CMDShell:
         # The pager prompt rides with the platform so a hot reload that swaps it
         # also refreshes the `--More--` string (#307 / P3-4).
         self.more_prompt = platform.more_prompt
+        # Per-shell device pin (#349 gap c): the device generation is captured
+        # in the SAME exception-free commit as the command table, so
+        # `_invoke_handler` always runs a handler against the device it was
+        # installed with. A sibling session's reload swapping `nos.device`
+        # cannot hand this shell a "new device × old handler" mismatch pair —
+        # this shell answers with its own (old, consistent) generation until
+        # its OWN precmd reload re-installs. Callers hold the reload lock in
+        # every mutating context (self-build / `_rebuild`), pairing the read.
+        self._device = self.nos.device
 
     @property
     def paging_disabled(self) -> bool:
@@ -640,9 +659,12 @@ class CMDShell:
         atomic, so live `self.commands` is never touched by a failed reload
         (2nd round codex #1).
 
-        The A3 platform parse is cached by `load_platform_dir`; drop that cache
-        first so a reload re-reads the changed files instead of the stale parse
-        (#264 / D6 cache bypass). No-op for py module reloads.
+        The A3 platform parse is cached by `load_platform_dir`; invalidate that
+        cache first so a reload re-reads the changed files instead of the stale
+        parse (#264 / D6 cache bypass). Only when the batch actually contains an
+        A3 dir target — a `.py` module reload never touches the parse cache, so
+        invalidating for it would only force other hosts into pointless
+        re-parses (#349, design review codex#3).
 
         `reload_targets` are reload units (A3 platform dirs / `.py` modules), not
         raw changed files (#274 / D1). Per-platform watch (#281 / D2) means a
@@ -650,17 +672,20 @@ class CMDShell:
         cannot contain a sibling platform — the #274 ownership filter is gone as
         unreachable dead code (#281 / D7).
 
-        Serialized by the per-host `_reload_lock` (#281 / D6): `self.nos` is shared
-        by every session of this host, and dispatch runs on a bounded executor, so
-        two sessions could otherwise reload concurrently and corrupt the shared
-        `nos` (or race this method against a new connection's self-build read in
-        `__init__`). The whole body — including `load_platform_dir.cache_clear()` —
-        is under the lock: clearing the cache outside it would let session B drop
-        the cache while session A is still populating from it, re-opening the stale
-        parse window the cache bypass closes (#281 / D6, claude#2/codex#2).
+        Serialized by the per-Nos `_reload_lock` (#281 / D6, ownership moved to
+        the Nos in #349): `self.nos` is shared by every session of every host
+        using this Nos, and dispatch runs on a bounded executor, so two sessions
+        could otherwise reload concurrently and corrupt the shared `nos` (or
+        race this method against a new connection's self-build in `__init__`).
+        Cross-host cache consistency is NOT this lock's job any more: the
+        generation guard inside `load_platform_dir` guarantees a parse that
+        straddled an invalidation is neither cached nor returned (#349 / 案B4),
+        so another Nos's concurrent reload can no longer re-open the stale
+        parse window the old per-host `cache_clear()` left (#281 / D6 follow-up).
         """
         with self._reload_lock:
-            load_platform_dir.cache_clear()
+            if any(os.path.isdir(target) for target in reload_targets):
+                invalidate_platform_cache()
             for target in reload_targets:
                 snapshot_attrs = {attr: getattr(self.nos, attr) for attr in self._NOS_RELOAD_ATTRS}
                 try:
@@ -898,8 +923,12 @@ class CMDShell:
         log line — same shape as the crash boundary in the caller, so broken
         plugin code never puts garbage on the wire (#317 / P-2).
         """
+        # `self._device`, not `self.nos.device` (#349 gap c): the pin captured in
+        # `_apply_platform`'s commit keeps this handler paired with the device
+        # generation it was installed with, immune to a sibling reload swapping
+        # the shared `nos.device` mid-session.
         ret = handler(
-            self.nos.device,
+            self._device,
             base_prompt=self.base_prompt,
             current_mode=self.current_mode,
             current_prompt=self.prompt,

--- a/simnos/plugins/shell/cmd_shell.py
+++ b/simnos/plugins/shell/cmd_shell.py
@@ -17,12 +17,7 @@ from jinja2 import TemplateSyntaxError
 from simnos.core.command_contract import CommandHandler
 from simnos.core.nos import Nos
 from simnos.core.overlay_loader import resolve_overlay
-from simnos.core.platform_loader import (
-    PLATFORM_META_FILENAME,
-    invalidate_platform_cache,
-    resolve_modes,
-    resolve_transitions,
-)
+from simnos.core.platform_loader import invalidate_platform_cache, resolve_modes, resolve_transitions
 from simnos.core.pydantic_models import ModelInventoryCommand, NosPluginConfig
 from simnos.core.resolved_command import (
     NO_OUTPUT,
@@ -689,10 +684,14 @@ class CMDShell:
         parse window the old per-host `cache_clear()` left (#281 / D6 follow-up).
         """
         with self._reload_lock:
-            # "Is an A3 dir" = carries a platform.yaml, not merely "is a dir" —
-            # a future package-form py plugin (a dir with __init__.py) must not
-            # trigger a cache invalidation (code review gemini#3).
-            if any(os.path.isfile(os.path.join(target, PLATFORM_META_FILENAME)) for target in reload_targets):
+            # `isdir` is the A3 classifier ON PURPOSE — it matches the reload
+            # target contract ("A3 platform dir or .py file", same dispatch as
+            # `Nos.from_file`) and, unlike a platform.yaml-presence probe, still
+            # invalidates when the meta file was DELETED: that reload must
+            # re-parse, fail loudly and roll back, not "succeed" off a stale
+            # cache hit (code review codex 2nd#1; a package-form py plugin is
+            # out of contract until `Nos.from_file` itself learns the type).
+            if any(os.path.isdir(target) for target in reload_targets):
                 invalidate_platform_cache()
             for target in reload_targets:
                 snapshot_attrs = {attr: getattr(self.nos, attr) for attr in self._NOS_RELOAD_ATTRS}

--- a/tests/core/test_platform_loader.py
+++ b/tests/core/test_platform_loader.py
@@ -462,24 +462,31 @@ class TestLoadCache:
         assert load_platform_dir(str(root)) is returned  # cached at current generation
 
     def test_same_generation_concurrent_miss_converges_on_winner(self, tmp_path, monkeypatch):
-        """Same-generation concurrent misses converge on the first committed
-        entry (`setdefault`): identity is per generation, not per caller
-        (design review codex 2nd#2). Simulated by having a second load commit
-        the winner while the first is still parsing (no generation change)."""
+        """Same-generation concurrent misses converge on one identity via the
+        real protocol (design review codex 2nd#2, code review codex#1): two
+        threads both take the miss path, a barrier proves their parses overlap
+        outside `_CACHE_LOCK`, and both public-API returns are the SAME object
+        (the `setdefault` winner) — no lock-external cache poking."""
+        import threading
+
         import simnos.core.platform_loader as loader_mod
 
         root, commands = _platform(tmp_path)
         _cmd(commands, "x.yaml", "command: x\ntype: ntc\noutput: x.txt\n", output_files={"x.txt": "v\n"})
         real_uncached = loader_mod._load_platform_dir_uncached
-        winners: list = []
+        barrier = threading.Barrier(2, timeout=5)
 
-        def parse_with_concurrent_winner(path):
+        def overlapping_parse(path):
             result = real_uncached(path)
-            if not winners:  # emulate a sibling miss committing first (same generation)
-                winner = real_uncached(path)
-                winners.append(winner)
-                loader_mod._CACHE[path] = winner
+            barrier.wait()  # both threads are mid-miss before either commits
             return result
 
-        monkeypatch.setattr(loader_mod, "_load_platform_dir_uncached", parse_with_concurrent_winner)
-        assert load_platform_dir(str(root)) is winners[0]  # loser adopts the winner
+        monkeypatch.setattr(loader_mod, "_load_platform_dir_uncached", overlapping_parse)
+        results: list = []
+        threads = [threading.Thread(target=lambda: results.append(load_platform_dir(str(root)))) for _ in range(2)]
+        for t in threads:
+            t.start()
+        for t in threads:
+            t.join(timeout=10)
+        assert len(results) == 2
+        assert results[0] is results[1]  # both callers got the committed winner

--- a/tests/core/test_platform_loader.py
+++ b/tests/core/test_platform_loader.py
@@ -9,15 +9,15 @@ isolation.
 
 import pytest
 
-from simnos.core.platform_loader import load_platform_dir
+from simnos.core.platform_loader import invalidate_platform_cache, load_platform_dir
 
 
 @pytest.fixture(autouse=True)
 def _clear_loader_cache():
     """Isolate the module-level load_platform_dir cache between tests."""
-    load_platform_dir.cache_clear()
+    invalidate_platform_cache()
     yield
-    load_platform_dir.cache_clear()
+    invalidate_platform_cache()
 
 
 def _write(path, content):
@@ -431,5 +431,55 @@ class TestLoadCache:
         root, commands = _platform(tmp_path)
         _cmd(commands, "x.yaml", "command: x\ntype: ntc\noutput: x.txt\n", output_files={"x.txt": "v\n"})
         first = load_platform_dir(str(root))
-        load_platform_dir.cache_clear()
+        invalidate_platform_cache()
         assert load_platform_dir(str(root)) is not first
+
+    def test_generation_guard_discards_parse_straddling_invalidation(self, tmp_path, monkeypatch):
+        """#349 / 案B4 keystone: a miss whose parse straddles an invalidation is
+        neither cached nor returned — the caller gets the retried, current-
+        generation result (design review codex 2nd#1). Pinned by injecting an
+        invalidation mid-parse on the first attempt only."""
+        import simnos.core.platform_loader as loader_mod
+
+        root, commands = _platform(tmp_path)
+        _cmd(commands, "x.yaml", "command: x\ntype: ntc\noutput: x.txt\n", output_files={"x.txt": "v\n"})
+        real_uncached = loader_mod._load_platform_dir_uncached
+        results: list = []
+
+        def parse_with_midflight_invalidate(path):
+            result = real_uncached(path)
+            results.append(result)
+            if len(results) == 1:  # first (straddling) parse only
+                invalidate_platform_cache()
+            return result
+
+        monkeypatch.setattr(loader_mod, "_load_platform_dir_uncached", parse_with_midflight_invalidate)
+        returned = load_platform_dir(str(root))
+        # The straddling first parse was discarded: the caller received the
+        # retry's result, and that (not the stale one) is what got cached.
+        assert len(results) == 2
+        assert returned is results[1] and returned is not results[0]
+        assert load_platform_dir(str(root)) is returned  # cached at current generation
+
+    def test_same_generation_concurrent_miss_converges_on_winner(self, tmp_path, monkeypatch):
+        """Same-generation concurrent misses converge on the first committed
+        entry (`setdefault`): identity is per generation, not per caller
+        (design review codex 2nd#2). Simulated by having a second load commit
+        the winner while the first is still parsing (no generation change)."""
+        import simnos.core.platform_loader as loader_mod
+
+        root, commands = _platform(tmp_path)
+        _cmd(commands, "x.yaml", "command: x\ntype: ntc\noutput: x.txt\n", output_files={"x.txt": "v\n"})
+        real_uncached = loader_mod._load_platform_dir_uncached
+        winners: list = []
+
+        def parse_with_concurrent_winner(path):
+            result = real_uncached(path)
+            if not winners:  # emulate a sibling miss committing first (same generation)
+                winner = real_uncached(path)
+                winners.append(winner)
+                loader_mod._CACHE[path] = winner
+            return result
+
+        monkeypatch.setattr(loader_mod, "_load_platform_dir_uncached", parse_with_concurrent_winner)
+        assert load_platform_dir(str(root)) is winners[0]  # loser adopts the winner

--- a/tests/core/test_platform_loader.py
+++ b/tests/core/test_platform_loader.py
@@ -427,7 +427,7 @@ class TestLoadCache:
         second = load_platform_dir(str(root))
         assert first is second  # shared parse, not re-read
 
-    def test_cache_clear_forces_reparse(self, tmp_path):
+    def test_invalidate_forces_reparse(self, tmp_path):
         root, commands = _platform(tmp_path)
         _cmd(commands, "x.yaml", "command: x\ntype: ntc\noutput: x.txt\n", output_files={"x.txt": "v\n"})
         first = load_platform_dir(str(root))

--- a/tests/core/test_platform_loader.py
+++ b/tests/core/test_platform_loader.py
@@ -488,5 +488,6 @@ class TestLoadCache:
             t.start()
         for t in threads:
             t.join(timeout=10)
+            assert not t.is_alive()  # a hung protocol fails here, not downstream
         assert len(results) == 2
         assert results[0] is results[1]  # both callers got the committed winner

--- a/tests/plugins/test_cmd_shell_a3.py
+++ b/tests/plugins/test_cmd_shell_a3.py
@@ -546,6 +546,44 @@ class TestA3HotReload:
         assert blocked
         assert built  # proceeds once the lock is released
 
+    def test_init_self_build_applies_under_lock(self, tmp_path, monkeypatch):
+        """The self-build holds `nos.reload_lock` THROUGH `_apply_platform`
+        (#349 gap c, design review gemini 2nd#3): a spy asserts the lock is
+        held when the install (incl. the device pin) runs, so reverting to the
+        old "build under lock, apply outside" shape fails here — the blocking
+        test alone cannot tell the two apart (code review codex#2)."""
+        platform_dir = _a3_platform(tmp_path)
+        nos_obj = Nos(filename=str(platform_dir))
+        held_at_apply: list[bool] = []
+        orig_apply = CMDShell._apply_platform
+
+        def spying_apply(self, platform):
+            held_at_apply.append(nos_obj.reload_lock.locked())
+            return orig_apply(self, platform)
+
+        monkeypatch.setattr(CMDShell, "_apply_platform", spying_apply)
+        CMDShell(nos=nos_obj, nos_inventory_config={}, base_prompt="R1", is_running=threading.Event())
+        assert held_at_apply == [True]
+
+    def test_failed_reload_keeps_table_and_device_pair(self, tmp_path, monkeypatch):
+        """A failed reload rolls back the nos AND leaves the shell's table +
+        device pin as the old, consistent pair (#349 rollback×pin contract,
+        code review codex#2)."""
+        platform_dir = _a3_platform(tmp_path)
+        nos_obj = Nos(filename=str(platform_dir))
+        shell = CMDShell(nos=nos_obj, nos_inventory_config={}, base_prompt="R1", is_running=threading.Event())
+        old_commands = shell.commands
+        old_device = shell._device
+
+        def broken_from_file(target):
+            raise ValueError("simulated broken reload target")
+
+        monkeypatch.setattr(nos_obj, "from_file", broken_from_file)
+        shell.reload_commands([str(platform_dir)])  # error is logged, not raised
+        assert shell.commands is old_commands
+        assert shell._device is old_device
+        assert nos_obj.device is old_device  # nos side rolled back / untouched too
+
     def test_device_pin_survives_sibling_reload(self, tmp_path):
         """`_invoke_handler` runs against the per-shell device pin, not the live
         `nos.device` (#349 gap c): a sibling reload swapping the shared device
@@ -577,14 +615,21 @@ class TestA3HotReload:
         platform_dir = _a3_platform(tmp_path)
         nos_obj = Nos(filename=str(platform_dir))
         shell = CMDShell(nos=nos_obj, nos_inventory_config={}, base_prompt="R1", is_running=threading.Event())
-        calls: list[int] = []
-        monkeypatch.setattr("simnos.plugins.shell.cmd_shell.invalidate_platform_cache", lambda: calls.append(1))
+        events: list[str] = []
+        monkeypatch.setattr("simnos.plugins.shell.cmd_shell.invalidate_platform_cache", lambda: events.append("inv"))
+        orig_from_file = nos_obj.from_file
+        monkeypatch.setattr(nos_obj, "from_file", lambda target: (events.append("load"), orig_from_file(target))[1])
         # .py-only batch: the gate is evaluated before the load, so even this
         # missing module (whose load fails and rolls back) proves the skip.
         shell.reload_commands([str(tmp_path / "missing_mod.py")])
-        assert calls == []
-        shell.reload_commands([str(platform_dir)])
-        assert calls == [1]  # once per batch, not per target
+        assert events == ["load"]
+        events.clear()
+        # A batch with TWO A3 dir targets: invalidate fires once, BEFORE the
+        # first load — not per target (code review codex#3; a second copy of the
+        # platform under another root keeps the shared nos state consistent).
+        second_dir = _a3_platform(tmp_path / "second")
+        shell.reload_commands([str(platform_dir), str(second_dir)])
+        assert events == ["inv", "load", "load"]
 
     def test_env_off_builds_no_watcher_state(self, tmp_path, monkeypatch):
         """Production (env off): `__init__` builds no watcher state and does no walk (#281 / D2, D5).

--- a/tests/plugins/test_cmd_shell_a3.py
+++ b/tests/plugins/test_cmd_shell_a3.py
@@ -575,14 +575,20 @@ class TestA3HotReload:
         old_commands = shell.commands
         old_device = shell._device
 
-        def broken_from_file(target):
+        def mutating_broken_from_file(target):
+            # Mutate BEFORE raising so the test identifies the snapshot-restore
+            # loop itself — a no-mutation fake would pass even with the rollback
+            # deleted (code review codex 2nd#2).
+            nos_obj.device = object()
+            nos_obj.resolved_platform = None
             raise ValueError("simulated broken reload target")
 
-        monkeypatch.setattr(nos_obj, "from_file", broken_from_file)
+        monkeypatch.setattr(nos_obj, "from_file", mutating_broken_from_file)
         shell.reload_commands([str(platform_dir)])  # error is logged, not raised
         assert shell.commands is old_commands
         assert shell._device is old_device
-        assert nos_obj.device is old_device  # nos side rolled back / untouched too
+        assert nos_obj.device is old_device  # partial mutation rolled back
+        assert nos_obj.resolved_platform is not None  # ...for every snapshot attr
 
     def test_device_pin_survives_sibling_reload(self, tmp_path):
         """`_invoke_handler` runs against the per-shell device pin, not the live
@@ -630,6 +636,22 @@ class TestA3HotReload:
         second_dir = _a3_platform(tmp_path / "second")
         shell.reload_commands([str(platform_dir), str(second_dir)])
         assert events == ["inv", "load", "load"]
+
+    def test_meta_deletion_invalidates_and_rolls_back(self, tmp_path):
+        """Deleting platform.yaml (a normal watcher event) still invalidates the
+        cache, so the reload re-parses, FAILS loudly and rolls back — instead of
+        "succeeding" off a stale cache hit (code review codex 2nd#1; this is why
+        the A3 gate is `isdir`, not a platform.yaml-presence probe)."""
+        platform_dir = _a3_platform(tmp_path)
+        nos_obj = Nos(filename=str(platform_dir))
+        shell = CMDShell(nos=nos_obj, nos_inventory_config={}, base_prompt="R1", is_running=threading.Event())
+        old_commands = shell.commands
+        old_device = shell._device
+        (platform_dir / "platform.yaml").unlink()
+        shell.reload_commands([str(platform_dir)])  # parse failure is logged + rolled back
+        assert shell.commands is old_commands  # NOT silently "reloaded" from stale cache
+        assert shell._device is old_device
+        assert nos_obj.resolved_platform is not None  # rollback restored the nos
 
     def test_env_off_builds_no_watcher_state(self, tmp_path, monkeypatch):
         """Production (env off): `__init__` builds no watcher state and does no walk (#281 / D2, D5).

--- a/tests/plugins/test_cmd_shell_a3.py
+++ b/tests/plugins/test_cmd_shell_a3.py
@@ -574,6 +574,7 @@ class TestA3HotReload:
         shell = CMDShell(nos=nos_obj, nos_inventory_config={}, base_prompt="R1", is_running=threading.Event())
         old_commands = shell.commands
         old_device = shell._device
+        old_resolved = nos_obj.resolved_platform
 
         def mutating_broken_from_file(target):
             # Mutate BEFORE raising so the test identifies the snapshot-restore
@@ -588,7 +589,7 @@ class TestA3HotReload:
         assert shell.commands is old_commands
         assert shell._device is old_device
         assert nos_obj.device is old_device  # partial mutation rolled back
-        assert nos_obj.resolved_platform is not None  # ...for every snapshot attr
+        assert nos_obj.resolved_platform is old_resolved  # the exact snapshot restored
 
     def test_device_pin_survives_sibling_reload(self, tmp_path):
         """`_invoke_handler` runs against the per-shell device pin, not the live
@@ -647,11 +648,12 @@ class TestA3HotReload:
         shell = CMDShell(nos=nos_obj, nos_inventory_config={}, base_prompt="R1", is_running=threading.Event())
         old_commands = shell.commands
         old_device = shell._device
+        old_resolved = nos_obj.resolved_platform
         (platform_dir / "platform.yaml").unlink()
         shell.reload_commands([str(platform_dir)])  # parse failure is logged + rolled back
         assert shell.commands is old_commands  # NOT silently "reloaded" from stale cache
         assert shell._device is old_device
-        assert nos_obj.resolved_platform is not None  # rollback restored the nos
+        assert nos_obj.resolved_platform is old_resolved  # rollback restored the exact snapshot
 
     def test_env_off_builds_no_watcher_state(self, tmp_path, monkeypatch):
         """Production (env off): `__init__` builds no watcher state and does no walk (#281 / D2, D5).

--- a/tests/plugins/test_cmd_shell_a3.py
+++ b/tests/plugins/test_cmd_shell_a3.py
@@ -476,20 +476,22 @@ class TestA3HotReload:
         assert shell2.commands["show version"].output.render("R1") == "Shared V2\n"
 
     def test_concurrent_reload_same_lock_no_corruption(self, tmp_path):
-        """Two sessions reloading concurrently under the shared host lock stay consistent (#281 / D6).
+        """Two sessions reloading concurrently share the Nos-owned lock and stay consistent (#281 / D6, #349).
 
-        Injects ONE lock into both shells (as `Host.start` does per host) and
-        fires `reload_commands` from two threads at a barrier. Per-shell fallback
-        locks would not serialize the shared-`nos` mutation, so the explicit
-        single lock is what this pins; both shells must end consistent and the
-        shared nos uncorrupted.
+        Since #349 the lock is not injected: both shells derive it from the SAME
+        shared `nos.reload_lock`, which is exactly what serializes the shared-
+        `nos` mutation (two hosts of one registered Nos included). Fires
+        `reload_commands` from two threads at a barrier; both shells must end
+        consistent and the shared nos uncorrupted.
         """
         platform_dir = _a3_platform(tmp_path)
         nos_obj = Nos(filename=str(platform_dir))
-        lock = threading.Lock()
         common = {"nos_inventory_config": {}, "base_prompt": "R1"}
-        shell1 = CMDShell(nos=nos_obj, is_running=threading.Event(), reload_lock=lock, **common)
-        shell2 = CMDShell(nos=nos_obj, is_running=threading.Event(), reload_lock=lock, **common)
+        shell1 = CMDShell(nos=nos_obj, is_running=threading.Event(), **common)
+        shell2 = CMDShell(nos=nos_obj, is_running=threading.Event(), **common)
+        # The #349 gap-a contract: same Nos -> same lock, no injection needed.
+        assert shell1._reload_lock is nos_obj.reload_lock
+        assert shell2._reload_lock is nos_obj.reload_lock
         _write(platform_dir / "commands" / "show_version.txt", "Concurrent\n")
         barrier = threading.Barrier(2)
         errors: list[BaseException] = []
@@ -512,16 +514,17 @@ class TestA3HotReload:
         assert nos_obj.name == "cisco_ios"  # shared nos not corrupted by the concurrent reloads
 
     def test_init_self_build_acquires_reload_lock(self, tmp_path):
-        """A new connection's self-build runs under the reload lock (#281 / D6, gemini#1).
+        """A new connection's self-build runs under the Nos-owned reload lock (#281 / D6, #349).
 
         When `resolved_platform` is None (hot-reload mode) the `__init__` builds
-        from the shared `nos`; that read must hold the per-host lock so a
-        concurrent executor reload cannot mutate `nos` mid-read. Holding the lock
-        in the main thread must therefore block a shell construction until release.
+        from the shared `nos` AND installs it (`_apply_platform`, incl. the
+        device pin) under `nos.reload_lock`, so a concurrent executor reload can
+        neither mutate `nos` mid-read nor swap the device between build and pin
+        (#349 gap c, design review gemini 2nd#3). Holding the Nos's own lock in
+        the main thread must therefore block a shell construction until release.
         """
         platform_dir = _a3_platform(tmp_path)
         nos_obj = Nos(filename=str(platform_dir))
-        lock = threading.Lock()
         built: list[CMDShell] = []
 
         def _build():
@@ -531,11 +534,10 @@ class TestA3HotReload:
                     nos_inventory_config={},
                     base_prompt="R1",
                     is_running=threading.Event(),
-                    reload_lock=lock,
                 )
             )
 
-        with lock:
+        with nos_obj.reload_lock:
             t = threading.Thread(target=_build)
             t.start()
             t.join(timeout=0.3)
@@ -543,6 +545,46 @@ class TestA3HotReload:
         t.join(timeout=2)
         assert blocked
         assert built  # proceeds once the lock is released
+
+    def test_device_pin_survives_sibling_reload(self, tmp_path):
+        """`_invoke_handler` runs against the per-shell device pin, not the live
+        `nos.device` (#349 gap c): a sibling reload swapping the shared device
+        cannot pair a new device with this shell's old handlers. The shell's OWN
+        `_rebuild` is what moves it to the new generation."""
+        platform_dir = _a3_platform(tmp_path)
+        nos_obj = Nos(filename=str(platform_dir))
+        shell = CMDShell(nos=nos_obj, nos_inventory_config={}, base_prompt="R1", is_running=threading.Event())
+        pinned = shell._device
+        assert pinned is nos_obj.device  # pin captured at install
+        sentinel = object()
+        nos_obj.device = sentinel  # a sibling session's reload swaps the shared device
+        seen: list = []
+
+        def handler(device, **_kwargs):
+            seen.append(device)
+            return "ok"
+
+        shell._invoke_handler(handler, "show test")
+        assert seen == [pinned]  # old, generation-consistent device — not the sentinel
+        shell._rebuild()  # own reload: installs the new generation (table + device pair)
+        assert shell._device is sentinel
+
+    def test_reload_invalidates_cache_only_for_a3_dir_targets(self, tmp_path, monkeypatch):
+        """`reload_commands` invalidates the parse cache once per batch and only
+        when the batch contains an A3 dir target — a `.py`-only reload never
+        touches `load_platform_dir` and must not force other hosts into
+        re-parses (#349 / 案B4, design review codex#3 / gemini#2)."""
+        platform_dir = _a3_platform(tmp_path)
+        nos_obj = Nos(filename=str(platform_dir))
+        shell = CMDShell(nos=nos_obj, nos_inventory_config={}, base_prompt="R1", is_running=threading.Event())
+        calls: list[int] = []
+        monkeypatch.setattr("simnos.plugins.shell.cmd_shell.invalidate_platform_cache", lambda: calls.append(1))
+        # .py-only batch: the gate is evaluated before the load, so even this
+        # missing module (whose load fails and rolls back) proves the skip.
+        shell.reload_commands([str(tmp_path / "missing_mod.py")])
+        assert calls == []
+        shell.reload_commands([str(platform_dir)])
+        assert calls == [1]  # once per batch, not per target
 
     def test_env_off_builds_no_watcher_state(self, tmp_path, monkeypatch):
         """Production (env off): `__init__` builds no watcher state and does no walk (#281 / D2, D5).


### PR DESCRIPTION
🐙claude:

refs #349 (dev-only、#281 続編。issue は v3→main まで OPEN 維持)

## 概要
hot-reload (`SIMNOS_RELOAD_COMMANDS`) の cross-host 並行性ギャップ 3 件を封鎖する。設計 doc (`design/20260730_205508`、ローカル) を design cross-review 3 round で確定してから実装した (案A1' / B4 / C1')。実運用 (env off) は非接触。

## 3 ギャップと対策
- **(a) 共有登録 Nos を別 lock で mutate** → **案A1'**: lock を `Nos.reload_lock` として instance 所有に移し、Host→server→shell の kwarg 配管を撤去。shell は `nos.reload_lock` 直読 — 共有 instance の全 host/shell が同一 lock を構造的に共有 (別 lock 注入という mis-wire クラスを型ごと排除)
- **(b) process-global cache を per-host lock で clear** → **案B4**: `functools.cache` を明示 dict + **世代 guard + retry** に置換。invalidate を跨いだ parse は cache にも**呼び出し元にも**渡らず現世代で retry (stale の恒久汚染と遅延 commit を両方封鎖)。同世代 concurrent miss は `setdefault` 先着 winner。invalidate は reload batch 先頭 1 回・A3 dir target を含む時のみ
- **(c) dispatch が `nos.device` を lock なし読み → 世代 mismatch** → **案C1'**: `_apply_platform` の exception-free commit block で `self._device` を per-shell pin し `_invoke_handler` は pin を使用。`__init__` self-build の lock 範囲を install まで拡張 — 「旧 handler × 新 device」ペアが self-build 経路含め構造的に消滅
- 意味論 pin: `auth:` の hot-reload は稼働中 server に no-op (構築時 1 回読み、Nos class docstring に明記)

## cross-review
- **design 3 round**: 1st (gemini MUST FIX ×3 + codex/claude SHOULD FIX → kwarg 撤去 / 明示 cache 化 / lock 範囲拡張へ改訂) → 2nd (codex MUST FIX: 世代 guard に retry が必要 → 改訂) → 3rd (codex SUGGESTION、収束)
- **code 3 round**: 1st (codex SHOULD FIX ×3 = 並行テストの実 protocol 化) → 2nd (codex MUST FIX: 1st で取り込んだ isfile gate が platform.yaml 削除時の regression → isdir へ差し戻し + 削除テスト) → 3rd (codex SUGGESTION、収束)

## 検証
- 新規テスト 8 本 (世代 guard mid-flight invalidate / 2-thread Barrier concurrent winner / lock identity / self-build lock spy / device pin / rollback×pin / invalidate 条件 / meta 削除 regression)
- full CI 相当 green (1281 passed) / byte-parity golden 無変更 (wire 非接触)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
