### PR TITLE
fix: 未認証 login 経路の入力 bound — _LINE_MAX cap + echo drain + login deadline (#269)

### DIFF
--- a/simnos/plugins/servers/async_session.py
+++ b/simnos/plugins/servers/async_session.py
@@ -164,9 +164,10 @@ _LINE_MAX = 4096
 # line reads. A client that never sends CR/LF must not hold an unauthenticated
 # session open forever. Real devices bound the login response the same way, so
 # the budget is natural for fidelity too, and interactive tests complete in
-# milliseconds — orders of magnitude below it. Exceeding it is folded into
+# milliseconds — orders of magnitude below it. Running out is folded into
 # "authentication failed" rather than raised, so it joins the existing
-# close-on-failure path at both call sites.
+# close-on-failure path at both call sites; a `TimeoutError` the transport itself
+# raised still propagates (see `async_interactive_login`).
 _LOGIN_DEADLINE = 60
 
 
@@ -508,7 +509,9 @@ async def _emit_paged(
     return skip_lf
 
 
-# --------------------------------------------------------------- credential readers
+# ------------------------------------------------- credential reader helpers (shared)
+# Used by both credential readers: `_read_challenge_line` just below (#338/#347)
+# and `_async_read_line`, the pre-auth login reader further down (#269).
 #: Longest client-supplied credential fragment echoed into a log record. The cap
 #: lets a username run to `_LINE_MAX`, and a failed login logs it, so clip it
 #: rather than spilling 4 KB of attacker text into the operator's log (#269).

--- a/simnos/plugins/servers/async_session.py
+++ b/simnos/plugins/servers/async_session.py
@@ -509,13 +509,31 @@ async def _emit_paged(
 
 
 # --------------------------------------------------------------- credential readers
-async def _accept_capped_byte(transport: AsyncPushTransport, buf: bytearray, byte: bytes, *, echo: bool) -> None:
+#: Longest client-supplied credential fragment echoed into a log record. The cap
+#: lets a username run to `_LINE_MAX`, and a failed login logs it, so clip it
+#: rather than spilling 4 KB of attacker text into the operator's log (#269).
+_LOG_CLIP = 64
+
+
+def _clip(text: str) -> str:
+    """Shorten *text* for a log record (see ``_LOG_CLIP``)."""
+    return text if len(text) <= _LOG_CLIP else text[:_LOG_CLIP] + "…"
+
+
+async def _accept_capped_byte(transport: AsyncPushTransport, buf: bytearray, byte: bytes, *, echo: bool) -> bool:
     """Buffer one client byte under the ``_LINE_MAX`` cap, echoing what it keeps.
 
     The single inflow gate behind both credential readers — the challenge answer
     (#347) and the in-band login (#269) — so the bound and the echo backpressure
     stay identical across them, the way ``_consume_terminator`` keeps their
     terminator handling identical (#350).
+
+    Returns whether the byte was kept. ``False`` means the line was already at the
+    cap, which the login reader turns into an authentication failure rather than
+    letting a truncated credential compare equal to a shorter configured one
+    (#269, codex 1st#3). The challenge answer reader ignores the result and keeps
+    truncating — that is the behaviour #347 shipped, and changing it is a separate
+    decision from this bound.
 
     Past the cap the byte is dropped unechoed (the editor's "ignored, no bell"
     convention) and costs no ``drain`` await, so a CR-less flood is free. The
@@ -524,11 +542,12 @@ async def _accept_capped_byte(transport: AsyncPushTransport, buf: bytearray, byt
     wire byte stream is unchanged — it only paces a client that stopped reading.
     """
     if len(buf) >= _LINE_MAX:
-        return
+        return False  # at the cap: drop it, echo nothing, and spend no drain await
     buf += byte
     if echo:
         transport.send(byte)
         await transport.drain()
+    return True
 
 
 # --------------------------------------------------------------------- challenge (#338)
@@ -788,21 +807,27 @@ async def run_async_push_session(
             return
 
 
-async def _async_read_line(transport: AsyncPushTransport, *, echo: bool, skip_lf: bool) -> tuple[str, bool]:
+async def _async_read_line(transport: AsyncPushTransport, *, echo: bool, skip_lf: bool) -> tuple[str, bool, bool]:
     """Read one line byte-by-byte for the in-band login.
 
-    Returns ``(line without trailing CR/LF, next_skip_lf)``; a CR sets
+    Returns ``(line without trailing CR/LF, next_skip_lf, overflowed)``; a CR sets
     ``next_skip_lf=True`` so the next read consumes the LF half of a CR LF pair.
     Reads one byte per ``recv`` (login is short and not perf-critical, so this
     avoids a leftover-buffer between the two reads). EOF returns the partial line.
     The credential is capped at ``_LINE_MAX`` and the echo is drained per byte
     (#269), matching the post-auth editor and challenge reader.
+
+    ``overflowed`` reports that bytes were dropped at the cap, so the caller can
+    refuse the credential instead of comparing a truncated one (#269, codex
+    1st#3): without it, an over-long input whose first ``_LINE_MAX`` bytes match a
+    configured credential of exactly that length would authenticate.
     """
     buf = bytearray()  # bytearray, not bytes: amortised O(1) append (#269)
+    overflowed = False
     while True:
         byte = await transport.recv(1)
         if not byte:  # EOF
-            return buf.decode("utf-8", errors="replace"), False
+            return buf.decode("utf-8", errors="replace"), False, overflowed
         # Shared terminator machine (#350): a NUL is always dropped (never echoed
         # nor buffered into the credential), and the LF half of a CR LF is
         # consumed via the carried skip_lf. It runs ahead of the cap below, so a
@@ -813,8 +838,9 @@ async def _async_read_line(transport: AsyncPushTransport, *, echo: bool, skip_lf
         if event == "line":
             if echo:
                 transport.send(b"\r\n")
-            return buf.decode("utf-8", errors="replace"), skip_lf
-        await _accept_capped_byte(transport, buf, byte, echo=echo)
+            return buf.decode("utf-8", errors="replace"), skip_lf, overflowed
+        if not await _accept_capped_byte(transport, buf, byte, echo=echo):
+            overflowed = True
 
 
 async def async_interactive_login(
@@ -837,19 +863,25 @@ async def async_interactive_login(
     here rather than at the call sites so every caller — current and future —
     inherits it; a timeout returns ``(False, False)``, which drops into the
     close-on-failed-login path the callers already have.
+
+    ``asyncio.timeout`` is used over ``wait_for`` so ``expired()`` can tell the
+    deadline apart from a ``TimeoutError`` the transport itself raised — the
+    builtin is an ``OSError`` subclass, so a socket ETIMEDOUT surfaces as one too
+    (claude 1st#2). A transport-origin one is re-raised for the caller's existing
+    I/O handler rather than mislabelled as the login deadline.
     """
     try:
-        return await asyncio.wait_for(
-            _interactive_login_body(
+        async with asyncio.timeout(_LOGIN_DEADLINE) as budget:
+            return await _interactive_login_body(
                 transport,
                 username,
                 password,
                 user_prompt=user_prompt,
                 pass_prompt=pass_prompt,
-            ),
-            _LOGIN_DEADLINE,
-        )
+            )
     except TimeoutError:
+        if not budget.expired():
+            raise  # transport I/O timeout, not our deadline
         log.warning(
             "async_session [%s] login deadline exceeded (%ss), closing session",
             transport.name,
@@ -875,16 +907,19 @@ async def _interactive_login_body(
     backpressure point.
     """
     transport.send(user_prompt)
-    entered_user, skip_lf = await _async_read_line(transport, echo=True, skip_lf=False)
+    entered_user, skip_lf, user_over = await _async_read_line(transport, echo=True, skip_lf=False)
     transport.send(pass_prompt)
-    entered_pass, skip_lf = await _async_read_line(transport, echo=False, skip_lf=skip_lf)
+    entered_pass, skip_lf, pass_over = await _async_read_line(transport, echo=False, skip_lf=skip_lf)
     transport.send(b"\r\n")
     await transport.drain()
-    authenticated = entered_user == username and entered_pass == password
+    # An over-long credential is refused outright (#269): comparing the truncated
+    # prefix would let a longer input authenticate against a configured value of
+    # exactly _LINE_MAX bytes.
+    authenticated = not (user_over or pass_over) and entered_user == username and entered_pass == password
     log.debug(
         "async_session.async_interactive_login [%s] %s for user %s",
         transport.name,
         "succeeded" if authenticated else "failed",
-        entered_user,
+        _clip(entered_user),
     )
     return authenticated, skip_lf

--- a/simnos/plugins/servers/async_session.py
+++ b/simnos/plugins/servers/async_session.py
@@ -153,16 +153,17 @@ _HISTORY_MAX = 1000  # per-session command-history cap (bounds long-session memo
 # chars); 4096 is far above any realistic CLI line — the longest byte-parity
 # golden line is 34 bytes — so the cap is unreachable for scrapers and the wire
 # stays byte-identical. Past the cap a byte is dropped unechoed (the editor's
-# "ignored, no bell" convention). Enforced at the client-byte growth points
-# (`_LineEditor.insert`, the challenge answer buffer and the pre-auth login read)
-# and at `set_line` (the Tab-completion inflow that bypasses `insert` — an
-# oversized replacement is refused); history / `_saved` re-entry is built from
+# "ignored, no bell" convention). Enforced at the client-byte growth points —
+# `_LineEditor.insert` for the edited line, `_accept_capped_byte` for both
+# credential readers (challenge answer #347 / pre-auth login #269) — and at
+# `set_line` (the Tab-completion inflow that bypasses `insert` — an oversized
+# replacement is refused); history / `_saved` re-entry is built from
 # already-capped lines, so every inflow honours the bound.
 _LINE_MAX = 4096
 # Total wall-clock budget for one in-band login (#269): both prompts and both
 # line reads. A client that never sends CR/LF must not hold an unauthenticated
 # session open forever. Real devices bound the login response the same way, so
-# the cap is natural for fidelity too, and interactive tests complete in
+# the budget is natural for fidelity too, and interactive tests complete in
 # milliseconds — orders of magnitude below it. Exceeding it is folded into
 # "authentication failed" rather than raised, so it joins the existing
 # close-on-failure path at both call sites.
@@ -507,6 +508,29 @@ async def _emit_paged(
     return skip_lf
 
 
+# --------------------------------------------------------------- credential readers
+async def _accept_capped_byte(transport: AsyncPushTransport, buf: bytearray, byte: bytes, *, echo: bool) -> None:
+    """Buffer one client byte under the ``_LINE_MAX`` cap, echoing what it keeps.
+
+    The single inflow gate behind both credential readers — the challenge answer
+    (#347) and the in-band login (#269) — so the bound and the echo backpressure
+    stay identical across them, the way ``_consume_terminator`` keeps their
+    terminator handling identical (#350).
+
+    Past the cap the byte is dropped unechoed (the editor's "ignored, no bell"
+    convention) and costs no ``drain`` await, so a CR-less flood is free. The
+    caller keeps reading either way: the terminator machine runs ahead of this,
+    so a capped line still submits on CR/LF. ``drain`` writes nothing, so the
+    wire byte stream is unchanged — it only paces a client that stopped reading.
+    """
+    if len(buf) >= _LINE_MAX:
+        return
+    buf += byte
+    if echo:
+        transport.send(byte)
+        await transport.drain()
+
+
 # --------------------------------------------------------------------- challenge (#338)
 async def _read_challenge_line(
     transport: AsyncPushTransport,
@@ -553,14 +577,7 @@ async def _read_challenge_line(
                     transport.send(b"\b \b")  # erase one echoed char (confirm only)
                     await transport.drain()
             continue
-        if len(buf) >= _LINE_MAX:
-            continue  # answer cap (#347): drop + no echo, same bound as the editor
-        buf += byte
-        if echo:
-            transport.send(byte)
-            # Interactive echo backpressure (#347): flush before the next key so a
-            # client that never reads cannot grow the write buffer without bound.
-            await transport.drain()
+        await _accept_capped_byte(transport, buf, byte, echo=echo)
 
 
 async def _run_challenge(
@@ -797,15 +814,7 @@ async def _async_read_line(transport: AsyncPushTransport, *, echo: bool, skip_lf
             if echo:
                 transport.send(b"\r\n")
             return buf.decode("utf-8", errors="replace"), skip_lf
-        if len(buf) >= _LINE_MAX:
-            continue  # credential cap (#269): drop + no echo, same bound as the editor
-        buf += byte
-        if echo:
-            transport.send(byte)
-            # Echo backpressure (#269): flush before the next byte so a client
-            # that never reads cannot grow the write buffer without bound. Past
-            # the cap nothing is echoed, so a CR-less flood costs no await.
-            await transport.drain()
+        await _accept_capped_byte(transport, buf, byte, echo=echo)
 
 
 async def async_interactive_login(
@@ -831,7 +840,7 @@ async def async_interactive_login(
     """
     try:
         return await asyncio.wait_for(
-            _async_interactive_login(
+            _interactive_login_body(
                 transport,
                 username,
                 password,
@@ -849,7 +858,7 @@ async def async_interactive_login(
         return False, False
 
 
-async def _async_interactive_login(
+async def _interactive_login_body(
     transport: AsyncPushTransport,
     username: str,
     password: str,

--- a/simnos/plugins/servers/async_session.py
+++ b/simnos/plugins/servers/async_session.py
@@ -20,6 +20,7 @@ executor-agnostic (and unit-testable with fakes):
   bounded executor and returns the :class:`DispatchResult`.
 """
 
+import asyncio
 from collections import deque
 from collections.abc import Awaitable, Callable
 import logging
@@ -153,11 +154,19 @@ _HISTORY_MAX = 1000  # per-session command-history cap (bounds long-session memo
 # golden line is 34 bytes — so the cap is unreachable for scrapers and the wire
 # stays byte-identical. Past the cap a byte is dropped unechoed (the editor's
 # "ignored, no bell" convention). Enforced at the client-byte growth points
-# (`_LineEditor.insert` / the challenge answer buffer) and at `set_line` (the
-# Tab-completion inflow that bypasses `insert` — an oversized replacement is
-# refused); history / `_saved` re-entry is built from already-capped lines, so
-# every inflow honours the bound.
+# (`_LineEditor.insert`, the challenge answer buffer and the pre-auth login read)
+# and at `set_line` (the Tab-completion inflow that bypasses `insert` — an
+# oversized replacement is refused); history / `_saved` re-entry is built from
+# already-capped lines, so every inflow honours the bound.
 _LINE_MAX = 4096
+# Total wall-clock budget for one in-band login (#269): both prompts and both
+# line reads. A client that never sends CR/LF must not hold an unauthenticated
+# session open forever. Real devices bound the login response the same way, so
+# the cap is natural for fidelity too, and interactive tests complete in
+# milliseconds — orders of magnitude below it. Exceeding it is folded into
+# "authentication failed" rather than raised, so it joins the existing
+# close-on-failure path at both call sites.
+_LOGIN_DEADLINE = 60
 
 
 def _parse_escape(seq: bytes) -> str:
@@ -769,15 +778,18 @@ async def _async_read_line(transport: AsyncPushTransport, *, echo: bool, skip_lf
     ``next_skip_lf=True`` so the next read consumes the LF half of a CR LF pair.
     Reads one byte per ``recv`` (login is short and not perf-critical, so this
     avoids a leftover-buffer between the two reads). EOF returns the partial line.
+    The credential is capped at ``_LINE_MAX`` and the echo is drained per byte
+    (#269), matching the post-auth editor and challenge reader.
     """
-    buf = b""
+    buf = bytearray()  # bytearray, not bytes: amortised O(1) append (#269)
     while True:
         byte = await transport.recv(1)
         if not byte:  # EOF
             return buf.decode("utf-8", errors="replace"), False
         # Shared terminator machine (#350): a NUL is always dropped (never echoed
         # nor buffered into the credential), and the LF half of a CR LF is
-        # consumed via the carried skip_lf.
+        # consumed via the carried skip_lf. It runs ahead of the cap below, so a
+        # capped line still terminates on CR/LF.
         event, skip_lf = _consume_terminator(byte, skip_lf, transport.nul_resets_skip_lf)
         if event == "drop":
             continue
@@ -785,9 +797,15 @@ async def _async_read_line(transport: AsyncPushTransport, *, echo: bool, skip_lf
             if echo:
                 transport.send(b"\r\n")
             return buf.decode("utf-8", errors="replace"), skip_lf
+        if len(buf) >= _LINE_MAX:
+            continue  # credential cap (#269): drop + no echo, same bound as the editor
+        buf += byte
         if echo:
             transport.send(byte)
-        buf += byte
+            # Echo backpressure (#269): flush before the next byte so a client
+            # that never reads cannot grow the write buffer without bound. Past
+            # the cap nothing is echoed, so a CR-less flood costs no await.
+            await transport.drain()
 
 
 async def async_interactive_login(
@@ -805,6 +823,41 @@ async def async_interactive_login(
     skip_lf)``; ``skip_lf`` is forwarded to ``run_async_push_session`` as
     ``initial_skip_lf`` so it consumes the trailing LF/NUL left by the final CR of
     the password line.
+
+    The whole exchange is bounded by ``_LOGIN_DEADLINE`` (#269). The budget lives
+    here rather than at the call sites so every caller — current and future —
+    inherits it; a timeout returns ``(False, False)``, which drops into the
+    close-on-failed-login path the callers already have.
+    """
+    try:
+        return await asyncio.wait_for(
+            _async_interactive_login(
+                transport,
+                username,
+                password,
+                user_prompt=user_prompt,
+                pass_prompt=pass_prompt,
+            ),
+            _LOGIN_DEADLINE,
+        )
+    except TimeoutError:
+        log.warning(
+            "async_session [%s] login deadline exceeded (%ss), closing session",
+            transport.name,
+            _LOGIN_DEADLINE,
+        )
+        return False, False
+
+
+async def _async_interactive_login(
+    transport: AsyncPushTransport,
+    username: str,
+    password: str,
+    *,
+    user_prompt: bytes,
+    pass_prompt: bytes,
+) -> tuple[bool, bool]:
+    """Body of :func:`async_interactive_login`, run under its deadline.
 
     Each prompt is ``send``-buffered without an explicit ``drain``; the prompt
     still reaches the client because the following ``await _async_read_line``

--- a/tests/plugins/test_async_session.py
+++ b/tests/plugins/test_async_session.py
@@ -584,9 +584,7 @@ def test_async_login_deadline_folds_into_failed_auth(monkeypatch):
 
     async def _run():
         transport = _HangingTransport([])
-        return await async_interactive_login(
-            transport, "admin", "secret", user_prompt=b"User: ", pass_prompt=b"Pass: "
-        )
+        return await async_interactive_login(transport, "admin", "secret", user_prompt=b"User: ", pass_prompt=b"Pass: ")
 
     ok, skip_lf = asyncio.run(_run())
     assert ok is False

--- a/tests/plugins/test_async_session.py
+++ b/tests/plugins/test_async_session.py
@@ -597,6 +597,30 @@ class _HangingTransport(_FakeTransport):
         raise AssertionError("unreachable")  # pragma: no cover
 
 
+class _FloodTransport(_FakeTransport):
+    """Transport that answers every read with a non-terminator byte (#269 deadline).
+
+    The ``sleep(0)`` models the real readers, which suspend once their buffer
+    empties (``StreamReader.read`` awaits ``_wait_for_data``) — that suspension is
+    what lets the deadline's timer run. A fake returning bytes with no suspension
+    at all would spin forever, which is a property of the fake, not of the
+    transports this bounds; the live end-to-end pin is
+    ``test_telnet_server.py::test_preauth_flood_is_closed_at_the_deadline``
+    (codex 1st#1).
+    """
+
+    async def recv(self, n: int) -> bytes:
+        await asyncio.sleep(0)
+        return b"a"  # never a terminator
+
+
+class _TimingOutTransport(_FakeTransport):
+    """Transport that raises ``TimeoutError`` itself, as a socket ETIMEDOUT does."""
+
+    async def recv(self, n: int) -> bytes:
+        raise TimeoutError("simulated socket ETIMEDOUT")
+
+
 @pytest.mark.timeout(30)  # a lost deadline must fail fast here, not stall the run
 def test_async_login_deadline_folds_into_failed_auth(monkeypatch):
     """A client that never answers is cut loose at `_LOGIN_DEADLINE`, and the
@@ -620,19 +644,6 @@ def test_async_login_deadline_bounds_a_capped_flood(monkeypatch):
     ends the session (#269) — the two bounds are complementary, not redundant."""
     monkeypatch.setattr("simnos.plugins.servers.async_session._LOGIN_DEADLINE", 0.05)
 
-    class _FloodTransport(_FakeTransport):
-        async def recv(self, n: int) -> bytes:
-            # The `sleep(0)` models the real readers, which suspend once their
-            # buffer empties (`StreamReader.read` awaits `_wait_for_data`) — that
-            # suspension is what lets the deadline's timer run. A fake returning
-            # bytes with no suspension at all would spin forever, which is a
-            # property of the fake, not of the transports this bounds; the live
-            # end-to-end pin is
-            # `test_telnet_server.py::test_preauth_flood_is_closed_at_the_deadline`
-            # (codex 1st#1).
-            await asyncio.sleep(0)
-            return b"a"  # never a terminator
-
     async def _run():
         return await async_interactive_login(
             _FloodTransport([]), "admin", "secret", user_prompt=b"User: ", pass_prompt=b"Pass: "
@@ -648,10 +659,6 @@ def test_async_login_transport_timeout_is_not_swallowed_as_the_deadline():
     I/O handler instead of being reported as the login deadline (#269, claude
     1st#2). The builtin is an `OSError` subclass, so a socket ETIMEDOUT arrives as
     one; `asyncio.timeout().expired()` is what tells the two apart."""
-
-    class _TimingOutTransport(_FakeTransport):
-        async def recv(self, n: int) -> bytes:
-            raise TimeoutError("simulated socket ETIMEDOUT")
 
     async def _run():
         return await async_interactive_login(

--- a/tests/plugins/test_async_session.py
+++ b/tests/plugins/test_async_session.py
@@ -507,6 +507,113 @@ def test_async_login_ssh_nul_lf_after_username_cr_password_intact():
     assert b"User: admin\r\n" in out  # username echo carries no extra NUL/LF artifact
 
 
+# ------------------------------------------------ pre-auth input bound (#269)
+def test_async_login_username_cap_and_terminator_survival():
+    """The pre-auth username read shares the `_LINE_MAX` bound (#269): a CR-less
+    flood stops accumulating AND echoing at the cap, yet the terminator machine
+    still runs ahead of it, so the CR ends the line and the password read follows.
+    That ordering is the contract: moving the cap check above `_consume_terminator`
+    would strand a capped session with no way to submit."""
+
+    async def _run():
+        # `x` appears in neither prompt, so counting it isolates the username echo.
+        transport = _FakeTransport([b"x" * (_LINE_MAX + 100) + b"\r", b"pw\r"])
+        ok, skip_lf = await async_interactive_login(
+            transport, "admin", "pw", user_prompt=b"User: ", pass_prompt=b"Pass: "
+        )
+        return ok, skip_lf, transport
+
+    ok, skip_lf, transport = asyncio.run(_run())
+    assert ok is False  # the capped credential is not "admin"
+    assert skip_lf is True  # ...but the password line WAS read, and ended on CR
+    assert transport.out.count(b"x") == _LINE_MAX  # excess never echoed
+    # One drain per accepted+echoed byte (_LINE_MAX); the 100 dropped bytes cost
+    # no await, the password read is silent (echo off), + the closing drain(1).
+    assert transport.drains == _LINE_MAX + 1
+
+
+def test_async_login_password_cap_is_silent():
+    """The password read (echo off) is capped too, and stays wire-silent: no echo,
+    no drain — a CR-less flood past the cap costs neither bytes nor awaits (#269)."""
+
+    async def _run():
+        transport = _FakeTransport([b"admin\r", b"p" * (_LINE_MAX + 50) + b"\r"])
+        ok, _ = await async_interactive_login(
+            transport, "admin", "p" * _LINE_MAX, user_prompt=b"User: ", pass_prompt=b"Pass: "
+        )
+        return ok, transport
+
+    ok, transport = asyncio.run(_run())
+    assert ok is True  # the password truncated to exactly _LINE_MAX matched
+    assert b"p" not in transport.out  # echo off: never on the wire, capped or not
+    # username echo (5) + closing drain (1); the password read adds none.
+    assert transport.drains == 6
+
+
+def test_async_login_echo_drains_per_byte():
+    """Every echoed pre-auth byte is followed by a drain (#269), so a client that
+    stops reading is paced by transport backpressure instead of growing the
+    user-space write buffer. `drain` writes nothing, so the wire is unchanged."""
+
+    async def _run():
+        transport = _FakeTransport([b"admin\r", b"secret\r"])
+        await async_interactive_login(transport, "admin", "secret", user_prompt=b"User: ", pass_prompt=b"Pass: ")
+        return transport
+
+    transport = asyncio.run(_run())
+    # 'a','d','m','i','n' echoed (5) + the closing `\r\n` drain (1). The CR
+    # terminator and the echo-off password contribute none.
+    assert transport.drains == 6
+
+
+class _HangingTransport(_FakeTransport):
+    """Transport whose ``recv`` never completes — a client that opens the
+    connection and then says nothing (#269 deadline)."""
+
+    async def recv(self, n: int) -> bytes:
+        await asyncio.Event().wait()  # never set
+        raise AssertionError("unreachable")  # pragma: no cover
+
+
+@pytest.mark.timeout(30)  # a lost deadline must fail fast here, not stall the run
+def test_async_login_deadline_folds_into_failed_auth(monkeypatch):
+    """A client that never answers is cut loose at `_LOGIN_DEADLINE`, and the
+    timeout is folded into `(False, False)` rather than raised (#269) — that is
+    what lets both call sites stay unchanged and reuse their close-on-failure path."""
+    monkeypatch.setattr("simnos.plugins.servers.async_session._LOGIN_DEADLINE", 0.05)
+
+    async def _run():
+        transport = _HangingTransport([])
+        return await async_interactive_login(
+            transport, "admin", "secret", user_prompt=b"User: ", pass_prompt=b"Pass: "
+        )
+
+    ok, skip_lf = asyncio.run(_run())
+    assert ok is False
+    assert skip_lf is False
+
+
+@pytest.mark.timeout(30)  # ditto: without the deadline this loop never returns
+def test_async_login_deadline_bounds_a_capped_flood(monkeypatch):
+    """The cap alone bounds memory; the deadline bounds *time*. A client that
+    floods past the cap forever still never completes a line, so only the deadline
+    ends the session (#269) — the two bounds are complementary, not redundant."""
+    monkeypatch.setattr("simnos.plugins.servers.async_session._LOGIN_DEADLINE", 0.05)
+
+    class _FloodTransport(_FakeTransport):
+        async def recv(self, n: int) -> bytes:
+            await asyncio.sleep(0)  # yield so the deadline can fire
+            return b"a"  # never a terminator
+
+    async def _run():
+        return await async_interactive_login(
+            _FloodTransport([]), "admin", "secret", user_prompt=b"User: ", pass_prompt=b"Pass: "
+        )
+
+    ok, _ = asyncio.run(_run())
+    assert ok is False
+
+
 # ---------------------------------------------------------------- paging (#307 P3-4)
 class _PagingShell(_FakeShell):
     """PushShell stub whose ``dispatch`` returns a fixed multi-line body.

--- a/tests/plugins/test_async_session.py
+++ b/tests/plugins/test_async_session.py
@@ -537,6 +537,9 @@ def test_async_login_password_cap_is_silent():
     no drain — a CR-less flood past the cap costs neither bytes nor awaits (#269)."""
 
     async def _run():
+        # Lowercase `p` appears in neither prompt (`Pass: ` is capitalised), so
+        # asserting its absence isolates the password echo the same way test 1
+        # isolates the username echo with `x`.
         transport = _FakeTransport([b"admin\r", b"p" * (_LINE_MAX + 50) + b"\r"])
         ok, _ = await async_interactive_login(
             transport, "admin", "p" * _LINE_MAX, user_prompt=b"User: ", pass_prompt=b"Pass: "
@@ -544,10 +547,29 @@ def test_async_login_password_cap_is_silent():
         return ok, transport
 
     ok, transport = asyncio.run(_run())
-    assert ok is True  # the password truncated to exactly _LINE_MAX matched
     assert b"p" not in transport.out  # echo off: never on the wire, capped or not
     # username echo (5) + closing drain (1); the password read adds none.
     assert transport.drains == 6
+    # An over-long password is REFUSED, not silently truncated to its first
+    # _LINE_MAX bytes — otherwise this input (a correct _LINE_MAX-byte password
+    # plus 50 bytes of junk) would authenticate against the configured one
+    # (#269, codex 1st#3).
+    assert ok is False
+
+
+def test_async_login_overflow_refused_even_when_prefix_matches():
+    """Overflow refusal is decided by the overflow flag, not by the compared text:
+    the truncated credential here is byte-for-byte the configured one, and it still
+    fails (#269, codex 1st#3). Pins that the cap cannot be used as a prefix oracle."""
+
+    async def _run():
+        # Username is exactly _LINE_MAX correct bytes + 1 extra byte before the CR.
+        name = "u" * _LINE_MAX
+        transport = _FakeTransport([name.encode() + b"Z\r", b"pw\r"])
+        return await async_interactive_login(transport, name, "pw", user_prompt=b"User: ", pass_prompt=b"Pass: ")
+
+    ok, _ = asyncio.run(_run())
+    assert ok is False
 
 
 def test_async_login_echo_drains_per_byte():
@@ -600,7 +622,15 @@ def test_async_login_deadline_bounds_a_capped_flood(monkeypatch):
 
     class _FloodTransport(_FakeTransport):
         async def recv(self, n: int) -> bytes:
-            await asyncio.sleep(0)  # yield so the deadline can fire
+            # The `sleep(0)` models the real readers, which suspend once their
+            # buffer empties (`StreamReader.read` awaits `_wait_for_data`) — that
+            # suspension is what lets the deadline's timer run. A fake returning
+            # bytes with no suspension at all would spin forever, which is a
+            # property of the fake, not of the transports this bounds; the live
+            # end-to-end pin is
+            # `test_telnet_server.py::test_preauth_flood_is_closed_at_the_deadline`
+            # (codex 1st#1).
+            await asyncio.sleep(0)
             return b"a"  # never a terminator
 
     async def _run():
@@ -610,6 +640,26 @@ def test_async_login_deadline_bounds_a_capped_flood(monkeypatch):
 
     ok, _ = asyncio.run(_run())
     assert ok is False
+
+
+@pytest.mark.timeout(30)
+def test_async_login_transport_timeout_is_not_swallowed_as_the_deadline():
+    """A `TimeoutError` raised by the transport itself propagates to the caller's
+    I/O handler instead of being reported as the login deadline (#269, claude
+    1st#2). The builtin is an `OSError` subclass, so a socket ETIMEDOUT arrives as
+    one; `asyncio.timeout().expired()` is what tells the two apart."""
+
+    class _TimingOutTransport(_FakeTransport):
+        async def recv(self, n: int) -> bytes:
+            raise TimeoutError("simulated socket ETIMEDOUT")
+
+    async def _run():
+        return await async_interactive_login(
+            _TimingOutTransport([]), "admin", "secret", user_prompt=b"User: ", pass_prompt=b"Pass: "
+        )
+
+    with pytest.raises(TimeoutError, match="simulated socket ETIMEDOUT"):
+        asyncio.run(_run())
 
 
 # ---------------------------------------------------------------- paging (#307 P3-4)

--- a/tests/plugins/test_telnet_server.py
+++ b/tests/plugins/test_telnet_server.py
@@ -207,6 +207,11 @@ def test_preauth_flood_is_closed_at_the_deadline(monkeypatch):
     once its buffer empties, which lets the timer run, and the whole pre-auth
     write volume (prompt + echo capped at ``_LINE_MAX``) stays far below the
     transport's high-water mark, so no ``drain`` ever blocks.
+
+    What is pinned is the teardown within ``close_budget`` of a client that stayed
+    silent past the deadline — not the exact instant the server let go, which this
+    socket-level view cannot distinguish (codex 3rd#2). That is enough to separate
+    "bounded" from "never", which is the claim under test.
     """
     login_deadline = 1.5
     quiet = login_deadline + 1.5  # not one recv() in this window: the client is non-draining

--- a/tests/plugins/test_telnet_server.py
+++ b/tests/plugins/test_telnet_server.py
@@ -9,6 +9,7 @@ client, and the auth-failure close path (message delivered + graceful FIN).
 """
 
 import asyncio
+import contextlib
 from contextlib import contextmanager
 import socket
 import threading
@@ -187,6 +188,50 @@ def test_telnet_auth_failure_raw_surplus_delivers_message_and_fin():
             sock.close()
     assert b"Authentication failed" in buf  # (1) message delivered
     assert eof  # (2) graceful FIN, not RST, despite surplus unread input
+
+
+@pytest.mark.timeout(60)
+def test_preauth_flood_is_closed_at_the_deadline(monkeypatch):
+    """A CR-less pre-auth flood from a client that never reads is closed by the
+    login deadline (#269), end to end on a real listener.
+
+    This is the live counterpart to the fake-transport deadline tests, and it is
+    what settles two cross-review claims (codex 1st#1 / 1st#2) that the deadline
+    could not fire in this scenario: (1) that the capped read loop never yields,
+    so the timer never runs, and (2) that the deadline fires inside a blocked
+    ``drain``, after which the caller's own unbounded ``drain`` of
+    ``Authentication failed.`` hangs and the session is never torn down.
+
+    Both predict "the server never closes". On v3 (no cap, no deadline) this
+    connection genuinely stays open; here it must close. The real reader suspends
+    once its buffer empties, which lets the timer run, and the whole pre-auth
+    write volume (prompt + echo capped at ``_LINE_MAX``) stays far below the
+    transport's high-water mark, so no ``drain`` ever blocks.
+    """
+    monkeypatch.setattr("simnos.plugins.servers.async_session._LOGIN_DEADLINE", 2.0)
+    flood = b"A" * 65536  # no CR/LF anywhere: the login line never completes
+    with _running_telnet_host() as port:
+        sock = socket.create_connection(("127.0.0.1", port), timeout=8)
+        sock.settimeout(8)
+        try:
+            with contextlib.suppress(OSError):
+                sock.sendall(flood)  # peer may already be gone on a slow runner
+            # Never read the echo back: the client is deliberately non-draining.
+            closed = False
+            deadline = time.monotonic() + 30.0
+            while time.monotonic() < deadline:
+                try:
+                    if not sock.recv(65536):  # b"" = server closed
+                        closed = True
+                        break
+                except TimeoutError:
+                    continue
+                except OSError:
+                    closed = True  # RST also means the server let go
+                    break
+        finally:
+            sock.close()
+    assert closed, "pre-auth flood held the session open past the login deadline"
 
 
 @pytest.mark.parametrize("device_type", ["cisco_ios"])

--- a/tests/plugins/test_telnet_server.py
+++ b/tests/plugins/test_telnet_server.py
@@ -208,18 +208,27 @@ def test_preauth_flood_is_closed_at_the_deadline(monkeypatch):
     write volume (prompt + echo capped at ``_LINE_MAX``) stays far below the
     transport's high-water mark, so no ``drain`` ever blocks.
     """
-    monkeypatch.setattr("simnos.plugins.servers.async_session._LOGIN_DEADLINE", 2.0)
+    login_deadline = 1.5
+    quiet = login_deadline + 1.5  # not one recv() in this window: the client is non-draining
+    close_budget = 12.0  # generous for a loaded CI runner, but far below "never"
+    monkeypatch.setattr("simnos.plugins.servers.async_session._LOGIN_DEADLINE", login_deadline)
     flood = b"A" * 65536  # no CR/LF anywhere: the login line never completes
     with _running_telnet_host() as port:
         sock = socket.create_connection(("127.0.0.1", port), timeout=8)
-        sock.settimeout(8)
         try:
+            sent_at = time.monotonic()
             with contextlib.suppress(OSError):
                 sock.sendall(flood)  # peer may already be gone on a slow runner
-            # Never read the echo back: the client is deliberately non-draining.
+            # The whole point: stay silent past the deadline without reading a
+            # single byte, so the server's echo sits in its write buffer while the
+            # budget expires (codex 2nd#4 — the first version read continuously
+            # from here, which quietly made the client a draining one).
+            time.sleep(quiet)
+            # Only now drain what was buffered, and require the close to have
+            # happened within the budget rather than merely "eventually".
+            sock.settimeout(1.0)
             closed = False
-            deadline = time.monotonic() + 30.0
-            while time.monotonic() < deadline:
+            while time.monotonic() - sent_at < close_budget:
                 try:
                     if not sock.recv(65536):  # b"" = server closed
                         closed = True


### PR DESCRIPTION
## 概要

issue #269 = **未認証 in-band login の入力 bound 欠損**を塞ぐ。`_async_read_line` は
`async_session.py` で唯一 `_LINE_MAX` bound を持たない client-byte 蓄積点であり、かつ
**唯一 credential 検査より前に走る**。#347 (PR #363) で post-auth 側には cap + echo drain
を入れたが、未認証側は #269 の明示 scope として意図的に非接触で残していた分の回収。

塞いだ欠損:

| # | 欠損 | 帰結 |
|---|------|------|
| 1 | 長さ bound 無し | 行終端を送らない client が server 側 buffer を無制限に成長させる |
| 2 | `bytes` への 1 byte 追記 | 毎回 buffer 全体を copy = O(n²)。共有 loop thread を占有 |
| 3 | echo drain 無し / 総時間 budget 無し | 読まない client 相手に送信 buffer も無制限成長。stall した未認証 session を無期限保持 |

3 つとも**未認証**で到達する。既定 bind は `127.0.0.1` だが、共有 asyncio loop は
プロセス内の**全 host** を駆動するため、1 本の接続が他の全 simulated host を巻き込む。

### 裏付け (Claude Security scan)

network-facing runtime (30 files) を medium effort で scan (29/29 researcher + sweep 2 本
完走、35 候補 → 17 dedup、51 panel 票)。**17 候補中 15 件が 3/3 で却下され、生存したのは
本件のみ** (同一 sink の 2 framing、いずれも **panel 3/3 満票 / MEDIUM / confidence high**)。

## 変更内容

- **D1** `_LINE_MAX` (既存 4096) を login 読取にも適用。超過 byte は drop + 非 echo
- **D2** `buf` を `bytes` → `bytearray` (O(n²) → 償却 O(n))
- **D3** echo 後に `await transport.drain()`。cap で drop した byte では drain しない
- **D4** `_LOGIN_DEADLINE = 60` を `async_interactive_login` の**内側**に。timeout は
  `(False, False)` に畳んで既存の「認証失敗 → 切断」経路へ流すため、**呼出側 2 箇所
  (`telnet_server.py` / `ssh_server_asyncssh.py`) は無改変**
- **D6** overflow した credential は**無条件で認証失敗** — cap 単体だと、設定値がちょうど
  `_LINE_MAX` byte のとき「正しい prefix + 任意 suffix」が通ってしまう (cap 導入前は
  全長比較なので通らなかった = 本 PR が持ち込む退行を同時に封鎖)
- **D7** `asyncio.wait_for` ではなく `asyncio.timeout` + `expired()`。組込み `TimeoutError`
  は `OSError` subclass のため、transport 由来の ETIMEDOUT を deadline と誤認して
  握り潰すのを防ぐ (transport 由来は呼出側の I/O handler へ再送出)
- cap + echo + drain は challenge answer reader と完全一致したため `_accept_capped_byte`
  へ抽出し共有 (`_consume_terminator` #350 と同じ形)

D6 / D7 はいずれも「cap や deadline を入れたこと自体が生む副作用」を塞ぐもの。

## byte-parity golden 非接触

**golden 無変更・再録なし** (差分は 3 ファイルのみ)。論証:

1. **cap**: golden 最長送信行は 34 byte。login 行はさらに短く、4096 には桁で届かないため
   golden 経路で cap 分岐は一度も踏まれない
2. **drain**: byte を書かない (flush の pacing のみ)。wire 上の byte 列は不変
3. **bytearray**: 内部表現のみ
4. **deadline**: golden 録画は login を即時完了する

## 実測による検証

cross-review で「deadline は発火しない / timeout 後に drain が詰まって session が閉じない」
という指摘が出たため、推論ではなく**実 listener に対する実測**で決着させた
(`_LOGIN_DEADLINE` を 3s に縮め、生 socket で CR-less flood を送り一切読まない client を再現):

| 実装 | 攻撃 | 結果 |
|---|---|---|
| **v3 (修正前)** | 256KB flood | **12 秒経っても close されない** = 脆弱性の実在を確認 |
| **本 PR** | 8MB / 256KB flood | deadline どおり **close** |

判明した構造的事実 (今後壊してはいけない):

1. **deadline は発火する** — 実 reader は buffer が空になると suspend するため、cap 後の
   read loop も必ず制御を event loop へ戻す
2. **pre-auth の drain は block しない** — cap により pre-auth 総送信量が prompt + echo
   ≤ 約 4KB に有界化され、transport の high-water mark に届かない。**cap 自身が
   「drain 詰まり起点の hang」の前提を消している**

この計測は `test_preauth_flood_is_closed_at_the_deadline` (実 listener + 生 socket) として
恒久化した。

## テスト

- `tests/plugins/test_async_session.py` — #269 テスト **7 本** (username cap + 終端生存 /
  password cap の wire 無音 + overflow 拒否 / prefix 一致でも overflow 拒否 / echo drain
  回数 pin / deadline の failed-auth 畳み込み / cap+deadline の相補性 / transport
  TimeoutError の非握り潰し)
- `tests/plugins/test_telnet_server.py` — **live 回帰テスト 1 本** (非 draining client)
- **回帰強度確認済**: 実装を戻すと新規テストは全て fail する (vacuous でない)

## 検証

- full suite **1307 passed, 9 skipped** (`-n auto`)
- ruff / yamllint / lint-platform-data / ty 全 green
- bandit は `simnos/` 配下で **v3 と同一** (Low 16 / Medium 4 / High 3 = 新規ゼロ)
- **golden 無変更**
- docker 2 errors は iptables 起因の pre-existing なホスト環境要因 (v3 でも同一再現)

## レビュー

cross-review **3 round 収束** (codex / gemini / claude)。

- 1st: codex **MUST FIX ×2** + SHOULD FIX / gemini SUGGESTION / claude SUGGESTION
- 2nd: codex SHOULD FIX — **MUST FIX 2 件は実測による反証を受けて撤回**
- 3rd: codex SUGGESTION — **merge を妨げる残件なし**

SHOULD FIX / SUGGESTION は全件取り込み。不採用は上記 MUST FIX 2 件と、その前提に依存
していた SUGGESTION 1 件のみ (理由は worklog に記録)。取り込み後に final-refactor
(fake transport の配置統一 + コメント drift 是正) を実施。

## 関連

- issue #269 (本 PR)
- #347 / PR #363 — post-auth 側の同型 cap + drain (本 PR の流用元)
- #350 — `_consume_terminator` による byte consumer の DRY 化 (抽出の前例)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
